### PR TITLE
resource-level middleware and authorization feature

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,6 +25,10 @@
   blaze/thread-pool-executor-collector
   {:local/root "modules/thread-pool-executor-collector"}
 
+  blaze-authorization-example
+  {:git/url "https://github.com/Breezeemr/blaze-authorization-example"
+   :sha "62286d49c15d34bc7c82cb442368a9757ce00ae3"}
+
   com.cognitect/anomalies
   {:mvn/version "0.1.12"}
 

--- a/modules/rest-api/src/blaze/rest_api.clj
+++ b/modules/rest-api/src/blaze/rest_api.clj
@@ -45,13 +45,16 @@
   {:arglists '([resource-patterns structure-definition])}
   [auth-backends resource-patterns {:keys [name] :as structure-definition}]
   (when-let
-    [{:blaze.rest-api.resource-pattern/keys [interactions]}
+    [{:blaze.rest-api.resource-pattern/keys [interactions middleware]}
      (resolve-pattern resource-patterns structure-definition)]
     [(str "/" name)
      {:middleware
       (cond-> []
         (seq auth-backends)
-        (conj wrap-auth-guard))
+        (conj wrap-auth-guard)
+
+        (not-empty middleware)
+        (concat middleware))
       :fhir.resource/type name}
      [""
       (cond-> {:name (keyword name "type")}

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -66,6 +66,7 @@
    :resource-patterns
    [#:blaze.rest-api.resource-pattern
        {:type :default
+        :middleware #blaze/refset :blaze/middleware
         :interactions
         {:read
          #:blaze.rest-api.interaction
@@ -104,4 +105,9 @@
    :toggle "OPENID_PROVIDER_URL"
    :config
    {[:blaze.auth/backend :blaze.openid-auth/backend]
-    {:openid-provider/url #blaze/cfg ["OPENID_PROVIDER_URL" string?]}}}]}
+    {:openid-provider/url #blaze/cfg ["OPENID_PROVIDER_URL" string?]}}}
+  {:name "Authorization"
+   :toggle "AUTHORIZATION"
+   :config
+   {[:blaze/middleware :blaze-authorization-example/authorization]
+    {:database/conn #blaze/ref :blaze.datomic/conn}}}]}

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -44,7 +44,7 @@
   (try
     (with-open [rdr (PushbackReader. (io/reader (io/resource "blaze.edn")))]
       (edn/read
-        {:readers {'blaze/ref ig/ref 'blaze/cfg cfg}}
+        {:readers {'blaze/ref ig/ref 'blaze/refset ig/refset 'blaze/cfg cfg}}
         rdr))
     (catch Exception e
       (log/warn "Problem while reading blaze.edn. Skipping it." e))))


### PR DESCRIPTION
I have added a generic middleware feature so that middleware may be supplied using a composite Integrant key, for example

```clj
[:blaze/middleware :blaze-authorization-example/authorization]
```

I created and included as a dependency an [example authorization middleware](https://github.com/Breezeemr/blaze-authorization-example) that accepts only requests to `Patient` type resources.

I also added `#blaze/refset` as an edn reader literal.

Let me know if you'd like any changes such as removing the example middleware as a dependency.