### PR TITLE
Fix Blocking on Transaction Concurrency Greater or Equal to Number of…

### DIFF
--- a/modules/db/test/blaze/db/indexer/resource_spec.clj
+++ b/modules/db/test/blaze/db/indexer/resource_spec.clj
@@ -6,6 +6,7 @@
     [blaze.db.indexer-spec]
     [blaze.db.kv-spec]
     [blaze.executors :as ex]
+    [blaze.executors_spec]
     [clojure.spec.alpha :as s]))
 
 

--- a/modules/executor/src/blaze/executors_spec.clj
+++ b/modules/executor/src/blaze/executors_spec.clj
@@ -1,0 +1,20 @@
+(ns blaze.executors-spec
+  (:require
+    [blaze.executors :as ex]
+    [clojure.spec.alpha :as s]))
+
+
+(s/fdef ex/cpu-bound-pool
+  :args (s/cat :name-template string?))
+
+
+(s/fdef ex/cpu-bound-dedicated-pool
+  :args (s/cat :name-template string?))
+
+
+(s/fdef ex/io-pool
+  :args (s/cat :n pos-int? :name-template string?))
+
+
+(s/fdef ex/single-thread-executor
+  :args (s/cat :name (s/? string?)))

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -383,10 +383,15 @@
   (handler node executor))
 
 
+(defn- executor-init-msg []
+  (format "Init FHIR transaction interaction executor with %d threads"
+          (.availableProcessors (Runtime/getRuntime))))
+
+
 (defmethod ig/init-key ::executor
   [_ _]
-  (log/info "Init FHIR transaction interaction executor")
-  (ex/cpu-bound-pool "transaction-interaction-%d"))
+  (log/info (executor-init-msg))
+  (ex/cpu-bound-pool "blaze-transaction-interaction-%d"))
 
 
 (derive ::executor :blaze.metrics/thread-pool-executor)

--- a/modules/operations/measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
+++ b/modules/operations/measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
@@ -40,10 +40,15 @@
   (handler (Clock/systemDefaultZone) node executor))
 
 
+(defn- executor-init-msg []
+  (format "Init FHIR $evaluate-measure operation executor with %d threads"
+          (.availableProcessors (Runtime/getRuntime))))
+
+
 (defmethod ig/init-key ::executor
   [_ _]
-  (log/info "Init FHIR $evaluate-measure operation executor")
-  (ex/cpu-bound-pool "evaluate-measure-operation-%d"))
+  (log/info (executor-init-msg))
+  (ex/cpu-bound-pool "blaze-evaluate-measure-operation-%d"))
 
 
 (derive ::executor :blaze.metrics/thread-pool-executor)

--- a/modules/rest-api/src/blaze/rest_api/spec.clj
+++ b/modules/rest-api/src/blaze/rest_api/spec.clj
@@ -1,5 +1,6 @@
 (ns blaze.rest-api.spec
   (:require
+    [blaze.executors :as ex]
     [blaze.spec]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig])
@@ -116,3 +117,7 @@
 
 (s/def :blaze.rest-api/operations
   (s/coll-of :blaze.rest-api/operation))
+
+
+(s/def :blaze.rest-api.json-parse/executor
+  ex/executor?)

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -98,13 +98,16 @@
 
    :blaze.handler/health {}
 
+   :blaze.rest-api.json-parse/executor {}
+
    :blaze/rest-api
    {:base-url (->Cfg "BASE_URL" string? "http://localhost:8080")
     :version (ig/ref :blaze/version)
     :structure-definitions (ig/ref :blaze/structure-definition)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :auth-backends (ig/refset :blaze.auth/backend)
-    :context-path (->Cfg "CONTEXT_PATH" string? "/fhir")}
+    :context-path (->Cfg "CONTEXT_PATH" string? "/fhir")
+    :blaze.rest-api.json-parse/executor (ig/ref :blaze.rest-api.json-parse/executor)}
 
    :blaze.rest-api/requests-total {}
    :blaze.rest-api/request-duration-seconds {}
@@ -196,10 +199,15 @@
     (fhir-capabilities-handler/handler base-url version structure-definitions))
 
 
+(defn- executor-init-msg []
+  (format "Init server executor with %d threads"
+          (.availableProcessors (Runtime/getRuntime))))
+
+
 (defmethod ig/init-key :blaze.server/executor
   [_ _]
-  (log/info "Init server executor")
-  (ex/cpu-bound-pool "server-%d"))
+  (log/info (executor-init-msg))
+  (ex/cpu-bound-pool "blaze-server-%d"))
 
 
 (derive :blaze.server/executor :blaze.metrics/thread-pool-executor)


### PR DESCRIPTION
… Processors

The problem was the JSON parsing or more specific, the input stream
handling by aleph. The server thread did block on some async take
operation inside a custom implementation of InputStream provided by
aleph. By using a separate thread pool for JSON parsing which doesn't
capture deferreds, I could prevent that blocking.

I think the problem was that all server threads were used and the
deferreds created by the async input stream also liked to be executed
on that server thread pool. I think this is especially a problem because
the deferreds were dereferenced blocking inside the InputStream because
InputStreams don't have an async API.

Closes: #139