### PR TITLE
Run container as non-root user in a distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,5 @@ COPY --from=build --chown=nonroot:nonroot /app ./
 COPY --from=build --chown=nonroot:nonroot /build/target/ ./
 
 USER nonroot
-EXPOSE 8080
 ENV DB_DIR="/app/data/db"
 CMD ["blaze-standalone.jar", "-m", "blaze.core"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,4 @@ COPY --from=build --chown=nonroot:nonroot /build/target/ ./
 USER nonroot
 EXPOSE 8080
 ENV DB_DIR="/app/data/db"
-ENTRYPOINT [ "java", "-jar", "-server" ]
 CMD ["blaze-standalone.jar", "-m", "blaze.core"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,16 @@ COPY . /build/
 WORKDIR /build
 RUN clojure -A:depstar -m hf.depstar.uberjar target/blaze-standalone.jar
 
-FROM openjdk:11.0.7-jre
+RUN mkdir -p /app/data
 
-COPY --from=build /build/target/blaze-standalone.jar /app/
+FROM gcr.io/distroless/java:11
 
 WORKDIR /app
 
-CMD ["/bin/bash", "-c", "java $JVM_OPTS -jar blaze-standalone.jar -m blaze.core"]
+COPY --from=build --chown=nonroot:nonroot /app ./
+COPY --from=build --chown=nonroot:nonroot /build/target/ ./
+
+USER nonroot
+EXPOSE 8080
+ENV DB_DIR="/app/data/db"
+CMD ["blaze-standalone.jar", "-m", "blaze.core"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ COPY --from=build --chown=nonroot:nonroot /build/target/ ./
 USER nonroot
 EXPOSE 8080
 ENV DB_DIR="/app/data/db"
+ENTRYPOINT [ "java", "-jar", "-server" ]
 CMD ["blaze-standalone.jar", "-m", "blaze.core"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ docker run -p 8080:8080 -v <local-dir>:/data -e DB_DIR="/data/db" samply/blaze:0
 
 Please replace `<local-dir>` with a directory in which Blaze should store it's database files. It's important to specify a `DB_DIR` which resides inside the mounted volume, because Blaze needs to create its database directory itself. Blaze will use any previously created database directory on subsequent starts.
 
+For security reasons, the container is executed as a non-root user (65532:65532) by default. When mounting a folder from your host filesystem you will need to set the permissions accordingly, e.g.
+
+```bash
+# Use ~/blaze-data on your host to store the database files
+mkdir ~/blaze-data
+sudo chown -R 65532:65532 ~/blaze-data
+docker run -p 8080:8080 -v ~/blaze-data:/data -e DB_DIR="/data/db" samply/blaze:0.8.0-beta.2
+```
+
+If you use a Docker volume, mount it on `/app/data` and make sure `DB_DIR` is set to `/app/data/db` (the default value), because the non-root user only has write-permissions inside the `/app` directory.
+Using a Docker volume instead of a host directory mount makes it unnecassary to set the file permissions:
+
+```bash
+docker run -p 8080:8080 -v blaze-data-volume:/app/data -e DB_DIR="/app/data/db" samply/blaze:0.8.0-beta.2
+```
+
+Note that you can always revert back to running the container as root by specifying `-u root` for `docker run` or setting the `services[].user: root` in Docker compose.
+
 ### Java
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run -p 8080:8080 -v ~/blaze-data:/data -e DB_DIR="/data/db" samply/blaze:
 ```
 
 If you use a Docker volume, mount it on `/app/data` and make sure `DB_DIR` is set to `/app/data/db` (the default value), because the non-root user only has write-permissions inside the `/app` directory.
-Using a Docker volume instead of a host directory mount makes it unnecassary to set the file permissions:
+Using a Docker volume instead of a host directory mount makes it unnecessary to set the file permissions:
 
 ```bash
 docker run -p 8080:8080 -v blaze-data-volume:/app/data -e DB_DIR="/app/data/db" samply/blaze:0.8.0-beta.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     image: "samply/blaze:0.8.0-beta.2"
     environment:
       BASE_URL: "http://localhost:8080"
-      DB_DIR: "/data"
-      JVM_OPTS: "-server -Xms2g -Xmx2g -XX:+UseG1GC"
+      DB_DIR: "/app/data/db"
+      JAVA_TOOL_OPTIONS: "-Xms2g -Xmx2g -XX:+UseG1GC"
     ports:
     - "8080:8080"
     volumes:
-    - "db-data:/data"
+    - "db-data:/app/data"
 volumes:
   db-data:


### PR DESCRIPTION
Modifies the Dockerfile to run the container as a non-root user instead of the default root. 

It also changes the runtime image to a Java distroless one, see https://github.com/GoogleContainerTools/distroless. These images are incredibly stripped down and, while sometimes annoying to work with, provide a significant security advantage over images which include shells and tools like wget/curl which may be used by an attacker. Additionally, this reduces the image size from ~430 MB to ~268MB uncompressed.