### PR TITLE
Add Basic Authentication to FHIR Client

### DIFF
--- a/modules/fhir-client/test/blaze/fhir_client_test.clj
+++ b/modules/fhir-client/test/blaze/fhir_client_test.clj
@@ -312,3 +312,24 @@
         ::anom/category := ::anom/fault))))
 
 
+(deftest basic-auth-client
+  (testing "Authenticator is set"
+    (let [username "user-134952"
+          password "password-135000"
+          client (fhir-client/authenticated-client "http://localhost:8080/fhir" username password)
+          optionalAuthenticator (-> client
+                                    :http-client
+                                    .authenticator)]
+      (is (.isPresent optionalAuthenticator))))
+
+  (testing "Authenticator has given credentials"
+    (let [username "user-134952"
+          password "password-135000"
+          client (fhir-client/authenticated-client "http://localhost:8080/fhir" username password)
+          passwordAuth (-> client
+                           :http-client
+                           .authenticator
+                           .get
+                           .getPasswordAuthentication)]
+      (is (= (.getUserName passwordAuth) username))
+      (is (= (String. (.getPassword passwordAuth)) password)))))


### PR DESCRIPTION
These changes target issue #228 and implement basic authentication into the FHIR client.

The credentials are set while building the HttpClient and used for all requests requiring authentication. To change the credentials a new client needs to be created.

This feature can be useful, e.g. when accessing an IBM FHIR server in default configuration with authentication being enabled.