### PR TITLE
Move FhirType Protocol into its own Namespace

### DIFF
--- a/modules/db/src/blaze/db/impl/index/resource_handle.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_handle.clj
@@ -3,7 +3,7 @@
     [blaze.byte-string :as bs]
     [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
-    [blaze.fhir.spec.type :as type]))
+    [blaze.fhir.spec.type.protocols :as p]))
 
 
 (set! *warn-on-reflection* true)
@@ -11,7 +11,7 @@
 
 
 (defrecord ResourceHandle [^int tid id ^long t hash ^long num-changes op]
-  type/FhirType
+  p/FhirType
   (-type [_]
     ;; TODO: maybe cache this
     (keyword "fhir" (codec/tid->type tid))))

--- a/modules/fhir-structure/src/blaze/fhir/hash.clj
+++ b/modules/fhir-structure/src/blaze/fhir/hash.clj
@@ -14,5 +14,5 @@
   resource, overwriting it."
   [resource]
   (let [hasher (.newHasher (Hashing/sha256))]
-    (type/-hash-into resource hasher)
+    (type/hash-into resource hasher)
     (bs/from-byte-array (.asBytes (.hash hasher)))))

--- a/modules/fhir-structure/src/blaze/fhir/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.fhir.hash.spec]
     [blaze.fhir.spec.impl :as impl]
+    [blaze.fhir.spec.spec]
     [blaze.fhir.spec.type :as type]
     [clojure.alpha.spec :as s2]
     [clojure.spec.alpha :as s]
@@ -11,49 +12,8 @@
     [java.util.regex Pattern]))
 
 
-;; ---- Specs -----------------------------------------------------------------
-
-(s/def :fhir.type/name
-  (s/and string? #(re-matches #"[A-Z]([A-Za-z0-9_]){0,254}" %)))
-
-
-(s/def :fhir/type
-  (s/and
-    keyword?
-    #(some-> (namespace %) (str/starts-with? "fhir"))
-    #(s/valid? :fhir.type/name (name %))))
-
-
-(s/def :blaze.resource/id
-  (s/and string? #(re-matches #"[A-Za-z0-9\-\.]{1,64}" %)))
-
-
-(s/def :blaze.fhir/local-ref
-  (s/and string?
-         (s/conformer #(str/split % #"/" 2))
-         (s/tuple :fhir.type/name :blaze.resource/id)))
-
-
-(s/def :blaze/resource
-  #(s2/valid? :fhir/Resource %))
-
-
-
-;; ---- Functions -------------------------------------------------------------
-
 (defn type-exists? [type]
   (some? (s2/get-spec (keyword "fhir" type))))
-
-
-(defn valid-json?
-  "Determines whether the resource is valid."
-  {:arglists '([resource])}
-  [{type :resourceType :as resource}]
-  (if type
-    (if-let [spec (s2/get-spec (keyword "fhir.json" type))]
-      (s2/valid? spec resource)
-      false)
-    false))
 
 
 (defn conform-json

--- a/modules/fhir-structure/src/blaze/fhir/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec.clj
@@ -98,7 +98,7 @@
 (defn unform-json
   "Returns the JSON representation of `resource`."
   [resource]
-  (let [key (keyword "fhir.json" (name (type/-type resource)))]
+  (let [key (keyword "fhir.json" (name (type/type resource)))]
     (if-let [spec (s2/get-spec key)]
       (s2/unform spec resource)
       (throw (ex-info (format "Missing spec: %s" key) {:key key})))))
@@ -107,7 +107,7 @@
 (defn unform-cbor
   "Returns the CBOR representation of `resource`."
   [resource]
-  (let [key (keyword "fhir.cbor" (name (type/-type resource)))]
+  (let [key (keyword "fhir.cbor" (name (type/type resource)))]
     (if-let [spec (s2/get-spec key)]
       (s2/unform spec resource)
       (throw (ex-info (format "Missing spec: %s" key) {:key key})))))
@@ -116,7 +116,7 @@
 (defn unform-xml
   "Returns the XML representation of `resource`."
   [resource]
-  (let [key (keyword "fhir.xml" (name (type/-type resource)))]
+  (let [key (keyword "fhir.xml" (name (type/type resource)))]
     (if-let [spec (s2/get-spec key)]
       (s2/unform spec resource)
       (throw (ex-info (format "Missing spec: %s" key) {:key key})))))
@@ -126,7 +126,7 @@
   "Returns the FHIR type of `x` as keyword with the namespace `fhir` or nil if
   `x` has no FHIR type."
   [x]
-  (type/-type x))
+  (type/type x))
 
 
 (defn to-date-time [x]

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -298,7 +298,7 @@
 
 
 (defn- type-check-form [key]
-  `(fn [~'m] (identical? ~key (type/-type ~'m))))
+  `(fn [~'m] (identical? ~key (type/type ~'m))))
 
 
 (defn- internal-schema-spec-def [parent-path-parts path-part elem-def child-spec-defs]
@@ -333,7 +333,7 @@
 
 
 (defn- type-suffix [x]
-  (if-let [type (type/-type x)]
+  (if-let [type (type/type x)]
     (str/capital (name type))
     (throw (ex-info (format "Unknown type of `%s`." x) {:x x}))))
 
@@ -585,25 +585,25 @@
   (let [regex (type-regex (value-type element))]
     (case name
       "boolean" `boolean?
-      "integer" `(s/and int? (s/conformer int type/-to-json))
-      "string" `(s/and string? ~(re-matches-form-json regex) (s/conformer identity type/-to-json))
+      "integer" `(s/and int? (s/conformer int type/to-json))
+      "string" `(s/and string? ~(re-matches-form-json regex) (s/conformer identity type/to-json))
       "decimal" `(s/conformer conform-decimal-json identity)
-      "uri" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Uri type/-to-json))
-      "url" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Url type/-to-json))
-      "canonical" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Canonical type/-to-json))
-      "base64Binary" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Base64Binary type/-to-json))
-      "instant" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Instant type/-to-json))
-      "date" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Date type/-to-json))
-      "dateTime" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->DateTime type/-to-json))
-      "time" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Time type/-to-json))
-      "code" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Code type/-to-json))
-      "oid" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Oid type/-to-json))
-      "id" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Id type/-to-json))
-      "markdown" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Markdown type/-to-json))
-      "unsignedInt" `(s/and int? (s/conformer type/->UnsignedInt type/-to-json))
-      "positiveInt" `(s/and int? (s/conformer type/->PositiveInt type/-to-json))
-      "uuid" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Uuid type/-to-json))
-      "xhtml" `(s/and string? (s/conformer type/->Xhtml type/-to-json))
+      "uri" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Uri type/to-json))
+      "url" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Url type/to-json))
+      "canonical" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Canonical type/to-json))
+      "base64Binary" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Base64Binary type/to-json))
+      "instant" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Instant type/to-json))
+      "date" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Date type/to-json))
+      "dateTime" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->DateTime type/to-json))
+      "time" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Time type/to-json))
+      "code" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Code type/to-json))
+      "oid" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Oid type/to-json))
+      "id" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Id type/to-json))
+      "markdown" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Markdown type/to-json))
+      "unsignedInt" `(s/and int? (s/conformer type/->UnsignedInt type/to-json))
+      "positiveInt" `(s/and int? (s/conformer type/->PositiveInt type/to-json))
+      "uuid" `(s/and string? ~(re-matches-form-json regex) (s/conformer type/->Uuid type/to-json))
+      "xhtml" `(s/and string? (s/conformer type/->Xhtml type/to-json))
       (throw (ex-info (format "Unknown primitive type `%s`." name) {})))))
 
 
@@ -623,39 +623,39 @@
      (fn [~'e] (xml-value-matches? ~regex ~'e))
      (s/conformer identity set-extension-tag)
      (s/schema {:content (s/coll-of :fhir.xml/Extension)})
-     (s/conformer ~constructor type/-to-xml)))
+     (s/conformer ~constructor type/to-xml)))
 
 
 (defn- xml-spec-form [name {:keys [element]}]
   (let [regex (type-regex (value-type element))
         constructor (str "xml->" (str/capital name))]
     (case name
-      "xhtml" `(s/and element? (s/conformer type/xml->Xhtml type/-to-xml))
+      "xhtml" `(s/and element? (s/conformer type/xml->Xhtml type/to-xml))
       (primitive-xml-form regex (symbol "blaze.fhir.spec.type" constructor)))))
 
 
 (defn- cbor-spec-form [name _]
   (case name
     "boolean" `any?
-    "integer" `(s/conformer int type/-to-json)
+    "integer" `(s/conformer int type/to-json)
     "string" `any?
     "decimal" `any?
-    "uri" `(s/conformer type/->Uri type/-to-json)
-    "url" `(s/conformer type/->Url type/-to-json)
-    "canonical" `(s/conformer type/->Canonical type/-to-json)
-    "base64Binary" `(s/conformer type/->Base64Binary type/-to-json)
-    "instant" `(s/conformer type/->Instant type/-to-json)
-    "date" `(s/conformer type/->Date type/-to-json)
-    "dateTime" `(s/conformer type/->DateTime type/-to-json)
-    "time" `(s/conformer type/->Time type/-to-json)
-    "code" `(s/conformer type/->Code type/-to-json)
-    "oid" `(s/conformer type/->Oid type/-to-json)
-    "id" `(s/conformer type/->Id type/-to-json)
-    "markdown" `(s/conformer type/->Markdown type/-to-json)
-    "unsignedInt" `(s/conformer type/->UnsignedInt type/-to-json)
-    "positiveInt" `(s/conformer type/->PositiveInt type/-to-json)
-    "uuid" `(s/conformer type/->Uuid type/-to-json)
-    "xhtml" `(s/conformer type/->Xhtml type/-to-json)
+    "uri" `(s/conformer type/->Uri type/to-json)
+    "url" `(s/conformer type/->Url type/to-json)
+    "canonical" `(s/conformer type/->Canonical type/to-json)
+    "base64Binary" `(s/conformer type/->Base64Binary type/to-json)
+    "instant" `(s/conformer type/->Instant type/to-json)
+    "date" `(s/conformer type/->Date type/to-json)
+    "dateTime" `(s/conformer type/->DateTime type/to-json)
+    "time" `(s/conformer type/->Time type/to-json)
+    "code" `(s/conformer type/->Code type/to-json)
+    "oid" `(s/conformer type/->Oid type/to-json)
+    "id" `(s/conformer type/->Id type/to-json)
+    "markdown" `(s/conformer type/->Markdown type/to-json)
+    "unsignedInt" `(s/conformer type/->UnsignedInt type/to-json)
+    "positiveInt" `(s/conformer type/->PositiveInt type/to-json)
+    "uuid" `(s/conformer type/->Uuid type/to-json)
+    "xhtml" `(s/conformer type/->Xhtml type/to-json)
     (throw (ex-info (format "Unknown primitive type `%s`." name) {}))))
 
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
@@ -1,0 +1,30 @@
+(ns blaze.fhir.spec.spec
+  (:require
+    [clojure.alpha.spec :as s2]
+    [clojure.spec.alpha :as s]
+    [clojure.string :as str]))
+
+
+(s/def :fhir.type/name
+  (s/and string? #(re-matches #"[A-Z]([A-Za-z0-9_]){0,254}" %)))
+
+
+(s/def :fhir/type
+  (s/and
+    keyword?
+    #(some-> (namespace %) (str/starts-with? "fhir"))
+    #(s/valid? :fhir.type/name (name %))))
+
+
+(s/def :blaze.resource/id
+  (s/and string? #(re-matches #"[A-Za-z0-9\-\.]{1,64}" %)))
+
+
+(s/def :blaze.fhir/local-ref
+  (s/and string?
+         (s/conformer #(str/split % #"/" 2))
+         (s/tuple :fhir.type/name :blaze.resource/id)))
+
+
+(s/def :blaze/resource
+  #(s2/valid? :fhir/Resource %))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/protocols.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/protocols.clj
@@ -1,0 +1,9 @@
+(ns blaze.fhir.spec.type.protocols)
+
+
+(defprotocol FhirType
+  (-type [_])
+  (-value [_])
+  (-to-json [_])
+  (-to-xml [_])
+  (-hash-into [_ sink]))

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
@@ -56,7 +56,7 @@
                 (fn [~'e] (impl/xml-value-matches? "true|false" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Boolean type/-to-xml))}
+                (s2/conformer type/xml->Boolean type/to-xml))}
             {:key :fhir.cbor/boolean
              :spec-form `any?}])))
 
@@ -66,7 +66,7 @@
            [{:key :fhir/integer
              :spec-form `(fn [~'x] (instance? Integer ~'x))}
             {:key :fhir.json/integer
-             :spec-form `(s2/and int? (s2/conformer int type/-to-json))}
+             :spec-form `(s2/and int? (s2/conformer int type/to-json))}
             {:key :fhir.xml/integer
              :spec-form
              `(s2/and
@@ -74,9 +74,9 @@
                 (fn [~'e] (impl/xml-value-matches? "-?([0]|([1-9][0-9]*))" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Integer type/-to-xml))}
+                (s2/conformer type/xml->Integer type/to-xml))}
             {:key :fhir.cbor/integer
-             :spec-form `(s2/conformer int type/-to-json)}])))
+             :spec-form `(s2/conformer int type/to-json)}])))
 
   (testing "string"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "string"))
@@ -88,7 +88,7 @@
              `(s2/and
                 string?
                 (fn [~'s] (re-matches "[ \\r\\n\\t\\S]+" ~'s))
-                (s2/conformer identity type/-to-json))}
+                (s2/conformer identity type/to-json))}
             {:key :fhir.xml/string
              :spec-form
              `(s2/and
@@ -96,7 +96,7 @@
                 (fn [~'e] (impl/xml-value-matches? "[ \\r\\n\\t\\S]+" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->String type/-to-xml))}
+                (s2/conformer type/xml->String type/to-xml))}
             {:key :fhir.cbor/string
              :spec-form `any?}])))
 
@@ -114,7 +114,7 @@
                 (fn [~'e] (impl/xml-value-matches? "-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Decimal type/-to-xml))}
+                (s2/conformer type/xml->Decimal type/to-xml))}
             {:key :fhir.cbor/decimal
              :spec-form `any?}])))
 
@@ -128,7 +128,7 @@
              `(s2/and
                 string?
                 (fn [~'s] (re-matches "\\S*" ~'s))
-                (s2/conformer type/->Uri type/-to-json))}
+                (s2/conformer type/->Uri type/to-json))}
             {:key :fhir.xml/uri
              :spec-form
              `(s2/and
@@ -136,9 +136,9 @@
                 (fn [~'e] (impl/xml-value-matches? "\\S*" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Uri type/-to-xml))}
+                (s2/conformer type/xml->Uri type/to-xml))}
             {:key :fhir.cbor/uri
-             :spec-form `(s2/conformer type/->Uri type/-to-json)}])))
+             :spec-form `(s2/conformer type/->Uri type/to-json)}])))
 
   (testing "canonical"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "canonical"))
@@ -150,7 +150,7 @@
              `(s2/and
                 string?
                 (fn [~'s] (re-matches "\\S*" ~'s))
-                (s2/conformer type/->Canonical type/-to-json))}
+                (s2/conformer type/->Canonical type/to-json))}
             {:key :fhir.xml/canonical
              :spec-form
              `(s2/and
@@ -158,9 +158,9 @@
                 (fn [~'e] (impl/xml-value-matches? "\\S*" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Canonical type/-to-xml))}
+                (s2/conformer type/xml->Canonical type/to-xml))}
             {:key :fhir.cbor/canonical
-             :spec-form `(s2/conformer type/->Canonical type/-to-json)}])))
+             :spec-form `(s2/conformer type/->Canonical type/to-json)}])))
 
   (testing "base64Binary"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "base64Binary"))
@@ -172,7 +172,7 @@
              `(s2/and
                 string?
                 (fn [~'s] (re-matches "([0-9a-zA-Z\\\\+/=]{4})+" ~'s))
-                (s2/conformer type/->Base64Binary type/-to-json))}
+                (s2/conformer type/->Base64Binary type/to-json))}
             {:key :fhir.xml/base64Binary
              :spec-form
              `(s2/and
@@ -180,9 +180,9 @@
                 (fn [~'e] (impl/xml-value-matches? "([0-9a-zA-Z\\\\+/=]{4})+" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Base64Binary type/-to-xml))}
+                (s2/conformer type/xml->Base64Binary type/to-xml))}
             {:key :fhir.cbor/base64Binary
-             :spec-form `(s2/conformer type/->Base64Binary type/-to-json)}])))
+             :spec-form `(s2/conformer type/->Base64Binary type/to-json)}])))
 
   (testing "code"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "code"))
@@ -194,7 +194,7 @@
              `(s2/and
                 string?
                 (fn [~'s] (re-matches "[^\\s]+(\\s[^\\s]+)*" ~'s))
-                (s2/conformer type/->Code type/-to-json))}
+                (s2/conformer type/->Code type/to-json))}
             {:key :fhir.xml/code
              :spec-form
              `(s2/and
@@ -202,9 +202,9 @@
                 (fn [~'e] (impl/xml-value-matches? "[^\\s]+(\\s[^\\s]+)*" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Code type/-to-xml))}
+                (s2/conformer type/xml->Code type/to-xml))}
             {:key :fhir.cbor/code
-             :spec-form `(s2/conformer type/->Code type/-to-json)}])))
+             :spec-form `(s2/conformer type/->Code type/to-json)}])))
 
   (testing "unsignedInt"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "unsignedInt"))
@@ -212,7 +212,7 @@
            [{:key :fhir/unsignedInt
              :spec-form `type/unsignedInt?}
             {:key :fhir.json/unsignedInt
-             :spec-form `(s2/and int? (s2/conformer type/->UnsignedInt type/-to-json))}
+             :spec-form `(s2/and int? (s2/conformer type/->UnsignedInt type/to-json))}
             {:key :fhir.xml/unsignedInt
              :spec-form
              `(s2/and
@@ -220,9 +220,9 @@
                 (fn [~'e] (impl/xml-value-matches? "[0]|([1-9][0-9]*)" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->UnsignedInt type/-to-xml))}
+                (s2/conformer type/xml->UnsignedInt type/to-xml))}
             {:key :fhir.cbor/unsignedInt
-             :spec-form `(s2/conformer type/->UnsignedInt type/-to-json)}])))
+             :spec-form `(s2/conformer type/->UnsignedInt type/to-json)}])))
 
   (testing "positiveInt"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "positiveInt"))
@@ -230,7 +230,7 @@
            [{:key :fhir/positiveInt
              :spec-form `type/positiveInt?}
             {:key :fhir.json/positiveInt
-             :spec-form `(s2/and int? (s2/conformer type/->PositiveInt type/-to-json))}
+             :spec-form `(s2/and int? (s2/conformer type/->PositiveInt type/to-json))}
             {:key :fhir.xml/positiveInt
              :spec-form
              `(s2/and
@@ -238,9 +238,9 @@
                 (fn [~'e] (impl/xml-value-matches? "[1-9][0-9]*" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->PositiveInt type/-to-xml))}
+                (s2/conformer type/xml->PositiveInt type/to-xml))}
             {:key :fhir.cbor/positiveInt
-             :spec-form `(s2/conformer type/->PositiveInt type/-to-json)}])))
+             :spec-form `(s2/conformer type/->PositiveInt type/to-json)}])))
 
   (testing "uuid"
     (is (= (-> (impl/primitive-type->spec-defs (primitive-type "uuid"))
@@ -252,7 +252,7 @@
              `(s2/and
                 string?
                 (fn [~'s] (re-matches "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" ~'s))
-                (s2/conformer type/->Uuid type/-to-json))}
+                (s2/conformer type/->Uuid type/to-json))}
             {:key :fhir.xml/uuid
              :spec-form
              `(s2/and
@@ -260,9 +260,9 @@
                 (fn [~'e] (impl/xml-value-matches? "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" ~'e))
                 (s2/conformer identity impl/set-extension-tag)
                 (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                (s2/conformer type/xml->Uuid type/-to-xml))}
+                (s2/conformer type/xml->Uuid type/to-xml))}
             {:key :fhir.cbor/uuid
-             :spec-form `(s2/conformer type/->Uuid type/-to-json)}])))
+             :spec-form `(s2/conformer type/->Uuid type/to-json)}])))
 
   (testing "xhtml"
     (is (= (impl/primitive-type->spec-defs (primitive-type "xhtml"))
@@ -272,14 +272,14 @@
              :spec-form
              `(s2/and
                 string?
-                (s2/conformer type/->Xhtml type/-to-json))}
+                (s2/conformer type/->Xhtml type/to-json))}
             {:key :fhir.xml/xhtml
              :spec-form
              `(s2/and
                 impl/element?
-                (s2/conformer type/xml->Xhtml type/-to-xml))}
+                (s2/conformer type/xml->Xhtml type/to-xml))}
             {:key :fhir.cbor/xhtml
-             :spec-form `(s2/conformer type/->Xhtml type/-to-json)}]))))
+             :spec-form `(s2/conformer type/->Xhtml type/to-json)}]))))
 
 
 (defn- complex-type [name]
@@ -303,7 +303,7 @@
     (testing "has a type checker"
       (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
         [:fhir/UsageContext 0 :spec-form 1]
-        := `(fn [~'m] (identical? :fhir/UsageContext (type/-type ~'m)))))
+        := `(fn [~'m] (identical? :fhir/UsageContext (type/type ~'m)))))
     (testing "has a schema form"
       (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
         [:fhir/UsageContext 0 :spec-form 2]

--- a/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
@@ -44,10 +44,6 @@
   (.toPrintable (GraphLayout/parseInstance (object-array xs))))
 
 
-(defn graph-footprint [& xs]
-  (.toFootprint (GraphLayout/parseInstance (object-array xs))))
-
-
 (defn total-size [& xs]
   (.totalSize (GraphLayout/parseInstance (object-array xs))))
 
@@ -58,7 +54,7 @@
 
 (defn murmur3 [x]
   (let [hasher (.newHasher (Hashing/murmur3_32))]
-    (type/-hash-into x hasher)
+    (type/hash-into x hasher)
     (Integer/toHexString (.asInt (.hash hasher)))))
 
 
@@ -74,40 +70,31 @@
 (deftest nil-test
   (testing "all FhirType methods can be called on nil"
     (testing "type"
-      (is (nil? (type/-type nil))))
+      (is (nil? (type/type nil))))
     (testing "value"
-      (is (nil? (type/-value nil))))
+      (is (nil? (type/value nil))))
     (testing "to-json"
-      (is (nil? (type/-to-json nil))))
+      (is (nil? (type/to-json nil))))
     (testing "to-xml"
-      (is (nil? (type/-to-xml nil))))
+      (is (nil? (type/to-xml nil))))
     (testing "hash-into"
       (is (= "0" (murmur3 nil))))))
 
 
 (deftest Object-test
-  (testing "all FhirType methods can be called on arbitrary Objects"
-    (testing "type"
-      (is (nil? (type/-type (Object.)))))
-    (testing "value"
-      (is (nil? (type/-value (Object.)))))
-    (testing "to-json"
-      (is (nil? (type/-to-json (Object.)))))
-    (testing "to-xml"
-      (is (nil? (type/-to-xml (Object.)))))
-    (testing "hash-into"
-      (is (= "0" (murmur3 (Object.)))))))
+  (testing "arbitrary instances have no fhir type"
+    (is (nil? (type/type (Object.))))))
 
 
 (deftest boolean-test
   (testing "type"
-    (is (= :fhir/boolean (type/-type true))))
+    (is (= :fhir/boolean (type/type true))))
   (testing "value"
-    (is (= true (type/-value true))))
+    (is (= true (type/value true))))
   (testing "to-json"
-    (is (= true (type/-to-json true))))
+    (is (= true (type/to-json true))))
   (testing "to-xml"
-    (are [b s] (= (sexp [nil {:value s}]) (type/-to-xml b))
+    (are [b s] (= (sexp [nil {:value s}]) (type/to-xml b))
       true "true"
       false "false"))
   (testing "hash-into"
@@ -120,13 +107,13 @@
   (testing "from XML"
     (is (= #fhir/integer 1 (type/xml->Integer (sexp [nil {:value "1"}])))))
   (testing "type"
-    (is (= :fhir/integer (type/-type #fhir/integer 1))))
+    (is (= :fhir/integer (type/type #fhir/integer 1))))
   (testing "value"
-    (is (= 1 (type/-value #fhir/integer 1))))
+    (is (= 1 (type/value #fhir/integer 1))))
   (testing "to-json"
-    (is (= 1 (type/-to-json #fhir/integer 1))))
+    (is (= 1 (type/to-json #fhir/integer 1))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "1"}]) (type/-to-xml #fhir/integer 1))))
+    (is (= (sexp  [nil {:value "1"}]) (type/to-xml #fhir/integer 1))))
   (testing "instance size"
     (is (= 16 (total-size #fhir/integer 1))))
   (testing "hash-into"
@@ -139,13 +126,13 @@
   (testing "from XML"
     (is (= #fhir/integer 1 (type/xml->Long (sexp [nil {:value "1"}])))))
   (testing "type"
-    (is (= :fhir/long (type/-type #fhir/long 1))))
+    (is (= :fhir/long (type/type #fhir/long 1))))
   (testing "value"
-    (is (= 1 (type/-value #fhir/long 1))))
+    (is (= 1 (type/value #fhir/long 1))))
   (testing "to-json"
-    (is (= 1 (type/-to-json #fhir/long 1))))
+    (is (= 1 (type/to-json #fhir/long 1))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "1"}]) (type/-to-xml #fhir/long 1))))
+    (is (= (sexp  [nil {:value "1"}]) (type/to-xml #fhir/long 1))))
   (testing "instance size"
     (is (= 24 (total-size #fhir/long 1))))
   (testing "hash-into"
@@ -158,13 +145,13 @@
   (testing "from XML"
     (is (= "142214" (type/xml->String (sexp [nil {:value "142214"}])))))
   (testing "type"
-    (is (= :fhir/string (type/-type ""))))
+    (is (= :fhir/string (type/type ""))))
   (testing "value"
-    (is (= "175227" (type/-value "175227"))))
+    (is (= "175227" (type/value "175227"))))
   (testing "to-json"
-    (is (= "105406" (type/-to-json "105406"))))
+    (is (= "105406" (type/to-json "105406"))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "121344"}]) (type/-to-xml "121344"))))
+    (is (= (sexp  [nil {:value "121344"}]) (type/to-xml "121344"))))
   (testing "instance size"
     (is (= 48 (total-size "a")))
     (is (= 48 (total-size (str/repeat "a" 8))))
@@ -179,13 +166,13 @@
   (testing "from XML"
     (is (= 1M (type/xml->Decimal (sexp [nil {:value "1"}])))))
   (testing "type"
-    (is (= :fhir/decimal (type/-type 1M))))
+    (is (= :fhir/decimal (type/type 1M))))
   (testing "value"
-    (is (= 1M (type/-value 1M))))
+    (is (= 1M (type/value 1M))))
   (testing "to-json"
-    (is (= 1M (type/-to-json 1M))))
+    (is (= 1M (type/to-json 1M))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "1.1"}]) (type/-to-xml 1.1M))))
+    (is (= (sexp  [nil {:value "1.1"}]) (type/to-xml 1.1M))))
   (testing "instance size"
     (is (= 40 (total-size (parse-json "1.1")))))
   (testing "hash-into"
@@ -198,13 +185,13 @@
   (testing "from XML"
     (is (= #fhir/uri"142307" (type/xml->Uri (sexp [nil {:value "142307"}])))))
   (testing "type"
-    (is (= :fhir/uri (type/-type #fhir/uri""))))
+    (is (= :fhir/uri (type/type #fhir/uri""))))
   (testing "value"
-    (is (= "105614" (type/-value #fhir/uri"105614"))))
+    (is (= "105614" (type/value #fhir/uri"105614"))))
   (testing "to-json"
-    (is (= "105846" (type/-to-json #fhir/uri"105846"))))
+    (is (= "105846" (type/to-json #fhir/uri"105846"))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "105846"}]) (type/-to-xml #fhir/uri"105846"))))
+    (is (= (sexp  [nil {:value "105846"}]) (type/to-xml #fhir/uri"105846"))))
   (testing "equals"
     (is (= #fhir/uri"142334" #fhir/uri"142334")))
   (testing "print"
@@ -222,13 +209,13 @@
   (testing "from XML"
     (is (= #fhir/url"142307" (type/xml->Url (sexp [nil {:value "142307"}])))))
   (testing "type"
-    (is (= :fhir/url (type/-type #fhir/url""))))
+    (is (= :fhir/url (type/type #fhir/url""))))
   (testing "value"
-    (is (= "105614" (type/-value #fhir/url"105614"))))
+    (is (= "105614" (type/value #fhir/url"105614"))))
   (testing "to-json"
-    (is (= "105846" (type/-to-json #fhir/url"105846"))))
+    (is (= "105846" (type/to-json #fhir/url"105846"))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "105846"}]) (type/-to-xml #fhir/url"105846"))))
+    (is (= (sexp  [nil {:value "105846"}]) (type/to-xml #fhir/url"105846"))))
   (testing "equals"
     (is (= #fhir/url"142334" #fhir/url"142334")))
   (testing "print"
@@ -246,13 +233,13 @@
   (testing "from XML"
     (is (= #fhir/canonical"142307" (type/xml->Canonical (sexp [nil {:value "142307"}])))))
   (testing "type"
-    (is (= :fhir/canonical (type/-type #fhir/canonical""))))
+    (is (= :fhir/canonical (type/type #fhir/canonical""))))
   (testing "value"
-    (is (= "105614" (type/-value #fhir/canonical"105614"))))
+    (is (= "105614" (type/value #fhir/canonical"105614"))))
   (testing "to-json"
-    (is (= "105846" (type/-to-json #fhir/canonical"105846"))))
+    (is (= "105846" (type/to-json #fhir/canonical"105846"))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "105846"}]) (type/-to-xml #fhir/canonical"105846"))))
+    (is (= (sexp  [nil {:value "105846"}]) (type/to-xml #fhir/canonical"105846"))))
   (testing "equals"
     (is (= #fhir/canonical"142334" #fhir/canonical"142334")))
   (testing "print"
@@ -271,13 +258,13 @@
     (is (= #fhir/base64Binary"MTA1NjE0Cg=="
            (type/xml->Base64Binary (sexp [nil {:value "MTA1NjE0Cg=="}])))))
   (testing "type"
-    (is (= :fhir/base64Binary (type/-type #fhir/base64Binary""))))
+    (is (= :fhir/base64Binary (type/type #fhir/base64Binary""))))
   (testing "value"
-    (is (= "MTA1NjE0Cg==" (type/-value #fhir/base64Binary"MTA1NjE0Cg=="))))
+    (is (= "MTA1NjE0Cg==" (type/value #fhir/base64Binary"MTA1NjE0Cg=="))))
   (testing "to-json"
-    (is (= "MTA1NjE0Cg==" (type/-to-json #fhir/base64Binary"MTA1NjE0Cg=="))))
+    (is (= "MTA1NjE0Cg==" (type/to-json #fhir/base64Binary"MTA1NjE0Cg=="))))
   (testing "to-xml"
-    (is (= (sexp  [nil {:value "MTA1NjE0Cg=="}]) (type/-to-xml #fhir/base64Binary"MTA1NjE0Cg=="))))
+    (is (= (sexp  [nil {:value "MTA1NjE0Cg=="}]) (type/to-xml #fhir/base64Binary"MTA1NjE0Cg=="))))
   (testing "equals"
     (is (= #fhir/base64Binary"MTA1NjE0Cg==" #fhir/base64Binary"MTA1NjE0Cg==")))
   (testing "instance size"
@@ -299,22 +286,22 @@
     (is (= Instant/EPOCH (type/->Instant "1970-01-01T00:00:00Z"))))
   (testing "type"
     (is (= :fhir/instant
-           (type/-type (type/->Instant "2020-01-01T00:00:00+02:00"))))
-    (is (= :fhir/instant (type/-type Instant/EPOCH))))
+           (type/type (type/->Instant "2020-01-01T00:00:00+02:00"))))
+    (is (= :fhir/instant (type/type Instant/EPOCH))))
   (testing "value is a System.DateTime which is a OffsetDateTime"
     (is (= (OffsetDateTime/of 2020 1 1 0 0 0 0 (ZoneOffset/ofHours 2))
-           (type/-value (type/->Instant "2020-01-01T00:00:00+02:00"))))
+           (type/value (type/->Instant "2020-01-01T00:00:00+02:00"))))
     (is (= (OffsetDateTime/of 1970 1 1 0 0 0 0 ZoneOffset/UTC)
-           (type/-value Instant/EPOCH))))
+           (type/value Instant/EPOCH))))
   (testing "to-json"
     (is (= "2020-01-01T00:00:00+02:00"
-           (type/-to-json (type/->Instant "2020-01-01T00:00:00+02:00"))))
-    (is (= "1970-01-01T00:00:00Z" (type/-to-json Instant/EPOCH))))
+           (type/to-json (type/->Instant "2020-01-01T00:00:00+02:00"))))
+    (is (= "1970-01-01T00:00:00Z" (type/to-json Instant/EPOCH))))
   (testing "to-xml"
     (is (= (sexp  [nil {:value "2020-01-01T00:00:00+02:00"}])
-           (type/-to-xml (type/->Instant "2020-01-01T00:00:00+02:00"))))
+           (type/to-xml (type/->Instant "2020-01-01T00:00:00+02:00"))))
     (is (= (sexp  [nil {:value "1970-01-01T00:00:00Z"}])
-           (type/-to-xml Instant/EPOCH))))
+           (type/to-xml Instant/EPOCH))))
   (testing "equals"
     (is (= (type/->Instant "2020-01-01T00:00:00+02:00")
            (type/->Instant "2020-01-01T00:00:00+02:00")))
@@ -338,13 +325,13 @@
     (testing "from XML"
       (is (= #fhir/date"2010" (type/xml->Date (sexp [nil {:value "2010"}])))))
     (testing "type"
-      (is (= :fhir/date (type/-type #fhir/date"2020"))))
+      (is (= :fhir/date (type/type #fhir/date"2020"))))
     (testing "value"
-      (is (= (Year/of 2020) (type/-value #fhir/date"2020"))))
+      (is (= (Year/of 2020) (type/value #fhir/date"2020"))))
     (testing "to-json"
-      (is (= "2020" (type/-to-json #fhir/date"2020"))))
+      (is (= "2020" (type/to-json #fhir/date"2020"))))
     (testing "to-xml"
-      (is (= (sexp  [nil {:value "2020"}]) (type/-to-xml #fhir/date"2020"))))
+      (is (= (sexp  [nil {:value "2020"}]) (type/to-xml #fhir/date"2020"))))
     (testing "equals"
       (is (= #fhir/date"2020" #fhir/date"2020")))
     (testing "instance size"
@@ -358,13 +345,13 @@
       (is (= #fhir/date"2010-04"
              (type/xml->Date (sexp [nil {:value "2010-04"}])))))
     (testing "type"
-      (is (= :fhir/date (type/-type #fhir/date"2020-01"))))
+      (is (= :fhir/date (type/type #fhir/date"2020-01"))))
     (testing "value"
-      (is (= (YearMonth/of 2020 1) (type/-value #fhir/date"2020-01"))))
+      (is (= (YearMonth/of 2020 1) (type/value #fhir/date"2020-01"))))
     (testing "to-json"
-      (is (= "2020-01" (type/-to-json #fhir/date"2020-01"))))
+      (is (= "2020-01" (type/to-json #fhir/date"2020-01"))))
     (testing "to-xml"
-      (is (= (sexp  [nil {:value "2020-01"}]) (type/-to-xml #fhir/date"2020-01"))))
+      (is (= (sexp  [nil {:value "2020-01"}]) (type/to-xml #fhir/date"2020-01"))))
     (testing "equals"
       (is (= #fhir/date"2020-01" #fhir/date"2020-01")))
     (testing "instance size"
@@ -378,14 +365,14 @@
       (is (= #fhir/date"2010-05-15"
              (type/xml->Date (sexp [nil {:value "2010-05-15"}])))))
     (testing "type"
-      (is (= :fhir/date (type/-type #fhir/date"2020-01-01"))))
+      (is (= :fhir/date (type/type #fhir/date"2020-01-01"))))
     (testing "value"
-      (is (= (LocalDate/of 2020 1 1) (type/-value #fhir/date"2020-01-01"))))
+      (is (= (LocalDate/of 2020 1 1) (type/value #fhir/date"2020-01-01"))))
     (testing "to-json"
-      (is (= "2020-01-01" (type/-to-json #fhir/date"2020-01-01"))))
+      (is (= "2020-01-01" (type/to-json #fhir/date"2020-01-01"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01"}])
-             (type/-to-xml #fhir/date"2020-01-01"))))
+             (type/to-xml #fhir/date"2020-01-01"))))
     (testing "equals"
       (is (= #fhir/date"2020-01-01" #fhir/date"2020-01-01")))
     (testing "instance size"
@@ -401,13 +388,13 @@
       (is (= #fhir/dateTime"2010"
              (type/xml->DateTime (sexp [nil {:value "2010"}])))))
     (testing "type"
-      (is (= :fhir/dateTime (type/-type #fhir/dateTime"2020"))))
+      (is (= :fhir/dateTime (type/type #fhir/dateTime"2020"))))
     (testing "value"
-      (is (= (system/date-time 2020) (type/-value #fhir/dateTime"2020"))))
+      (is (= (system/date-time 2020) (type/value #fhir/dateTime"2020"))))
     (testing "to-json"
-      (is (= "2020" (type/-to-json #fhir/dateTime"2020"))))
+      (is (= "2020" (type/to-json #fhir/dateTime"2020"))))
     (testing "to-xml"
-      (is (= (sexp  [nil {:value "2020"}]) (type/-to-xml #fhir/dateTime"2020"))))
+      (is (= (sexp  [nil {:value "2020"}]) (type/to-xml #fhir/dateTime"2020"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020" #fhir/dateTime"2020")))
     (testing "instance size"
@@ -423,15 +410,15 @@
       (is (= #fhir/dateTime"2010-04"
              (type/xml->DateTime (sexp [nil {:value "2010-04"}])))))
     (testing "type"
-      (is (= :fhir/dateTime (type/-type #fhir/dateTime"2020-01"))))
+      (is (= :fhir/dateTime (type/type #fhir/dateTime"2020-01"))))
     (testing "value"
       (is (= (system/date-time 2020 1)
-             (type/-value #fhir/dateTime"2020-01"))))
+             (type/value #fhir/dateTime"2020-01"))))
     (testing "to-json"
-      (is (= "2020-01" (type/-to-json #fhir/dateTime"2020-01"))))
+      (is (= "2020-01" (type/to-json #fhir/dateTime"2020-01"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01"}])
-             (type/-to-xml #fhir/dateTime"2020-01"))))
+             (type/to-xml #fhir/dateTime"2020-01"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01" #fhir/dateTime"2020-01")))
     (testing "instance size"
@@ -445,15 +432,15 @@
       (is (= #fhir/dateTime"2010-05-15"
              (type/xml->DateTime (sexp [nil {:value "2010-05-15"}])))))
     (testing "type"
-      (is (= :fhir/dateTime (type/-type #fhir/dateTime"2020-01-01"))))
+      (is (= :fhir/dateTime (type/type #fhir/dateTime"2020-01-01"))))
     (testing "value"
       (is (= (system/date-time 2020 1 1)
-             (type/-value #fhir/dateTime"2020-01-01"))))
+             (type/value #fhir/dateTime"2020-01-01"))))
     (testing "to-json"
-      (is (= "2020-01-01" (type/-to-json #fhir/dateTime"2020-01-01"))))
+      (is (= "2020-01-01" (type/to-json #fhir/dateTime"2020-01-01"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01"))))
+             (type/to-xml #fhir/dateTime"2020-01-01"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01" #fhir/dateTime"2020-01-01")))
     (testing "instance size"
@@ -469,13 +456,13 @@
       (is (= #fhir/dateTime"2020-01-01T00:00:00"
              (type/xml->DateTime (sexp [nil {:value "2020-01-01T00:00:00"}])))))
     (testing "type"
-      (is (= :fhir/dateTime (type/-type #fhir/dateTime"2020-01-01T00:00:00"))))
+      (is (= :fhir/dateTime (type/type #fhir/dateTime"2020-01-01T00:00:00"))))
     (testing "to-json"
       (is (= "2020-01-01T00:00:00"
-             (type/-to-json #fhir/dateTime"2020-01-01T00:00:00"))))
+             (type/to-json #fhir/dateTime"2020-01-01T00:00:00"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01T00:00:00"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01T00:00:00"))))
+             (type/to-xml #fhir/dateTime"2020-01-01T00:00:00"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01T00:00:00"
              #fhir/dateTime"2020-01-01T00:00:00")))
@@ -490,13 +477,13 @@
       (is (= #fhir/dateTime"2020-01-01T00:00:00.001"
              (type/xml->DateTime (sexp [nil {:value "2020-01-01T00:00:00.001"}])))))
     (testing "type"
-      (is (= :fhir/dateTime (type/-type #fhir/dateTime"2020-01-01T00:00:00.000"))))
+      (is (= :fhir/dateTime (type/type #fhir/dateTime"2020-01-01T00:00:00.000"))))
     (testing "to-json"
       (is (= "2020-01-01T00:00:00.001"
-             (type/-to-json #fhir/dateTime"2020-01-01T00:00:00.001"))))
+             (type/to-json #fhir/dateTime"2020-01-01T00:00:00.001"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01T00:00:00.001"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01T00:00:00.001"))))
+             (type/to-xml #fhir/dateTime"2020-01-01T00:00:00.001"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01T00:00:00.000"
              #fhir/dateTime"2020-01-01T00:00:00.000")))
@@ -511,13 +498,13 @@
       (is (= #fhir/dateTime"2020-01-01T00:00:00Z"
              (type/xml->DateTime (sexp [nil {:value "2020-01-01T00:00:00Z"}])))))
     (testing "type"
-      (is (= :fhir/dateTime (type/-type #fhir/dateTime"2020-01-01T00:00:00Z"))))
+      (is (= :fhir/dateTime (type/type #fhir/dateTime"2020-01-01T00:00:00Z"))))
     (testing "to-json"
       (is (= "2020-01-01T00:00:00Z"
-             (type/-to-json #fhir/dateTime"2020-01-01T00:00:00Z"))))
+             (type/to-json #fhir/dateTime"2020-01-01T00:00:00Z"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01T00:00:00Z"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01T00:00:00Z"))))
+             (type/to-xml #fhir/dateTime"2020-01-01T00:00:00Z"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01T00:00:00Z"
              #fhir/dateTime"2020-01-01T00:00:00Z")))
@@ -534,13 +521,13 @@
              (type/xml->DateTime (sexp [nil {:value "2020-01-01T00:00:00+01:00"}])))))
     (testing "type"
       (is (= :fhir/dateTime
-             (type/-type #fhir/dateTime"2020-01-01T00:00:00+01:00"))))
+             (type/type #fhir/dateTime"2020-01-01T00:00:00+01:00"))))
     (testing "to-json"
       (is (= "2020-01-01T00:00:00+01:00"
-             (type/-to-json #fhir/dateTime"2020-01-01T00:00:00+01:00"))))
+             (type/to-json #fhir/dateTime"2020-01-01T00:00:00+01:00"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01T00:00:00+01:00"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01T00:00:00+01:00"))))
+             (type/to-xml #fhir/dateTime"2020-01-01T00:00:00+01:00"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01T00:00:00+01:00"
              #fhir/dateTime"2020-01-01T00:00:00+01:00")))
@@ -554,13 +541,13 @@
              (type/xml->DateTime (sexp [nil {:value "2020-01-01T00:00:00-01:00"}])))))
     (testing "type"
       (is (= :fhir/dateTime
-             (type/-type #fhir/dateTime"2020-01-01T00:00:00-01:00"))))
+             (type/type #fhir/dateTime"2020-01-01T00:00:00-01:00"))))
     (testing "to-json"
       (is (= "2020-01-01T00:00:00-01:00"
-             (type/-to-json #fhir/dateTime"2020-01-01T00:00:00-01:00"))))
+             (type/to-json #fhir/dateTime"2020-01-01T00:00:00-01:00"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01T00:00:00-01:00"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01T00:00:00-01:00"))))
+             (type/to-xml #fhir/dateTime"2020-01-01T00:00:00-01:00"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01T00:00:00-01:00"
              #fhir/dateTime"2020-01-01T00:00:00-01:00")))
@@ -574,16 +561,16 @@
              (type/xml->DateTime (sexp [nil {:value "2020-01-01T00:00:00.001Z"}])))))
     (testing "type"
       (is (= :fhir/dateTime
-             (type/-type #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
+             (type/type #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
     (testing "value is a System.DateTime which is a OffsetDateTime"
       (is (= (OffsetDateTime/of 2020 1 1 0 0 0 1000000 ZoneOffset/UTC)
-             (type/-value #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
+             (type/value #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
     (testing "to-json"
       (is (= "2020-01-01T00:00:00.001Z"
-             (type/-to-json #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
+             (type/to-json #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
     (testing "to-xml"
       (is (= (sexp  [nil {:value "2020-01-01T00:00:00.001Z"}])
-             (type/-to-xml #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
+             (type/to-xml #fhir/dateTime"2020-01-01T00:00:00.001Z"))))
     (testing "equals"
       (is (= #fhir/dateTime"2020-01-01T00:00:00.001Z"
              #fhir/dateTime"2020-01-01T00:00:00.001Z")))
@@ -595,13 +582,13 @@
     (let [extended-date-time (type/->DateTime nil [string-extension] "2020")
           extended-date-time-element (xml-node/element nil {:value "2020"} string-extension)]
       (testing "type"
-        (is (= :fhir/dateTime (type/-type extended-date-time))))
+        (is (= :fhir/dateTime (type/type extended-date-time))))
       (testing "value"
-        (is (= (system/date-time 2020) (type/-value extended-date-time))))
+        (is (= (system/date-time 2020) (type/value extended-date-time))))
       (testing "to-json"
-        (is (= "2020" (type/-to-json extended-date-time))))
+        (is (= "2020" (type/to-json extended-date-time))))
       (testing "to-xml"
-        (is (= extended-date-time-element (type/-to-xml extended-date-time))))
+        (is (= extended-date-time-element (type/to-xml extended-date-time))))
       (testing "equals"
         (is (= (type/->DateTime nil [string-extension] "2020") extended-date-time)))
       (testing "hash-into"
@@ -615,14 +602,14 @@
   (testing "from XML"
     (is (= #fhir/time"13:53:21" (type/xml->Time (sexp [nil {:value "13:53:21"}])))))
   (testing "type"
-    (is (= :fhir/time (type/-type #fhir/time"13:53:21"))))
+    (is (= :fhir/time (type/type #fhir/time"13:53:21"))))
   (testing "value is a System.Time which is a LocalTime"
-    (is (= (LocalTime/of 13 53 21) (type/-value #fhir/time"13:53:21"))))
+    (is (= (LocalTime/of 13 53 21) (type/value #fhir/time"13:53:21"))))
   (testing "to-json"
-    (is (= "13:53:21" (type/-to-json #fhir/time"13:53:21"))))
+    (is (= "13:53:21" (type/to-json #fhir/time"13:53:21"))))
   (testing "to-xml"
     (is (= (sexp  [nil {:value "13:53:21"}])
-           (type/-to-xml #fhir/time"13:53:21"))))
+           (type/to-xml #fhir/time"13:53:21"))))
   (testing "equals"
     (is (= #fhir/time"13:53:21" #fhir/time"13:53:21")))
   (testing "hash-into"
@@ -655,16 +642,16 @@
     (is (= #fhir/code"code-150725"
            (type/xml->Code (sexp [nil {:value "code-150725"}])))))
   (testing "type"
-    (is (= :fhir/code (type/-type #fhir/code""))))
+    (is (= :fhir/code (type/type #fhir/code""))))
   (testing "value is a System.String which is a String"
-    (is (= "code-123745" (type/-value #fhir/code"code-123745")))
-    (is (= "other" (type/-value (type/->ExtendedCode nil [] "other")))))
+    (is (= "code-123745" (type/value #fhir/code"code-123745")))
+    (is (= "other" (type/value (type/->ExtendedCode nil [] "other")))))
   (testing "to-json"
-    (is (= "code-123745" (type/-to-json #fhir/code"code-123745"))))
+    (is (= "code-123745" (type/to-json #fhir/code"code-123745"))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "code-123745"}])
-           (type/-to-xml #fhir/code"code-123745")))
-    (is (= extended-gender-code-element (type/-to-xml extended-gender-code))))
+           (type/to-xml #fhir/code"code-123745")))
+    (is (= extended-gender-code-element (type/to-xml extended-gender-code))))
   (testing "equals"
     (is (= #fhir/code"175726" #fhir/code"175726")))
   (testing "print"
@@ -679,14 +666,14 @@
     (is (= #fhir/oid"oid-150725"
            (type/xml->Oid (sexp [nil {:value "oid-150725"}])))))
   (testing "type"
-    (is (= :fhir/oid (type/-type #fhir/oid""))))
+    (is (= :fhir/oid (type/type #fhir/oid""))))
   (testing "value is a System.String which is a String"
-    (is (= "oid-123745" (type/-value #fhir/oid"oid-123745"))))
+    (is (= "oid-123745" (type/value #fhir/oid"oid-123745"))))
   (testing "to-json"
-    (is (= "oid-123745" (type/-to-json #fhir/oid"oid-123745"))))
+    (is (= "oid-123745" (type/to-json #fhir/oid"oid-123745"))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "oid-123745"}])
-           (type/-to-xml #fhir/oid"oid-123745"))))
+           (type/to-xml #fhir/oid"oid-123745"))))
   (testing "equals"
     (is (= #fhir/oid"175726" #fhir/oid"175726")))
   (testing "print"
@@ -702,14 +689,14 @@
     (is (= #fhir/id"id-150725"
            (type/xml->Id (sexp [nil {:value "id-150725"}])))))
   (testing "type"
-    (is (= :fhir/id (type/-type #fhir/id""))))
+    (is (= :fhir/id (type/type #fhir/id""))))
   (testing "value is a System.String which is a String"
-    (is (= "id-123745" (type/-value #fhir/id"id-123745"))))
+    (is (= "id-123745" (type/value #fhir/id"id-123745"))))
   (testing "to-json"
-    (is (= "id-123745" (type/-to-json #fhir/id"id-123745"))))
+    (is (= "id-123745" (type/to-json #fhir/id"id-123745"))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "id-123745"}])
-           (type/-to-xml #fhir/id"id-123745"))))
+           (type/to-xml #fhir/id"id-123745"))))
   (testing "equals"
     (is (= #fhir/id"175726" #fhir/id"175726")))
   (testing "print"
@@ -724,14 +711,14 @@
     (is (= #fhir/markdown"markdown-150725"
            (type/xml->Markdown (sexp [nil {:value "markdown-150725"}])))))
   (testing "type"
-    (is (= :fhir/markdown (type/-type #fhir/markdown""))))
+    (is (= :fhir/markdown (type/type #fhir/markdown""))))
   (testing "value is a System.String which is a String"
-    (is (= "markdown-123745" (type/-value #fhir/markdown"markdown-123745"))))
+    (is (= "markdown-123745" (type/value #fhir/markdown"markdown-123745"))))
   (testing "to-json"
-    (is (= "markdown-123745" (type/-to-json #fhir/markdown"markdown-123745"))))
+    (is (= "markdown-123745" (type/to-json #fhir/markdown"markdown-123745"))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "markdown-123745"}])
-           (type/-to-xml #fhir/markdown"markdown-123745"))))
+           (type/to-xml #fhir/markdown"markdown-123745"))))
   (testing "equals"
     (is (= #fhir/markdown"175726" #fhir/markdown"175726")))
   (testing "print"
@@ -746,15 +733,15 @@
     (is (= #fhir/unsignedInt 150725
            (type/xml->UnsignedInt (sexp [nil {:value "150725"}])))))
   (testing "type"
-    (is (= :fhir/unsignedInt (type/-type #fhir/unsignedInt 0))))
+    (is (= :fhir/unsignedInt (type/type #fhir/unsignedInt 0))))
   (testing "value is a System.Integer which is a Integer"
-    (is (= 160845 (type/-value #fhir/unsignedInt 160845)))
-    (is (instance? Integer (type/-value #fhir/unsignedInt 160845))))
+    (is (= 160845 (type/value #fhir/unsignedInt 160845)))
+    (is (instance? Integer (type/value #fhir/unsignedInt 160845))))
   (testing "to-json"
-    (is (= 160845 (type/-to-json #fhir/unsignedInt 160845))))
+    (is (= 160845 (type/to-json #fhir/unsignedInt 160845))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "160845"}])
-           (type/-to-xml #fhir/unsignedInt 160845))))
+           (type/to-xml #fhir/unsignedInt 160845))))
   (testing "equals"
     (is (= #fhir/unsignedInt 160845 #fhir/unsignedInt 160845)))
   (testing "print"
@@ -769,15 +756,15 @@
     (is (= #fhir/positiveInt 150725
            (type/xml->PositiveInt (sexp [nil {:value "150725"}])))))
   (testing "type"
-    (is (= :fhir/positiveInt (type/-type #fhir/positiveInt 0))))
+    (is (= :fhir/positiveInt (type/type #fhir/positiveInt 0))))
   (testing "value is a System.Integer which is a Integer"
-    (is (= 160845 (type/-value #fhir/positiveInt 160845)))
-    (is (instance? Integer (type/-value #fhir/positiveInt 160845))))
+    (is (= 160845 (type/value #fhir/positiveInt 160845)))
+    (is (instance? Integer (type/value #fhir/positiveInt 160845))))
   (testing "to-json"
-    (is (= 160845 (type/-to-json #fhir/positiveInt 160845))))
+    (is (= 160845 (type/to-json #fhir/positiveInt 160845))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "160845"}])
-           (type/-to-xml #fhir/positiveInt 160845))))
+           (type/to-xml #fhir/positiveInt 160845))))
   (testing "equals"
     (is (= #fhir/positiveInt 160845 #fhir/positiveInt 160845)))
   (testing "print"
@@ -792,16 +779,16 @@
     (is (= #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"
            (type/xml->Uuid (sexp [nil {:value "urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"}])))))
   (testing "type"
-    (is (= :fhir/uuid (type/-type #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
+    (is (= :fhir/uuid (type/type #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
   (testing "value is a System.String which is a String"
     (is (= "urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"
-           (type/-value #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
+           (type/value #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
   (testing "to-json"
     (is (= "urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"
-           (type/-to-json #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
+           (type/to-json #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
   (testing "to-xml"
     (is (= (sexp [nil {:value "urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"}])
-           (type/-to-xml #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
+           (type/to-xml #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"))))
   (testing "equals"
     (is (= #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3"
            #fhir/uuid"urn:uuid:6d270b7d-bf7d-4c95-8e30-4d87360d47a3")))
@@ -820,13 +807,13 @@
     (is (= #fhir/xhtml"<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>FHIR is cool.</p></div>"
            (type/xml->Xhtml xhtml-element))))
   (testing "type"
-    (is (= :fhir/xhtml (type/-type #fhir/xhtml""))))
+    (is (= :fhir/xhtml (type/type #fhir/xhtml""))))
   (testing "value is a System.String which is a String"
-    (is (= "xhtml-123745" (type/-value #fhir/xhtml"xhtml-123745"))))
+    (is (= "xhtml-123745" (type/value #fhir/xhtml"xhtml-123745"))))
   (testing "to-json"
-    (is (= "xhtml-123745" (type/-to-json #fhir/xhtml"xhtml-123745"))))
+    (is (= "xhtml-123745" (type/to-json #fhir/xhtml"xhtml-123745"))))
   (testing "to-xml"
-    (is (= xhtml-element (type/-to-xml #fhir/xhtml"<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>FHIR is cool.</p></div>"))))
+    (is (= xhtml-element (type/to-xml #fhir/xhtml"<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>FHIR is cool.</p></div>"))))
   (testing "equals"
     (is (= #fhir/xhtml"175726" #fhir/xhtml"175726")))
   (testing "print"


### PR DESCRIPTION
Moving the protocol into its own namespace that the advantage, that the
type namespace can be reloaded without reloading the protocol.