### PR TITLE
Improve Hashing Performance

### DIFF
--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -1784,27 +1784,27 @@
         (is (= (r-sp-v-tu/decode-index-entries
                  (:kv-store node)
                  :type :id :hash-prefix :code :v-hash)
-               [["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+               [["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "value-quantity" #blaze/byte-string"0000000080"]
-                ["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+                ["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "value-quantity" #blaze/byte-string"5C38E45A80"]
-                ["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+                ["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "value-quantity" #blaze/byte-string"9B780D9180"]
-                ["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+                ["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "combo-value-quantity" #blaze/byte-string"0000000080"]
-                ["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+                ["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "combo-value-quantity" #blaze/byte-string"5C38E45A80"]
-                ["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+                ["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "combo-value-quantity" #blaze/byte-string"9B780D9180"]
-                ["Observation" "id-0" #blaze/byte-string"7B68D1DB"
+                ["Observation" "id-0" #blaze/byte-string"01FD55D1"
                  "_id" #blaze/byte-string"165494C5"]
-                ["TestScript" "id-0" #blaze/byte-string"10FA3621"
+                ["TestScript" "id-0" #blaze/byte-string"DF8AA1E3"
                  "context-quantity" #blaze/byte-string"0000000080"]
-                ["TestScript" "id-0" #blaze/byte-string"10FA3621"
+                ["TestScript" "id-0" #blaze/byte-string"DF8AA1E3"
                  "context-quantity" #blaze/byte-string"5C38E45A80"]
-                ["TestScript" "id-0" #blaze/byte-string"10FA3621"
+                ["TestScript" "id-0" #blaze/byte-string"DF8AA1E3"
                  "context-quantity" #blaze/byte-string"9B780D9180"]
-                ["TestScript" "id-0" #blaze/byte-string"10FA3621"
+                ["TestScript" "id-0" #blaze/byte-string"DF8AA1E3"
                  "_id" #blaze/byte-string"165494C5"]])))
 
 

--- a/modules/db/test/blaze/db/node/resource_indexer_test.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_test.clj
@@ -75,7 +75,7 @@
     @(ri/index-resources i [hash])
 
     (testing "SearchParamValueResource index"
-      (is (every? #{["Condition" "id-204446" #blaze/byte-string"F6260321"]}
+      (is (every? #{["Condition" "id-204446" #blaze/byte-string"7EF16FC6"]}
                   (sp-vr-tu/decode-index-entries
                     kv-store :type :id :hash-prefix)))
       (is (= (sp-vr-tu/decode-index-entries kv-store :code :v-hash)
@@ -102,7 +102,7 @@
               ["_id" (codec/v-hash "id-204446")]])))
 
     (testing "ResourceSearchParamValue index"
-      (is (every? #{["Condition" "id-204446" #blaze/byte-string"F6260321"]}
+      (is (every? #{["Condition" "id-204446" #blaze/byte-string"7EF16FC6"]}
                   (r-sp-v-tu/decode-index-entries
                     kv-store :type :id :hash-prefix)))
       (is (= (r-sp-v-tu/decode-index-entries kv-store :code :v-hash)
@@ -129,7 +129,7 @@
 
     (testing "CompartmentSearchParamValueResource index"
       (is (every? #{[["Patient" "id-145552"] "Condition" "id-204446"
-                     #blaze/byte-string"F6260321"]}
+                     #blaze/byte-string"7EF16FC6"]}
                   (c-sp-vr-tu/decode-index-entries
                     kv-store :compartment :type :id :hash-prefix)))
       (is (= (c-sp-vr-tu/decode-index-entries kv-store :code :v-hash)
@@ -185,7 +185,7 @@
     @(ri/index-resources i [hash])
 
     (testing "SearchParamValueResource index"
-      (is (every? #{["Observation" "id-192702" #blaze/byte-string"DD3A49CC"]}
+      (is (every? #{["Observation" "id-192702" #blaze/byte-string"7EFFE8CC"]}
                   (sp-vr-tu/decode-index-entries
                     kv-store :type :id :hash-prefix)))
       (is (= (sp-vr-tu/decode-index-entries kv-store :code :v-hash)

--- a/modules/db/test/blaze/db/node/transaction_test.clj
+++ b/modules/db/test/blaze/db/node/transaction_test.clj
@@ -29,9 +29,9 @@
       [0 0 :op] := "create"
       [0 0 :type] := "Observation"
       [0 0 :id] := "0"
-      [0 0 :hash] := #blaze/byte-string"188C7598C8AB1DBDCF94ACD7B60F3E324FBE7535CBB6A56A89C2977F4A30F9CE"
+      [0 0 :hash] := #blaze/byte-string"3E2D4F15EFD656DE2EAB5237CB5EFDB452FF4A21F18DD808AC14BEB2D83DF2BB"
       [0 0 :refs] := [["Patient" "0"]]
-      [1 0 0] := #blaze/byte-string"188C7598C8AB1DBDCF94ACD7B60F3E324FBE7535CBB6A56A89C2977F4A30F9CE"
+      [1 0 0] := #blaze/byte-string"3E2D4F15EFD656DE2EAB5237CB5EFDB452FF4A21F18DD808AC14BEB2D83DF2BB"
       [1 0 1] := {:fhir/type :fhir/Observation :id "0"
                   :subject
                   {:fhir/type :fhir/Reference
@@ -42,8 +42,8 @@
       [0 0 :op] := "put"
       [0 0 :type] := "Patient"
       [0 0 :id] := "0"
-      [0 0 :hash] := #blaze/byte-string"6F04185DAEA9350F2E9D1D80DDFCD1890B0DA1300CDD83A3AEAF21D637442E9A"
-      [1 0 0] := #blaze/byte-string"6F04185DAEA9350F2E9D1D80DDFCD1890B0DA1300CDD83A3AEAF21D637442E9A"
+      [0 0 :hash] := #blaze/byte-string"C9ADE22457D5AD750735B6B166E3CE8D6878D09B64C2C2868DCB6DE4C9EFBD4F"
+      [1 0 0] := #blaze/byte-string"C9ADE22457D5AD750735B6B166E3CE8D6878D09B64C2C2868DCB6DE4C9EFBD4F"
       [1 0 1] := {:fhir/type :fhir/Patient :id "0"}))
 
   (testing "one put with matches"

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -12,7 +12,6 @@
     [clojure.lang Keyword]
     [com.google.common.hash PrimitiveSink]
     [java.io Writer]
-    [java.nio.charset StandardCharsets]
     [java.time
      Instant LocalDate LocalDateTime LocalTime OffsetDateTime Year YearMonth
      ZoneOffset]
@@ -940,22 +939,24 @@
   (-value [_])
   (-hash-into [xs sink]
     (.putByte ^PrimitiveSink sink (byte 36))
-    (doseq [x xs]
-      (p/-hash-into x sink)))
+    (reduce (fn [_ x] (p/-hash-into x sink)) nil xs))
   Keyword
   (-type [_])
   (-value [_])
   (-hash-into [k sink]
-    (.putString ^PrimitiveSink sink (name k) StandardCharsets/UTF_8))
+    (.putInt ^PrimitiveSink sink (.hasheq k)))
   Map
   (-type [m]
     (:fhir/type m))
   (-value [_])
   (-hash-into [m sink]
     (.putByte ^PrimitiveSink sink (byte 37))
-    (doseq [[k v] (into (sorted-map) m)]
-      (.putString ^PrimitiveSink sink (name k) StandardCharsets/UTF_8)
-      (p/-hash-into v sink))))
+    (reduce
+      (fn [_ k]
+        (p/-hash-into k sink)
+        (p/-hash-into (k m) sink))
+      nil
+      (sort (keys m)))))
 
 
 

--- a/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
@@ -593,7 +593,7 @@
         (is (= (type/->DateTime nil [string-extension] "2020") extended-date-time)))
       (testing "hash-into"
         (are [u hex] (= hex (murmur3 u))
-          extended-date-time "13a956a8"))
+          extended-date-time "e3246eac"))
       (comment
         (quick-bench extended-date-time)))))
 

--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -264,11 +264,6 @@
                 [::f/type {:value "string"}]
                 [::f/text {:value "foo"}]]]])))))
 
-(comment
-  (s2/form :fhir.xml.Questionnaire/item)
-  (s2/form :fhir.json.Questionnaire/item)
-  )
-
 
 (defn remove-narrative [entry]
   (update entry :resource dissoc :text))
@@ -377,7 +372,42 @@
                 :entry
                 [{:resource
                   {:resourceType "Patient" :id "0"}}]}]
+      (is (= json (fhir-spec/unform-json (fhir-spec/conform-json json))))))
+
+  (testing "Observation with code"
+    (let [json {:resourceType "Observation"
+                :code {:coding [{:system "http://loinc.org" :code "39156-5"}]}}]
       (is (= json (fhir-spec/unform-json (fhir-spec/conform-json json)))))))
+
+
+(deftest unform-cbor-test
+  (testing "Patient with deceasedBoolean"
+    (let [cbor {:resourceType "Patient" :deceasedBoolean true}]
+      (is (= cbor (fhir-spec/unform-cbor (fhir-spec/conform-cbor cbor))))))
+
+  (testing "Patient with deceasedDateTime"
+    (let [cbor {:resourceType "Patient" :deceasedDateTime "2020"}]
+      (is (= cbor (fhir-spec/unform-cbor (fhir-spec/conform-cbor cbor))))))
+
+  (testing "Patient with multipleBirthBoolean"
+    (let [cbor {:resourceType "Patient" :multipleBoolean false}]
+      (is (= cbor (fhir-spec/unform-cbor (fhir-spec/conform-cbor cbor))))))
+
+  (testing "Patient with multipleBirthInteger"
+    (let [cbor {:resourceType "Patient" :multipleBirthInteger 2}]
+      (is (= cbor (fhir-spec/unform-cbor {:fhir/type :fhir/Patient :multipleBirth (int 2)})))))
+
+  (testing "Bundle with Patient"
+    (let [cbor {:resourceType "Bundle"
+                :entry
+                [{:resource
+                  {:resourceType "Patient" :id "0"}}]}]
+      (is (= cbor (fhir-spec/unform-cbor (fhir-spec/conform-cbor cbor))))))
+
+  (testing "Observation with code"
+    (let [cbor {:resourceType "Observation"
+                :code {:coding [{:system "http://loinc.org" :code "39156-5"}]}}]
+      (is (= cbor (fhir-spec/unform-cbor (fhir-spec/conform-cbor cbor)))))))
 
 
 (deftest unform-primitives-test


### PR DESCRIPTION
Hashing a typical Observations shows a 10% runtime speedup. On top of
that, fewer garbage is produced because instead of a new map, only a new
list of keys is produced.