### PR TITLE
Move Back to Upstream Integrant Dependency

### DIFF
--- a/modules/module-base/deps.edn
+++ b/modules/module-base/deps.edn
@@ -9,8 +9,8 @@
   {:mvn/version "5.1.0"}
 
   integrant/integrant
-  {:git/url "https://github.com/alexanderkiel/integrant.git"
-   :sha "c673b85130e553feec6d4c5d2d1ec773a49c929c"}
+  {:git/url "https://github.com/weavejester/integrant.git"
+   :sha "b4f77b0fe9618c5d65bf2cafd27510e8e6ba7cdd"}
 
   io.prometheus/simpleclient
   {:mvn/version "0.9.0"}

--- a/modules/thread-pool-executor-collector/src/blaze/thread_pool_executor_collector.clj
+++ b/modules/thread-pool-executor-collector/src/blaze/thread_pool_executor_collector.clj
@@ -67,11 +67,13 @@
 
 (defmethod ig/init-key :blaze/thread-pool-executor-collector
   [_ {:keys [executors]}]
-  (log/info "Init thread pool executor collector.")
+  (log/info "Init thread pool executor collector")
   (->> executors
        (map
          (fn [[key executor]]
-           [(str (namespace key) "." (name key)) executor]))
+           (let [name (str (namespace key) "." (name key))]
+             (log/debug "Collecting from" name "executor")
+             [name executor])))
        (thread-pool-executor-collector)))
 
 

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -76,6 +76,13 @@
     (log/info "Loaded the following namespaces:" (str/join ", " loaded-ns))))
 
 
+(defrecord RefMap [key]
+  ig/RefLike
+  (ref-key [_] key)
+  (ref-resolve [_ config resolvef]
+    (into {} (map (fn [[k v]] [k (resolvef k v)])) (ig/find-derived config key))))
+
+
 (def ^:private root-config
   {:blaze/version "0.10.3"
 
@@ -112,7 +119,7 @@
     :version (ig/ref :blaze/version)}
 
    :blaze/thread-pool-executor-collector
-   {:executors (ig/refmap :blaze.metrics/thread-pool-executor)}
+   {:executors (->RefMap :blaze.metrics/thread-pool-executor)}
 
    :blaze.metrics/registry
    {:collectors (ig/refset :blaze.metrics/collector)}


### PR DESCRIPTION
With help of the new `ref-resolve` protocol method, I'm able to
implement the RefMap directly in Blaze.