### PR TITLE
Improve Performance of Resource Handle Function

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -84,9 +84,6 @@
     org.clojars.akiel/iota
     {:mvn/version "0.1"}
 
-    org.clojure/data.xml
-    {:mvn/version "0.2.0-alpha6"}
-
     org.clojure/test.check
     {:mvn/version "1.1.0"}
 
@@ -94,6 +91,13 @@
     {:mvn/version "1.1.0"}}
 
    :main-opts ["-m" "kaocha.runner"]}
+
+  :profiling
+  {:extra-paths ["profiling"]
+
+   :extra-deps
+   {org.clojure/tools.namespace
+    {:mvn/version "1.1.0"}}}
 
   :outdated
   {:replace-deps

--- a/modules/db/src/blaze/db/impl/db.clj
+++ b/modules/db/src/blaze/db/impl/db.clj
@@ -2,7 +2,9 @@
   "Primary Database Implementation"
   (:require
     [blaze.db.impl.batch-db :as batch-db]
-    [blaze.db.impl.protocols :as p])
+    [blaze.db.impl.index.resource-as-of :as rao]
+    [blaze.db.impl.protocols :as p]
+    [blaze.db.kv :as kv])
   (:import
     [clojure.lang IReduceInit Sequential Seqable Counted]
     [java.io Writer]))
@@ -49,8 +51,10 @@
   ;; ---- Instance-Level Functions --------------------------------------------
 
   (-resource-handle [_ tid id]
-    (with-open [batch-db (batch-db/new-batch-db node t)]
-      (p/-resource-handle batch-db tid id)))
+    (let [{:keys [kv-store rh-cache]} node]
+      (with-open [snapshot (kv/new-snapshot kv-store)
+                  raoi (kv/new-iterator snapshot :resource-as-of-index)]
+        ((rao/resource-handle rh-cache raoi t) tid id))))
 
 
 

--- a/perf-test/read-tests.sh
+++ b/perf-test/read-tests.sh
@@ -5,10 +5,8 @@ ID_END=3000
 
 
 echo "Patient Read Tests:"
-for (( ID=$ID_START; ID<$ID_END; ID++))
-do
-  cat patient-read.json | \
-  jq -cM --arg id ${ID} '.url += $id'
-done | \
+cat patient-read.json | \
+jq -cM --argjson id_start ${ID_START} --argjson id_end ${ID_END} \
+  '. as $request | range($id_start; $id_end) | tostring as $id | $request | .url += $id' | \
 vegeta attack -rate=3000 -format=json -duration=30s | \
 vegeta report

--- a/profiling/blaze/profiling.clj
+++ b/profiling/blaze/profiling.clj
@@ -1,0 +1,39 @@
+(ns blaze.profiling
+  "Profiling namespace without test dependencies."
+  (:require
+    [blaze.system :as system]
+    [clojure.tools.namespace.repl :refer [refresh]]
+    [taoensso.timbre :as log]))
+
+
+(defonce system nil)
+
+
+(defn init []
+  (alter-var-root #'system (constantly (system/init! (System/getenv))))
+  nil)
+
+
+(defn reset []
+  (some-> system system/shutdown!)
+  (refresh :after `init))
+
+
+;; Init Development
+(comment
+  (init)
+  (pst)
+  )
+
+
+;; Reset after making changes
+(comment
+  (reset)
+  )
+
+
+(comment
+  (log/set-level! :trace)
+  (log/set-level! :debug)
+  (log/set-level! :info)
+  )


### PR DESCRIPTION
Single calls to Db -resource-handle do not open a whole batch-db anymore. Instead the snapshot and ResourceAsOf iterator are opened separately.