### PR TITLE
Bundle Entries of a Page Should be a Vector

### DIFF
--- a/modules/interaction/src/blaze/interaction/search_compartment.clj
+++ b/modules/interaction/src/blaze/interaction/search_compartment.clj
@@ -85,7 +85,7 @@
                    :id (random-uuid)
                    :type #fhir/code"searchset"
                    :total (type/->UnsignedInt (count handles))
-                   :entry (take page-size entries)
+                   :entry (subvec entries 0 (min (count entries) page-size))
                    :link [(self-link context clauses t)]}
 
                   (< page-size (count entries))

--- a/modules/interaction/src/blaze/interaction/search_system.clj
+++ b/modules/interaction/src/blaze/interaction/search_system.clj
@@ -109,7 +109,7 @@
                 {:fhir/type :fhir/Bundle
                  :id (random-uuid)
                  :type #fhir/code"searchset"
-                 :entry (take page-size entries)
+                 :entry (subvec entries 0 (min (count entries) page-size))
                  :link [(self-link context clauses t entries)]}
 
                 total

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -123,7 +123,7 @@
                 {:fhir/type :fhir/Bundle
                  :id (random-uuid)
                  :type #fhir/code"searchset"
-                 :entry (take page-size entries)
+                 :entry (subvec entries 0 (min (count entries) page-size))
                  :link [(self-link context clauses t entries)]}
 
                 total


### PR DESCRIPTION
By using take, bundle entries are a list. By switching to a vector, unforming will be faster. Also subvec is a lot faster, because it doesn't create a new list.