### PR TITLE
Rename CQL Context Unspecified into Unfiltered

### DIFF
--- a/integration-test/arithmetic/query.cql
+++ b/integration-test/arithmetic/query.cql
@@ -1,6 +1,6 @@
 using FHIR version '4.0.0'
 
-context Unspecified
+context Unfiltered
 
 define OnePlusOne: 1 + 1
 define OnePointOnePlusOnePointOne: 1.1 + 1.1

--- a/integration-test/query-3/query.cql
+++ b/integration-test/query-3/query.cql
@@ -13,7 +13,7 @@ define Qualifies:
   exists([Condition: "Seronegative chronische Polyarthritis"] C
           where AgeInYearsAt(C.onset) >= 18)
 
-context Unspecified
+context Unfiltered
 
 define NumberOfPatients:
   Count(Qualifies Q where Q return all Q)

--- a/integration-test/query-5/query.cql
+++ b/integration-test/query-5/query.cql
@@ -14,7 +14,7 @@ define Qualifies:
   exists([Condition: "Speicheldrüsenkrebs"]) or
   exists([Condition: "Thrombotische Mikroangiopathie"])
 
-context Unspecified
+context Unfiltered
 
 define NumberOfPatients:
   Count(Qualifies Q where Q return all Q)

--- a/integration-test/query-6/query.cql
+++ b/integration-test/query-6/query.cql
@@ -12,7 +12,7 @@ context Patient
 define Qualifies:
   exists([Condition: "Brustkrebs"]) and exists([Specimen: "tissue frozen"])
 
-context Unspecified
+context Unfiltered
 
 define NumberOfPatients:
   Count(Qualifies Q where Q return all Q)

--- a/integration-test/query-7/query.cql
+++ b/integration-test/query-7/query.cql
@@ -20,7 +20,7 @@ define Qualifies:
   exists([Specimen: "Gesundes Gewebe"]) and
   (exists([Specimen: "Serum"]) or exists([Specimen: "Vollblut-EDTA"]))
 
-context Unspecified
+context Unfiltered
 
 define NumberOfPatients:
   Count(Qualifies Q where Q return all Q)

--- a/integration-test/readme-example/query.cql
+++ b/integration-test/readme-example/query.cql
@@ -1,7 +1,7 @@
 using FHIR version '4.0.0'
 
 context Patient
-context Unspecified
+context Unfiltered
 
 define NumberOfPatients:
   Count([Patient])

--- a/modules/cql/src/blaze/elm/compiler/external_data.clj
+++ b/modules/cql/src/blaze/elm/compiler/external_data.clj
@@ -158,12 +158,13 @@
     (->WithRelatedContextRetrieveExpression context-expr data-type)))
 
 
-(defn- unspecified-context-expr [node data-type code-property codes]
+(defn- unfiltered-context-expr [node data-type code-property codes]
   (if (empty? codes)
     (reify core/Expression
       (-eval [_ {:keys [db]} _ _]
         (into [] (d/type-list db data-type))))
-    (let [query (d/compile-type-query node data-type [[code-property codes]])]
+    (let [clauses [(cons code-property (map code->clause-value codes))]
+          query (d/compile-type-query node data-type clauses)]
       (if (::anom/category query)
         (throw (ex-info (::anom/message query) query))
         (reify core/Expression
@@ -186,8 +187,8 @@
     context-expr
     (related-context-expr node context-expr data-type code-property codes)
 
-    (= "Unspecified" eval-context)
-    (unspecified-context-expr node data-type code-property codes)
+    (= "Unfiltered" eval-context)
+    (unfiltered-context-expr node data-type code-property codes)
 
     :else
     (expr* node eval-context data-type code-property codes)))

--- a/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
+++ b/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
@@ -47,9 +47,9 @@
   (when name
     (if-let [def (find-expression-def library name)]
       (cond
-        (and (= "Unspecified" eval-context) (not= "Unspecified" def-eval-context))
+        (and (= "Unfiltered" eval-context) (not= "Unfiltered" def-eval-context))
         ;; The referenced expression has a concrete context but we are in the
-        ;; Unspecified context. So we map the referenced expression over all
+        ;; Unfiltered context. So we map the referenced expression over all
         ;; concrete resources.
         (reify core/Expression
           (-eval [_ {:keys [db library-context] :as context} _ _]

--- a/modules/cql/test/blaze/elm/compiler/queries_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/queries_test.clj
@@ -133,7 +133,7 @@
                      :source
                      [{:alias "P"
                        :expression retrieve}]}]
-          (given (core/-eval (c/compile {:node node :eval-context "Unspecified"} query) {:db db} nil nil)
+          (given (core/-eval (c/compile {:node node :eval-context "Unfiltered"} query) {:db db} nil nil)
             [0 fhir-spec/fhir-type] := :fhir/Patient
             [0 :id] := "0"))
 
@@ -142,14 +142,14 @@
                      [{:alias "P"
                        :expression retrieve}]
                      :where where}]
-          (is (empty? (core/-eval (c/compile {:node node :eval-context "Unspecified"} query) {:db db} nil nil))))
+          (is (empty? (core/-eval (c/compile {:node node :eval-context "Unfiltered"} query) {:db db} nil nil))))
 
         (let [query {:type "Query"
                      :source
                      [{:alias "P"
                        :expression retrieve}]
                      :return {:expression return}}]
-          (is (nil? (first (core/-eval (c/compile {:node node :eval-context "Unspecified"} query) {:db db} nil nil)))))
+          (is (nil? (first (core/-eval (c/compile {:node node :eval-context "Unfiltered"} query) {:db db} nil nil)))))
 
         (let [query {:type "Query"
                      :source
@@ -157,7 +157,7 @@
                        :expression retrieve}]
                      :where where
                      :return {:expression return}}]
-          (is (empty? (core/-eval (c/compile {:node node :eval-context "Unspecified"} query) {:db db} nil nil))))))))
+          (is (empty? (core/-eval (c/compile {:node node :eval-context "Unfiltered"} query) {:db db} nil nil))))))))
 
 
 ;; 10.3. AliasRef
@@ -195,7 +195,7 @@
                  :life/scopes #{"O1"}
                  :life/source-type "{http://hl7.org/fhir}Observation"}]}
           compile-context
-          {:node node :life/single-query-scope "O0" :eval-context "Unspecified"}
+          {:node node :life/single-query-scope "O0" :eval-context "Unfiltered"}
           xform-factory (queries/compile-with-equiv-clause compile-context elm)
           eval-context {:db (d/db node)}
           xform (queries/-create xform-factory eval-context nil)
@@ -226,7 +226,7 @@
                  :life/scopes #{"O"}
                  :life/source-type "{http://hl7.org/fhir}Observation"}]}
           compile-context
-          {:node node :life/single-query-scope "P" :eval-context "Unspecified"}
+          {:node node :life/single-query-scope "P" :eval-context "Unfiltered"}
           xform-factory (queries/compile-with-equiv-clause compile-context elm)
           eval-context {:db (d/db node)}
           xform (queries/-create xform-factory eval-context nil)

--- a/modules/cql/test/blaze/elm/compiler/structured_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/structured_values_test.clj
@@ -388,7 +388,7 @@
 
     (testing "Tuple"
       (are [elm result]
-        (= result (core/-eval (c/compile {:eval-context "Unspecified"} elm) {} nil nil))
+        (= result (core/-eval (c/compile {:eval-context "Unfiltered"} elm) {} nil nil))
         {:resultTypeName "{urn:hl7-org:elm-types:r1}Integer"
          :path "id"
          :type "Property"
@@ -408,7 +408,7 @@
     (testing "Quantity"
       (testing "value"
         (are [elm result]
-          (= result (core/-eval (c/compile {:eval-context "Unspecified"} elm) {} nil nil))
+          (= result (core/-eval (c/compile {:eval-context "Unfiltered"} elm) {} nil nil))
           {:resultTypeName "{urn:hl7-org:elm-types:r1}Decimal"
            :path "value"
            :type "Property"
@@ -417,7 +417,7 @@
 
       (testing "unit"
         (are [elm result]
-          (= result (core/-eval (c/compile {:eval-context "Unspecified"} elm) {} nil nil))
+          (= result (core/-eval (c/compile {:eval-context "Unfiltered"} elm) {} nil nil))
           {:resultTypeName "{urn:hl7-org:elm-types:r1}String"
            :path "unit"
            :type "Property"
@@ -426,7 +426,7 @@
 
     (testing "nil"
       (are [elm result]
-        (= result (core/-eval (c/compile {:eval-context "Unspecified"} elm) {} nil nil))
+        (= result (core/-eval (c/compile {:eval-context "Unfiltered"} elm) {} nil nil))
         {:path "value"
          :type "Property"
          :source {:type "Null"}}

--- a/modules/cql/test/blaze/elm/type_infer_test.clj
+++ b/modules/cql/test/blaze/elm/type_infer_test.clj
@@ -60,7 +60,7 @@
 
 ;; 9.2. ExpressionRef
 (deftest infer-types-expression-ref-test
-  (testing "Pointing from Unspecified Context into Patient Context"
+  (testing "Pointing from Unfiltered Context into Patient Context"
     (given-infer-types-with-context
       {:library
        {:statements
@@ -68,18 +68,18 @@
          [{:name "MalePatient"
            :context "Patient"
            :expression {}}]}}
-       :eval-context "Unspecified"}
+       :eval-context "Unfiltered"}
       {:type "ExpressionRef" :name "MalePatient"}
       :life/eval-context := "Patient"))
 
-  (testing "Pointing from Unspecified Context into Unspecified Context"
+  (testing "Pointing from Unfiltered Context into Unfiltered Context"
     (given-infer-types-with-context
       {:library
        {:statements
         {:def
          [{:name "MalePatients"
-           :context "Unspecified"
+           :context "Unfiltered"
            :expression {}}]}}
-       :eval-context "Unspecified"}
+       :eval-context "Unfiltered"}
       {:type "ExpressionRef" :name "MalePatients"}
-      :life/eval-context := "Unspecified")))
+      :life/eval-context := "Unfiltered")))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -144,7 +144,8 @@
     "q18-specimen-bmi" 1
     "q24" 1
     "q28-relationship-procedure-condition" 1
-    "q33-incompatible-quantities" 1)
+    "q33-incompatible-quantities" 1
+    "q34-medication" 1)
 
   (with-redefs [luid (take-from! (new-ids))]
     (let [result (evaluate "q1" "subject-list")]
@@ -300,5 +301,5 @@
 
 (comment
   (log/set-level! :trace)
-  (evaluate "q33-incompatible-quantities")
+  (evaluate "q34-medication")
   )

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q34-medication-data.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q34-medication-data.json
@@ -1,0 +1,111 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "0"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "1"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "0",
+        "medicationReference": {
+          "reference": "Medication/0"
+        },
+        "subject": {
+          "reference": "Patient/0"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationStatement/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Medication",
+        "id": "0",
+        "code": {
+          "coding": [
+            {
+              "system": "http://fhir.de/CodeSystem/dimdi/atc",
+              "code": "L01AX03"
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Medication/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Measure",
+        "id": "0",
+        "url": "0",
+        "status": "active",
+        "subjectCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/resource-types",
+              "code": "Patient"
+            }
+          ]
+        },
+        "library": [
+          "0"
+        ],
+        "scoring": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+              "code": "cohort"
+            }
+          ]
+        },
+        "group": [
+          {
+            "population": [
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "initial-population"
+                    }
+                  ]
+                },
+                "criteria": {
+                  "language": "text/cql",
+                  "expression": "InInitialPopulation"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Measure/0"
+      }
+    }
+  ]
+}

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q34-medication-query.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q34-medication-query.cql
@@ -1,0 +1,17 @@
+library Retrieve
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+codesystem atc: 'http://fhir.de/CodeSystem/dimdi/atc'
+
+context Unfiltered
+
+define "Temozolomid Ref":
+  'Medication/' + singleton from (
+    [Medication: Code 'L01AX03' from atc] M return FHIRHelpers.ToString(M.id))
+
+context Patient
+
+define InInitialPopulation:
+  exists(from [MedicationStatement] M
+    where (M.medication as Reference).reference = "Temozolomid Ref")


### PR DESCRIPTION
The new name for the context operating on the whole database is called
Unfiltered.

Closes #317