### PR TITLE
Fix JSON Generation of Instant Values

### DIFF
--- a/modules/db/src/blaze/db/tx_log/local.clj
+++ b/modules/db/src/blaze/db/tx_log/local.clj
@@ -20,7 +20,6 @@
     [blaze.executors :as ex]
     [blaze.module :refer [reg-collector]]
     [cheshire.core :as cheshire]
-    [cheshire.generate :refer [JSONable]]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
     [java-time :as jt]
@@ -30,8 +29,7 @@
     [java.io Closeable]
     [java.time Clock Instant]
     [java.util.concurrent
-     ArrayBlockingQueue BlockingQueue ExecutorService TimeUnit]
-    [com.fasterxml.jackson.core JsonGenerator]))
+     ArrayBlockingQueue BlockingQueue ExecutorService TimeUnit]))
 
 
 (set! *warn-on-reflection* true)
@@ -44,12 +42,6 @@
    :name "tx_log_duration_seconds"}
   (take 16 (iterate #(* 2 %) 0.00001))
   "op")
-
-
-(extend-protocol JSONable
-  Instant
-  (to-json [instant jg]
-    (.writeNumber ^JsonGenerator jg (.toEpochMilli instant))))
 
 
 (defn- parse-cbor [value t]
@@ -90,7 +82,7 @@
 
 (defn encode-tx-data [instant tx-cmds]
   (cheshire/generate-cbor
-    {:instant instant
+    {:instant (.toEpochMilli ^Instant instant)
      :tx-cmds tx-cmds}))
 
 

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -28,7 +28,8 @@
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :error (f))
+  (log/set-level! :trace)
+  (f)
   (st/unstrument))
 
 


### PR DESCRIPTION
I extended the JSONable protocol of cheshire at two places, once in
blaze.db.tx-log.local and once in blaze.fhir.spec.type. In
blaze.db.tx-log.local, I generated a number of the epoch seconds, were
in blaze.fhir.spec.type I called .toString.

I have decided to skip using JSONable in blaze.db.tx-log.local, because
there, I use an instant only once.

This case was not found by unit tests, because I do not load the
namespace blaze.db.tx-log.local in tests generating JSON from resources.
Instead it was detected by Touchstone.