### PR TITLE
Use LUID's instead of Random UUID's

### DIFF
--- a/modules/interaction/src/blaze/interaction/history/instance.clj
+++ b/modules/interaction/src/blaze/interaction/history/instance.clj
@@ -10,8 +10,8 @@
     [blaze.handler.fhir.util :as fhir-util]
     [blaze.handler.util :as handler-util]
     [blaze.interaction.history.util :as history-util]
+    [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]
     [integrant.core :as ig]
@@ -41,7 +41,7 @@
             (ring/response
               (cond->
                 {:fhir/type :fhir/Bundle
-                 :id (random-uuid)
+                 :id (luid/luid)
                  :type #fhir/code"history"
                  :total (type/->UnsignedInt total)
                  :link []

--- a/modules/interaction/src/blaze/interaction/history/system.clj
+++ b/modules/interaction/src/blaze/interaction/history/system.clj
@@ -11,8 +11,8 @@
     [blaze.handler.fhir.util :as fhir-util]
     [blaze.handler.util :as handler-util]
     [blaze.interaction.history.util :as history-util]
+    [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
     [reitit.core :as reitit]
@@ -47,7 +47,7 @@
             (ring/response
               (cond->
                 {:fhir/type :fhir/Bundle
-                 :id (random-uuid)
+                 :id (luid/luid)
                  :type #fhir/code"history"
                  :total (type/->UnsignedInt total)
                  :entry (mapv #(history-util/build-entry router %) pages-versions)}

--- a/modules/interaction/src/blaze/interaction/history/type.clj
+++ b/modules/interaction/src/blaze/interaction/history/type.clj
@@ -10,8 +10,8 @@
     [blaze.handler.fhir.util :as fhir-util]
     [blaze.handler.util :as handler-util]
     [blaze.interaction.history.util :as history-util]
+    [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
     [reitit.core :as reitit]
@@ -38,7 +38,7 @@
             (ring/response
               (cond->
                 {:fhir/type :fhir/Bundle
-                 :id (random-uuid)
+                 :id (luid/luid)
                  :type #fhir/code"history"
                  :total (type/->UnsignedInt total)
                  :entry (mapv #(history-util/build-entry router %) paged-versions)}

--- a/modules/interaction/src/blaze/interaction/search_compartment.clj
+++ b/modules/interaction/src/blaze/interaction/search_compartment.clj
@@ -10,8 +10,8 @@
     [blaze.interaction.search.nav :as nav]
     [blaze.interaction.search.params :as params]
     [blaze.interaction.search.util :as search-util]
+    [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]
     [integrant.core :as ig]
@@ -82,7 +82,7 @@
               (let [entries (entries context resources)]
                 (cond->
                   {:fhir/type :fhir/Bundle
-                   :id (random-uuid)
+                   :id (luid/luid)
                    :type #fhir/code"searchset"
                    :total (type/->UnsignedInt (count handles))
                    :entry (subvec entries 0 (min (count entries) page-size))
@@ -101,7 +101,7 @@
       (ac/failed-future (ex-anom handles-and-clauses))
       (ac/completed-future
         {:fhir/type :fhir/Bundle
-         :id (random-uuid)
+         :id (luid/luid)
          :type #fhir/code"searchset"
          :total (type/->UnsignedInt (count handles))
          :link [(self-link context clauses t)]}))))

--- a/modules/interaction/src/blaze/interaction/search_system.clj
+++ b/modules/interaction/src/blaze/interaction/search_system.clj
@@ -13,8 +13,8 @@
     [blaze.interaction.search.nav :as nav]
     [blaze.interaction.search.params :as params]
     [blaze.interaction.search.util :as search-util]
+    [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]
     [integrant.core :as ig]
@@ -107,7 +107,7 @@
                   total (total db params entries)]
               (cond->
                 {:fhir/type :fhir/Bundle
-                 :id (random-uuid)
+                 :id (luid/luid)
                  :type #fhir/code"searchset"
                  :entry (subvec entries 0 (min (count entries) page-size))
                  :link [(self-link context clauses t entries)]}
@@ -146,7 +146,7 @@
       (ac/failed-future (ex-anom summary-total))
       (ac/completed-future
         {:fhir/type :fhir/Bundle
-         :id (random-uuid)
+         :id (luid/luid)
          :type #fhir/code"searchset"
          :total (type/->UnsignedInt total)
          :link [(self-link context clauses t [])]}))))

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -13,8 +13,8 @@
     [blaze.interaction.search.nav :as nav]
     [blaze.interaction.search.params :as params]
     [blaze.interaction.search.util :as search-util]
+    [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]
     [integrant.core :as ig]
@@ -121,7 +121,7 @@
                   total (total db type params entries)]
               (cond->
                 {:fhir/type :fhir/Bundle
-                 :id (random-uuid)
+                 :id (luid/luid)
                  :type #fhir/code"searchset"
                  :entry (subvec entries 0 (min (count entries) page-size))
                  :link [(self-link context clauses t entries)]}
@@ -159,7 +159,7 @@
       (ac/failed-future (ex-anom summary-total))
       (ac/completed-future
         {:fhir/type :fhir/Bundle
-         :id (random-uuid)
+         :id (luid/luid)
          :type #fhir/code"searchset"
          :total (type/->UnsignedInt total)
          :link [(self-link context clauses t [])]}))))

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -15,7 +15,6 @@
     [blaze.interaction.transaction.spec]
     [blaze.luid :as luid]
     [blaze.middleware.fhir.metrics :refer [wrap-observe-request-duration]]
-    [blaze.uuid :refer [random-uuid]]
     [clojure.spec.alpha :as s]
     [clojure.string :as str]
     [cognitect.anomalies :as anom]
@@ -404,7 +403,7 @@
           (fn [response-entries]
             (ring/response
               {:fhir/type :fhir/Bundle
-               :id (random-uuid)
+               :id (luid/luid)
                :type (type/->Code (str (type/value type) "-response"))
                :entry response-entries})))
         (ac/exceptionally handler-util/error-response))))

--- a/modules/module-base/src/blaze/uuid.clj
+++ b/modules/module-base/src/blaze/uuid.clj
@@ -1,9 +1,0 @@
-(ns blaze.uuid
-  (:import
-    [java.util UUID]))
-
-
-(defn random-uuid
-  "Creates a random UUID string."
-  []
-  (str (UUID/randomUUID)))


### PR DESCRIPTION
Random UUID's are expensive to create. LUID's are much faster. The lower
entropy of 36 bit is not a problem, because not more than one bundle
should be generated for each client per millisecond.