### PR TITLE
Create Instance and Versioned URLs by Hand

### DIFF
--- a/modules/interaction/test/blaze/interaction/create_test.clj
+++ b/modules/interaction/test/blaze/interaction/create_test.clj
@@ -22,11 +22,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -38,8 +39,7 @@
 
 (def router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]
-     ["/Patient/{id}/_history/{vid}" {:name :Patient/versioned-instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/delete_test.clj
+++ b/modules/interaction/test/blaze/interaction/delete_test.clj
@@ -16,11 +16,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 

--- a/modules/interaction/test/blaze/interaction/history/instance_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/instance_test.clj
@@ -20,11 +20,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -33,7 +34,7 @@
 
 (def router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/history/system_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/system_test.clj
@@ -20,11 +20,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -33,7 +34,7 @@
 
 (def router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/history/type_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/type_test.clj
@@ -20,11 +20,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -33,7 +34,7 @@
 
 (def router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/history/util_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_test.clj
@@ -10,6 +10,9 @@
     [java.time Instant]))
 
 
+(st/instrument)
+
+
 (defn fixture [f]
   (st/instrument)
   (f)

--- a/modules/interaction/test/blaze/interaction/read_test.clj
+++ b/modules/interaction/test/blaze/interaction/read_test.clj
@@ -19,11 +19,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 

--- a/modules/interaction/test/blaze/interaction/search_compartment_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_compartment_test.clj
@@ -16,11 +16,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -30,7 +31,7 @@
 (def router
   (reitit/router
     [["/Patient/{id}/{type}" {:name :Patient/compartment}]
-     ["/Observation/{id}" {:name :Observation/instance}]]
+     ["/Observation" {:name :Observation/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/search_system_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_system_test.clj
@@ -17,11 +17,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -30,7 +31,7 @@
 
 (def ^:private router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -18,11 +18,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -31,11 +32,11 @@
 
 (def ^:private router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]
-     ["/MeasureReport/{id}" {:name :MeasureReport/instance}]
-     ["/Library/{id}" {:name :Library/instance}]
-     ["/List/{id}" {:name :List/instance}]
-     ["/Condition/{id}" {:name :Condition/instance}]]
+    [["/Patient" {:name :Patient/type}]
+     ["/MeasureReport" {:name :MeasureReport/type}]
+     ["/Library" {:name :Library/type}]
+     ["/List" {:name :List/type}]
+     ["/Condition" {:name :Condition/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -30,11 +30,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 

--- a/modules/interaction/test/blaze/interaction/update_test.clj
+++ b/modules/interaction/test/blaze/interaction/update_test.clj
@@ -22,11 +22,11 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/set-level! :trace)
   (f)
   (st/unstrument))
 
@@ -53,8 +53,7 @@
 
 (def ^:private router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]
-     ["/Patient/{id}/_history/{vid}" {:name :Patient/versioned-instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/handler/impl_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/handler/impl_test.clj
@@ -15,9 +15,13 @@
     [java.time Clock Instant Year ZoneOffset]))
 
 
+(st/instrument)
+(log/set-level! :trace)
+
+
 (defn- fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -29,8 +33,7 @@
 
 (def router
   (reitit/router
-    [["/Patient/{id}" {:name :Patient/instance}]
-     ["/MeasureReport/{id}/_history/{vid}" {:name :MeasureReport/versioned-instance}]]
+    [["/MeasureReport" {:name :MeasureReport/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/rest-util/src/blaze/handler/fhir/util.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util.clj
@@ -82,19 +82,18 @@
 (defn instance-url
   "Returns the URL of a instance (resource) like `[base]/[type]/[id]`."
   [router type id]
-  (let [{:keys [path] {:blaze/keys [base-url]} :data}
-        (reitit/match-by-name router (keyword type "instance") {:id id})]
-    (str base-url path)))
+  ;; URL's are build by hand here, because id's do not need to be URL encoded
+  ;; and the URL encoding in reitit is slow: https://github.com/metosin/reitit/issues/477
+  (str (type-url router type) "/" id))
 
 
 (defn versioned-instance-url
   "Returns the URL of a versioned instance (resource) like
   `[base]/[type]/[id]/_history/[vid]`."
   [router type id vid]
-  (let [{:keys [path] {:blaze/keys [base-url]} :data}
-        (reitit/match-by-name
-          router (keyword type "versioned-instance") {:id id :vid vid})]
-    (str base-url path)))
+  ;; URL's are build by hand here, because id's do not need to be URL encoded
+  ;; and the URL encoding in reitit is slow: https://github.com/metosin/reitit/issues/477
+  (str (instance-url router type id) "/_history/" vid))
 
 
 (defn etag->t [etag]

--- a/modules/rest-util/test/blaze/fhir/response/create_test.clj
+++ b/modules/rest-util/test/blaze/fhir/response/create_test.clj
@@ -9,9 +9,13 @@
     [taoensso.timbre :as log]))
 
 
+(st/instrument)
+(log/set-level! :trace)
+
+
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -20,7 +24,7 @@
 
 (def router
   (reitit/router
-    [["/Patient/{id}/_history/{vid}" {:name :Patient/versioned-instance}]]
+    [["/Patient" {:name :Patient/type}]]
     {:syntax :bracket}))
 
 

--- a/modules/rest-util/test/blaze/handler/fhir/util_test.clj
+++ b/modules/rest-util/test/blaze/handler/fhir/util_test.clj
@@ -128,7 +128,7 @@
       {:blaze/base-url "base-url"}
       ["/Patient" {:name :Patient/type}]
       ["/Patient/{id}" {:name :Patient/instance}]
-      ["/Patient/{id}/{vid}" {:name :Patient/versioned-instance}]]]
+      ["/Patient/{id}/_history/{vid}" {:name :Patient/versioned-instance}]]]
     {:syntax :bracket}))
 
 
@@ -141,7 +141,7 @@
 
 
 (deftest versioned-instance-url
-  (is (= "base-url/Patient/0/1"
+  (is (= "base-url/Patient/0/_history/1"
          (fhir-util/versioned-instance-url router "Patient" "0" "1"))))
 
 


### PR DESCRIPTION
I used reitit to generate the type, instance and versioned instance URL.
However reitit is very slow at encoding path parameters. because FHIR
ID's and our VID's are already URL safe, encoding isn't necessary. Also
the URL schema is fixed, so a decided to simply create them by hand. We
could revert to the old model if
https://github.com/metosin/reitit/issues/477 is solved.