### PR TITLE
Implement a Transaction Cache

### DIFF
--- a/dev/blaze/dev.clj
+++ b/dev/blaze/dev.clj
@@ -63,6 +63,12 @@
   (.invalidateAll ^Cache (:blaze.db/resource-handle-cache system))
   )
 
+;; Transaction Cache
+(comment
+  (str (cc/-stats (:blaze.db/tx-cache system)))
+  (resource-cache/invalidate-all! (:blaze.db/tx-cache system))
+  )
+
 ;; Resource Cache
 (comment
   (str (cc/-stats (:blaze.db/resource-cache system)))
@@ -83,7 +89,7 @@
 
   (.hash (d/resource-handle db "Patient" "01f5d727-e75c-4662-aecd-df2ffccd2e27"))
 
-  @(blaze.db.node/load-tx-result node (:kv-store node) 21228)
+  @(blaze.db.node/load-tx-result node 21228)
 
   )
 

--- a/modules/db/src/blaze/db/resource_handle_cache.clj
+++ b/modules/db/src/blaze/db/resource_handle_cache.clj
@@ -4,8 +4,7 @@
   Caffeine is used because it have better performance characteristics as a
   ConcurrentHashMap."
   (:require
-    [blaze.db.resource-cache.spec]
-    [blaze.db.resource-store.spec]
+    [blaze.db.resource-handle-cache.spec]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
     [taoensso.timbre :as log])

--- a/modules/db/src/blaze/db/resource_handle_cache/spec.clj
+++ b/modules/db/src/blaze/db/resource_handle_cache/spec.clj
@@ -1,0 +1,7 @@
+(ns blaze.db.resource-handle-cache.spec
+  (:require
+    [clojure.spec.alpha :as s]))
+
+
+(s/def :blaze.db.resource-handle-cache/max-size
+  nat-int?)

--- a/modules/db/src/blaze/db/spec.clj
+++ b/modules/db/src/blaze/db/spec.clj
@@ -6,19 +6,23 @@
     [blaze.db.tx-log.spec]
     [clojure.spec.alpha :as s])
   (:import
-    [com.github.benmanes.caffeine.cache Cache]))
+    [com.github.benmanes.caffeine.cache Cache LoadingCache]))
 
 
 (s/def :blaze.db/node
   #(satisfies? p/Node %))
 
 
-(s/def :blaze.db/resource-cache
-  :blaze.db/resource-store)
-
-
 (s/def :blaze.db/resource-handle-cache
   #(instance? Cache %))
+
+
+(s/def :blaze.db/tx-cache
+  #(instance? LoadingCache %))
+
+
+(s/def :blaze.db/resource-cache
+  :blaze.db/resource-store)
 
 
 (s/def :blaze.db/op

--- a/modules/db/src/blaze/db/tx_cache.clj
+++ b/modules/db/src/blaze/db/tx_cache.clj
@@ -1,0 +1,36 @@
+(ns blaze.db.tx-cache
+  "A cache for transactions.
+
+  Caffeine is used because it have better performance characteristics as a
+  ConcurrentHashMap."
+  (:require
+    [blaze.db.impl.index.tx-success :as tsi]
+    [blaze.db.kv.spec]
+    [blaze.db.tx-cache.spec]
+    [clojure.spec.alpha :as s]
+    [integrant.core :as ig]
+    [taoensso.timbre :as log])
+  (:import
+    [com.github.benmanes.caffeine.cache Caffeine]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn- new-tx-cache
+  "Creates a new transaction cache."
+  [kv-store max-size]
+  (-> (Caffeine/newBuilder)
+      (.maximumSize max-size)
+      (.recordStats)
+      (.build (tsi/cache-loader kv-store))))
+
+
+(defmethod ig/pre-init-spec :blaze.db/tx-cache [_]
+  (s/keys :req-un [:blaze.db/kv-store] :opt-un [::max-size]))
+
+
+(defmethod ig/init-key :blaze.db/tx-cache
+  [_ {:keys [kv-store max-size] :or {max-size 0}}]
+  (log/info "Create transaction cache with a size of" max-size "transactions")
+  (new-tx-cache kv-store max-size))

--- a/modules/db/src/blaze/db/tx_cache/spec.clj
+++ b/modules/db/src/blaze/db/tx_cache/spec.clj
@@ -1,0 +1,7 @@
+(ns blaze.db.tx-cache.spec
+  (:require
+    [clojure.spec.alpha :as s]))
+
+
+(s/def :blaze.db.tx-cache/max-size
+  nat-int?)

--- a/modules/db/test-perf/blaze/db/api_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/api_test_perf.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :refer [ex-anom]]
     [blaze.db.api :as d]
+    [blaze.db.impl.index.tx-success :as tsi]
     [blaze.db.kv.mem :refer [new-mem-kv-store]]
     [blaze.db.node :as node]
     [blaze.db.resource-store.kv :refer [new-kv-resource-store]]
@@ -57,11 +58,16 @@
 (def clock (Clock/fixed Instant/EPOCH (ZoneId/of "UTC")))
 
 
+(defn- tx-cache [index-kv-store]
+  (.build (Caffeine/newBuilder) (tsi/cache-loader index-kv-store)))
+
+
 (defn new-node []
   (let [tx-log (new-local-tx-log (new-mem-kv-store) clock local-tx-log-executor)
-        resource-handle-cache (.build (Caffeine/newBuilder))]
-    (node/new-node tx-log resource-handle-cache resource-indexer-executor 1
-                   indexer-executor (new-index-kv-store)
+        resource-handle-cache (.build (Caffeine/newBuilder))
+        index-kv-store (new-index-kv-store)]
+    (node/new-node tx-log resource-handle-cache (tx-cache index-kv-store)
+                   resource-indexer-executor 1 indexer-executor index-kv-store
                    (new-kv-resource-store (new-mem-kv-store))
                    search-param-registry (jt/millis 10))))
 

--- a/modules/db/test/blaze/db/impl/index/tx_success_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/tx_success_spec.clj
@@ -8,7 +8,7 @@
 
 
 (s/fdef tsi/tx
-  :args (s/cat :kv-store :blaze.db/kv-store :t :blaze.db/t)
+  :args (s/cat :tx-cache :blaze.db/tx-cache :t :blaze.db/t)
   :ret (s/nilable :blaze.db/tx))
 
 

--- a/modules/db/test/blaze/db/impl/index/tx_success_test.clj
+++ b/modules/db/test/blaze/db/impl/index/tx_success_test.clj
@@ -9,6 +9,7 @@
     [clojure.test :as test :refer [deftest is testing]]
     [juxt.iota :refer [given]])
   (:import
+    [com.github.benmanes.caffeine.cache Caffeine]
     [java.time Instant]))
 
 
@@ -29,39 +30,40 @@
     {:tx-success-index {:reverse-comparator? true}}))
 
 
-(defn- new-mem-kv-store-with [entries]
-  (let [kv-store (new-mem-kv-store)]
+(defn- new-mem-kv-store-and-cache-with [entries]
+  (let [kv-store (new-mem-kv-store)
+        cache (.build (Caffeine/newBuilder) (tsi/cache-loader kv-store))]
     (kv/put! kv-store entries)
-    kv-store))
+    [kv-store cache]))
 
 
 (deftest tx-test
   (testing "finds the transaction"
-    (let [kv-store (new-mem-kv-store-with
-                     [(tsi/index-entry 1 Instant/EPOCH)])]
-      (given (tsi/tx kv-store 1)
+    (let [[_ cache] (new-mem-kv-store-and-cache-with
+                      [(tsi/index-entry 1 Instant/EPOCH)])]
+      (given (tsi/tx cache 1)
         :blaze.db/t := 1
         :blaze.db.tx/instant := Instant/EPOCH)))
 
   (testing "doesn't find a non-existing transaction"
-    (let [kv-store (new-mem-kv-store-with
-                     [(tsi/index-entry 1 Instant/EPOCH)])]
-      (is (nil? (tsi/tx kv-store 2)))))
+    (let [[_ cache] (new-mem-kv-store-and-cache-with
+                      [(tsi/index-entry 1 Instant/EPOCH)])]
+      (is (nil? (tsi/tx cache 2)))))
 
   (testing "nothing is found on empty db"
-    (let [kv-store (new-mem-kv-store)]
-      (is (nil? (tsi/tx kv-store 1))))))
+    (let [[_ cache] (new-mem-kv-store-and-cache-with [])]
+      (is (nil? (tsi/tx cache 1))))))
 
 
 (deftest last-t-test
   (testing "finds the transaction"
-    (let [kv-store (new-mem-kv-store-with
-                     [(tsi/index-entry 1 Instant/EPOCH)
-                      (tsi/index-entry 2 (.plusMillis Instant/EPOCH 1))])]
+    (let [[kv-store] (new-mem-kv-store-and-cache-with
+                       [(tsi/index-entry 1 Instant/EPOCH)
+                        (tsi/index-entry 2 (.plusMillis Instant/EPOCH 1))])]
       (is (= 2 (tsi/last-t kv-store)))))
 
   (testing "is nil on empty db"
-    (let [kv-store (new-mem-kv-store)]
+    (let [[kv-store] (new-mem-kv-store-and-cache-with [])]
       (is (nil? (tsi/last-t kv-store))))))
 
 

--- a/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
+++ b/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
@@ -6,6 +6,7 @@
     [blaze.db.impl.index.rts-as-of :as rts]
     [blaze.db.impl.index.system-as-of :as sao]
     [blaze.db.impl.index.system-stats :as system-stats]
+    [blaze.db.impl.index.tx-success :as tsi]
     [blaze.db.impl.index.type-as-of :as tao]
     [blaze.db.impl.index.type-stats :as type-stats]
     [blaze.db.kv.mem :refer [new-mem-kv-store]]
@@ -79,11 +80,16 @@
 (def clock (Clock/fixed Instant/EPOCH (ZoneId/of "UTC")))
 
 
+(defn- tx-cache [index-kv-store]
+  (.build (Caffeine/newBuilder) (tsi/cache-loader index-kv-store)))
+
+
 (defn new-node []
   (let [tx-log (new-local-tx-log (new-mem-kv-store) clock local-tx-log-executor)
-        resource-handle-cache (.build (Caffeine/newBuilder))]
-    (node/new-node tx-log resource-handle-cache resource-indexer-executor 1
-                   indexer-executor (new-index-kv-store)
+        resource-handle-cache (.build (Caffeine/newBuilder))
+        index-kv-store (new-index-kv-store)]
+    (node/new-node tx-log resource-handle-cache (tx-cache index-kv-store)
+                   resource-indexer-executor 1 indexer-executor index-kv-store
                    (new-kv-resource-store (new-mem-kv-store))
                    search-param-registry (jt/millis 10))))
 

--- a/modules/db/test/blaze/db/node_spec.clj
+++ b/modules/db/test/blaze/db/node_spec.clj
@@ -20,6 +20,7 @@
 (s/fdef node/new-node
   :args (s/cat :tx-log :blaze.db/tx-log
                :resource-handle-cache :blaze.db/resource-handle-cache
+               :tx-cache :blaze.db/tx-cache
                :resource-indexer-executor ::node/resource-indexer-executor
                :resource-indexer-batch-size ::node/resource-indexer-batch-size
                :indexer-executor ::node/indexer-executor

--- a/modules/db/test/blaze/db/resource_handle_cache_test.clj
+++ b/modules/db/test/blaze/db/resource_handle_cache_test.clj
@@ -1,8 +1,10 @@
 (ns blaze.db.resource-handle-cache-test
   (:require
     [blaze.db.resource-handle-cache]
+    [blaze.db.test-util :refer [given-thrown]]
+    [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [deftest is]]
+    [clojure.test :as test :refer [deftest is testing]]
     [integrant.core :as ig]
     [taoensso.timbre :as log])
   (:import
@@ -10,11 +12,12 @@
 
 
 (st/instrument)
+(log/set-level! :trace)
 
 
 (defn fixture [f]
   (st/instrument)
-  (log/with-level :trace (f))
+  (f)
   (st/unstrument))
 
 
@@ -29,4 +32,11 @@
 
 
 (deftest init-test
-  (is (instance? Cache (cache 0))))
+  (testing "invalid max-size"
+    (given-thrown (cache nil)
+      :key := :blaze.db/resource-handle-cache
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `nat-int?))
+
+  (testing "success"
+    (is (instance? Cache (cache 0)))))

--- a/modules/db/test/blaze/db/test_util.clj
+++ b/modules/db/test/blaze/db/test_util.clj
@@ -1,0 +1,8 @@
+(ns blaze.db.test-util
+  (:require
+    [juxt.iota :refer [given]]))
+
+
+(defmacro given-thrown [v & body]
+  `(given (try ~v (catch Exception e# (ex-data e#)))
+     ~@body))

--- a/modules/db/test/blaze/db/tx_cache_test.clj
+++ b/modules/db/test/blaze/db/tx_cache_test.clj
@@ -1,0 +1,59 @@
+(ns blaze.db.tx-cache-test
+  (:require
+    [blaze.db.kv :as kv]
+    [blaze.db.kv.mem :refer [new-mem-kv-store]]
+    [blaze.db.test-util :refer [given-thrown]]
+    [blaze.db.tx-cache]
+    [clojure.spec.alpha :as s]
+    [clojure.spec.test.alpha :as st]
+    [clojure.test :as test :refer [deftest is testing]]
+    [integrant.core :as ig]
+    [taoensso.timbre :as log])
+  (:import
+    [com.github.benmanes.caffeine.cache LoadingCache]))
+
+
+(st/instrument)
+(log/set-level! :trace)
+
+
+(defn fixture [f]
+  (st/instrument)
+  (f)
+  (st/unstrument))
+
+
+(test/use-fixtures :each fixture)
+
+
+(defn- cache [kv-store max-size]
+  (-> (ig/init
+        {:blaze.db/tx-cache
+         {:kv-store kv-store
+          :max-size max-size}})
+      (:blaze.db/tx-cache)))
+
+
+(deftest failing-init-test
+  (testing "missing store"
+    (given-thrown (ig/init {:blaze.db/tx-cache {}})
+      :key := :blaze.db/tx-cache
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :kv-store))))
+
+  (testing "invalid store"
+    (given-thrown (ig/init {:blaze.db/tx-cache {:kv-store nil}})
+      :key := :blaze.db/tx-cache
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `(fn [~'%] (satisfies? kv/KvStore ~'%))))
+
+  (testing "invalid max-size"
+    (given-thrown (ig/init {:blaze.db/tx-cache {:kv-store (new-mem-kv-store) :max-size nil}})
+      :key := :blaze.db/tx-cache
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `nat-int?)))
+
+
+(deftest empty-store-test
+  (let [^LoadingCache cache (cache (new-mem-kv-store) 0)]
+    (is (nil? (.get cache 0)))))

--- a/profiling/blaze/profiling.clj
+++ b/profiling/blaze/profiling.clj
@@ -47,6 +47,12 @@
   (.invalidateAll ^Cache (:blaze.db/resource-handle-cache system))
   )
 
+;; Transaction Cache
+(comment
+  (str (cc/-stats (:blaze.db/tx-cache system)))
+  (resource-cache/invalidate-all! (:blaze.db/tx-cache system))
+  )
+
 ;; Resource Cache
 (comment
   (str (cc/-stats (:blaze.db/resource-cache system)))

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -160,6 +160,7 @@
   :blaze.db/node
   {:tx-log #blaze/ref :blaze.db/tx-log
    :resource-handle-cache #blaze/ref :blaze.db/resource-handle-cache
+   :tx-cache #blaze/ref :blaze.db/tx-cache
    :resource-indexer-executor #blaze/ref :blaze.db.node/resource-indexer-executor
    :resource-indexer-batch-size #blaze/cfg ["DB_RESOURCE_INDEXER_BATCH_SIZE" int? 1]
    :indexer-executor #blaze/ref :blaze.db.node/indexer-executor
@@ -180,6 +181,7 @@
   :blaze.db/cache-collector
   {:caches
    {"resource-handle-cache" #blaze/ref :blaze.db/resource-handle-cache
+    "tx-cache" #blaze/ref :blaze.db/tx-cache
     "resource-cache" #blaze/ref :blaze.db/resource-cache}}
 
   ;;
@@ -195,6 +197,17 @@
   ;;
   :blaze.db/resource-handle-cache
   {:max-size #blaze/cfg ["DB_RESOURCE_HANDLE_CACHE_SIZE" nat-int? 100000]}
+
+  ;;
+  ;; Transaction Cache
+  ;;
+  ;; The transaction cache holds transaction data that currently only consists
+  ;; of the instant at which the transaction happened. Transaction data is keyed
+  ;; by t.
+  ;;
+  :blaze.db/tx-cache
+  {:kv-store #blaze/ref :blaze.db/index-kv-store
+   :max-size #blaze/cfg ["DB_TRANSACTION_CACHE_SIZE" nat-int? 100000]}
 
   ;;
   ;; Resource Cache


### PR DESCRIPTION
The transaction cache holds transaction data that currently only
consists of the instant at which the transaction happened. Transaction
data is keyed by t.