### PR TITLE
Fix Cassandra Key Serialization

### DIFF
--- a/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
+++ b/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :refer [ex-anom]]
     [blaze.async.comp :as ac]
+    [blaze.byte-string :as bs]
     [blaze.db.resource-store :as rs]
     [blaze.db.resource-store.cassandra.spec]
     [blaze.fhir.spec :as fhir-spec]
@@ -80,7 +81,7 @@
 
 
 (defn- bind-get [^PreparedStatement statement hash]
-  (.bind statement (object-array [(str hash)])))
+  (.bind statement (object-array [(bs/hex hash)])))
 
 
 (defn- execute [^CqlSession session op ^Statement statement]
@@ -132,7 +133,7 @@
 (defn- bind-put [^PreparedStatement statement hash resource]
   (let [content (ByteBuffer/wrap (fhir-spec/unform-cbor resource))]
     (prom/observe! resource-bytes (.capacity content))
-    (.bind statement (object-array [(str hash) content]))))
+    (.bind statement (object-array [(bs/hex hash) content]))))
 
 
 (defn- execute-put [session statement [hash resource]]


### PR DESCRIPTION
At the migration of the hash from Guava HashCode to byte strings in #271, I forgot to use bs/hex instead of str to create a hexadecimal representation of the hashes.