### PR TITLE
Move Build Out of Docker Build Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,2 @@
 *
-!modules
-!resources
-!src
-!Dockerfile
-!deps.edn
-!pom.xml
+!target

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,8 +184,29 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '11'
+
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@master
+      with:
+        tools-deps: '1.10.3.822'
+
+    - name: Cache Local Maven Repo
+      uses: actions/cache@v2.1.5
+      with:
+        path: |
+          ~/.m2/repository
+        key: ${{ runner.os }}-maven-repo-build
+
     - name: Check out Git repository
       uses: actions/checkout@v2
+
+    - name: Build Uberjar
+      run: make uberjar
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -200,9 +221,16 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.CR_PAT }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
+        context: .
         push: true
         tags: ghcr.io/samply/blaze:${{ github.sha }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 /nginx.conf
 .cpcache
 .cache
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,18 @@
-FROM clojure:openjdk-11-tools-deps-1.10.1.727 as build
-
-COPY . /build/
-
-WORKDIR /build
-RUN clojure -X:depstar uberjar :jar target/blaze-standalone.jar
+FROM busybox as build
 
 RUN mkdir -p /app/data
 
 FROM gcr.io/distroless/java-debian10:11
 
+COPY --from=build --chown=nonroot:nonroot /app /app
+COPY --chown=nonroot:nonroot target/blaze-standalone.jar /app/
+
 WORKDIR /app
-
-COPY --from=build --chown=nonroot:nonroot /app ./
-COPY --from=build --chown=nonroot:nonroot /build/target/ ./
-
 USER nonroot
+
 ENV STORAGE="standalone"
 ENV INDEX_DB_DIR="/app/data/index"
 ENV TRANSACTION_DB_DIR="/app/data/transaction"
 ENV RESOURCE_DB_DIR="/app/data/resource"
+
 CMD ["blaze-standalone.jar", "-m", "blaze.core"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-VERSION := "0.11.0-beta.1"
 MODULES := $(wildcard modules/*)
 
 $(MODULES):
@@ -22,7 +21,7 @@ clean-root:
 clean: $(MODULES) clean-root
 
 uberjar:
-	clojure -X:depstar uberjar :jar target/blaze-${VERSION}-standalone.jar
+	clojure -X:depstar uberjar :jar target/blaze-standalone.jar
 
 outdated:
 	clojure -M:outdated


### PR DESCRIPTION
In the Docker build container, artefacts can't be cached. So building outside will be faster.