### PR TITLE
Migrate to AdoptOpenJDK

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,8 +1,0 @@
-general:
-  vulnerabilities:
-  # Newest Debian 10.8
-  - CVE-2020-1751
-  - CVE-2020-1752
-  - CVE-2021-3326
-  - CVE-2018-12886
-  - CVE-2019-15847

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM busybox as build
+FROM adoptopenjdk:11-jre-hotspot
 
-RUN mkdir -p /app/data
-
-FROM gcr.io/distroless/java-debian10:11
-
-COPY --from=build --chown=nonroot:nonroot /app /app
-COPY --chown=nonroot:nonroot target/blaze-standalone.jar /app/
+RUN mkdir -p /app/data && chown 1001:1001 /app/data
+COPY target/blaze-standalone.jar /app/
 
 WORKDIR /app
-USER nonroot
+USER 1001
 
 ENV STORAGE="standalone"
 ENV INDEX_DB_DIR="/app/data/index"
 ENV TRANSACTION_DB_DIR="/app/data/transaction"
 ENV RESOURCE_DB_DIR="/app/data/resource"
 
-CMD ["blaze-standalone.jar", "-m", "blaze.core"]
+CMD ["java", "-jar", "blaze-standalone.jar", "-m", "blaze.core"]


### PR DESCRIPTION
The Google [Distroless Java Project][1] is no longer maintained properly
to an extend that even Googles own [Jib Project][2] [moved][3] to
AdoptOpenJDK. So we will too.

[1]: <https://github.com/GoogleContainerTools/distroless>
[2]: <https://github.com/GoogleContainerTools/jib>
[3]: <https://github.com/GoogleContainerTools/jib/blob/master/docs/default_base_image.md#migration-from-pre-30>