### PR TITLE
Build Docker Hub Images in CI

### DIFF
--- a/.github/distributed-test/docker-compose.yml
+++ b/.github/distributed-test/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       HEAP_NEWSIZE: "100M"
 
   blaze:
-    image: "ghcr.io/samply/blaze:${GITHUB_SHA}"
+    image: "ghcr.io/samply/blaze:sha-${GITHUB_SHA}"
     hostname: "blaze"
     environment:
       JAVA_TOOL_OPTIONS: "-Xmx1g"

--- a/.github/openid-auth-test/docker-compose.yml
+++ b/.github/openid-auth-test/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "${GITHUB_WORKSPACE}/.github/openid-auth-test/realm.json:/tmp/realm.json"
 
   blaze:
-    image: "ghcr.io/samply/blaze:${GITHUB_SHA}"
+    image: "ghcr.io/samply/blaze:sha-${GITHUB_SHA}"
     environment:
       JAVA_TOOL_OPTIONS: "-Xmx2g"
       OPENID_PROVIDER_URL: "http://keycloak:8080/auth/realms/blaze"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,16 @@
 name: Build
 
-on: push
+on:
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   lint:
@@ -216,10 +226,18 @@ jobs:
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
+      if: github.event_name != 'pull_request'
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.CR_PAT }}
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      if: github.event_name != 'pull_request'
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -227,18 +245,34 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
+    - name: Docker meta
+      id: docker-meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          samply/blaze
+          ghcr.io/samply/blaze
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,format=long
+
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ghcr.io/samply/blaze:${{ github.sha }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.docker-meta.outputs.tags }}
+        labels: ${{ steps.docker-meta.outputs.labels }}
 
     - name: Scan Container Image
       uses: azure/container-scan@v0
       with:
-        image-name: ghcr.io/samply/blaze:${{ github.sha }}
+        image-name: ghcr.io/samply/blaze:sha-${{ github.sha }}
 
   integration-test:
     needs: build
@@ -253,10 +287,10 @@ jobs:
         password: ${{ secrets.CR_PAT }}
 
     - name: Pull Docker Image
-      run: docker pull ghcr.io/samply/blaze:${{ github.sha }}
+      run: docker pull ghcr.io/samply/blaze:sha-${{ github.sha }}
 
     - name: Run Blaze
-      run: docker run --name blaze --rm -d -e JAVA_TOOL_OPTIONS=-Xmx2g -p 8080:8080 -v blaze-data:/app/data ghcr.io/samply/blaze:${{ github.sha }}
+      run: docker run --name blaze --rm -d -e JAVA_TOOL_OPTIONS=-Xmx2g -p 8080:8080 -v blaze-data:/app/data ghcr.io/samply/blaze:sha-${{ github.sha }}
 
     - name: Check out Git repository
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## v0.11.0
+
+**!!! IMPORTANT !!!**
+
+The database schema has changed! Please start with a fresh database docker volume/directory.
+
+### New Features
+
+* Implement Search Param _include (#345)
+* Implement Search Param _revinclude (#342)
+* Implement Conditional Create (#359)
+* Allow Multiple Includes with same Type (#351)
+* Fall Back to Literal Reference Resolution on $evaluate-measure (#357)
+* Use Implementation of ge/le for gt/lt in Date Search Params (#410)
+* Override the base URL when Forwarded Headers are Present (#408)
+* Implement Search Parameters of Type Number (#391)
+
+### Performance Improvements
+
+* Improve Transaction Performance (#373)
+* Refactor Reference Extraction (#368)
+* Introduce Record for Attachment (#364)
+* Implement a Transaction Cache (#340)
+* Create Instance and Versioned URLs by Hand (#339)
+* Use LUID's instead of Random UUID's (#338)
+* Improve Performance of JSON Bundle Encoding (#336)
+* Bundle Entries of a Page Should be a Vector (#318)
+* Improve Performance of JSON Unforming (#308)
+* Improve Performance of Resource Handle Function (#307)
+* Improve Hashing Performance (#297)
+* Use Jsonista for Better JSON Encoding/Decoding Performance (#34)
+
+### Other Improvements
+
+* Fix and Enhance OpenID Connect Auth (#372)
+* Rename CQL Context Unspecified into Unfiltered (#317)
+* Migrate to a Java 15 Runtime (#315)
+
+### Bugfixes
+
+* Fix Total Counter on Recreating a Resource (#341)
+* Fix FHIR Date Search (#327)
+* Fix Inconsistent Paged Results on Disjunctive FHIR Searches (#324)
+* Fix JSON Generation of Instant Values (#320)
+* Make Lists of Values of OR Search Parameters Unique (#293)
+* Fix Issue Parsing of Large CQL Queries Never Finishes (#214)


### PR DESCRIPTION
I used to only build the GitHub Container Registry images tagged with the SHA and retag/push the Docker Hub Images myself. But now with the multi-arch build, that doesn't work anymore. Also is better to have everything in CI.