### PR TITLE
Revert to Default Stats Dump Period of 10 Minutes

### DIFF
--- a/modules/rocksdb/src/blaze/db/kv/rocksdb.clj
+++ b/modules/rocksdb/src/blaze/db/kv/rocksdb.clj
@@ -266,7 +266,6 @@
          compaction-readahead-size 0}}
    column-families]
   (let [opts (doto (DBOptions.)
-               (.setStatsDumpPeriodSec 0)
                (.setStatistics ^Statistics stats)
                (.setMaxBackgroundJobs ^long max-background-jobs)
                (.setCompactionReadaheadSize ^long compaction-readahead-size)


### PR DESCRIPTION
Previously, I had the stats dumped to often, resulting in a too large LOG file. After that, I disabled the stats completely, but it's a good thing to have the stats at all.