### PR TITLE
Fix Indexing of lastUpdated for Deleted Resources

### DIFF
--- a/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
@@ -12,6 +12,7 @@
     [blaze.elm.protocols :as p]
     [blaze.elm.quantity :as quantity]
     [blaze.fhir.spec.type.system :as system]
+    [blaze.test-util :refer [satisfies-prop]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest is testing]]
@@ -133,19 +134,19 @@
     (tu/testing-binary-null elm/add #elm/integer"1"))
 
   (testing "Adding zero integer to any integer or decimal doesn't change it"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [operand (s/gen (s/or :i :elm/integer :d :elm/decimal))]
         (let [elm (elm/equal [(elm/add [operand #elm/integer"0"]) operand])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding zero decimal to any decimal doesn't change it"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [operand (s/gen :elm/decimal)]
         (let [elm (elm/equal [(elm/add [operand #elm/decimal"0"]) operand])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding identical integers equals multiplying the same integer by two"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [integer (s/gen :elm/integer)]
         (let [elm (elm/equivalent [(elm/add [integer integer])
                                    (elm/multiply [integer #elm/integer"2"])])]
@@ -180,14 +181,14 @@
         #elm/decimal"99999999999999999999.99999999" #elm/decimal"1")))
 
   (testing "Adding identical decimals equals multiplying the same decimal by two"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/decimal)]
         (let [elm (elm/equal [(elm/add [decimal decimal])
                               (elm/multiply [decimal #elm/integer"2"])])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding identical decimals and dividing by two results in the same decimal"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/decimal)]
         (let [elm (elm/equal [(elm/divide [(elm/add [decimal decimal])
                                            #elm/integer"2"])
@@ -217,7 +218,7 @@
       [1 "m"] [1 "s"]))
 
   (testing "Adding identical quantities equals multiplying the same quantity with two"
-    (tu/satisfies-prop
+    (satisfies-prop
       100
       (prop/for-all [quantity (gen/such-that :value (s/gen :elm/quantity) 100)]
         (let [elm (elm/equal [(elm/add [quantity quantity])
@@ -225,7 +226,7 @@
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding identical quantities and dividing by two results in the same quantity"
-    (tu/satisfies-prop
+    (satisfies-prop
       100
       (prop/for-all [quantity (gen/such-that :value (s/gen :elm/quantity) 100)]
         (let [elm (elm/equal [(elm/divide [(elm/add [quantity quantity])
@@ -249,49 +250,49 @@
       #elm/date"2019-01-01" #elm/quantity[1 "day"] (system/date 2019 1 2)))
 
   (testing "Adding a positive amount of years to a year makes it greater"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year (s/gen :elm/year)
                      years (s/gen :elm/pos-years)]
         (let [elm (elm/greater [(elm/add [year years]) year])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of years to a year-month makes it greater"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year-month (s/gen :elm/year-month)
                      years (s/gen :elm/pos-years)]
         (let [elm (elm/greater [(elm/add [year-month years]) year-month])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of years to a date makes it greater"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date (s/gen :elm/literal-date)
                      years (s/gen :elm/pos-years)]
         (let [elm (elm/greater [(elm/add [date years]) date])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of years to a date-time makes it greater"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date-time (s/gen :elm/literal-date-time)
                      years (s/gen :elm/pos-years)]
         (let [elm (elm/greater [(elm/add [date-time years]) date-time])]
           (true? (core/-eval (c/compile {} elm) {:now tu/now} nil nil))))))
 
   (testing "Adding a positive amount of months to a year-month makes it greater"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year-month (s/gen :elm/year-month)
                      months (s/gen :elm/pos-months)]
         (let [elm (elm/greater [(elm/add [year-month months]) year-month])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of months to a date makes it greater or lets it equal because a date can be also a year and adding a small amount of months to a year doesn't change it."
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date (s/gen :elm/literal-date)
                      months (s/gen :elm/pos-months)]
         (let [elm (elm/greater-or-equal [(elm/add [date months]) date])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of months to a date-time makes it greater or lets it equal because a date-time can be also a year and adding a small amount of months to a year doesn't change it."
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date-time (s/gen :elm/literal-date-time)
                      months (s/gen :elm/pos-months)]
         (let [elm (elm/greater-or-equal [(elm/add [date-time months]) date-time])]
@@ -299,7 +300,7 @@
 
   ;; TODO: is that right?
   (testing "Adding a positive amount of days to a year doesn't change it."
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year (s/gen :elm/year)
                      days (s/gen :elm/pos-days)]
         (let [elm (elm/equal [(elm/add [year days]) year])]
@@ -307,21 +308,21 @@
 
   ;; TODO: is that right?
   (testing "Adding a positive amount of days to a year-month doesn't change it."
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year-month (s/gen :elm/year-month)
                      days (s/gen :elm/pos-days)]
         (let [elm (elm/equal [(elm/add [year-month days]) year-month])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of days to a date makes it greater or lets it equal because a date can be also a year or year-month and adding any amount of days to a year or year-month doesn't change it."
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date (s/gen :elm/literal-date)
                      days (s/gen :elm/pos-days)]
         (let [elm (elm/greater-or-equal [(elm/add [date days]) date])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding a positive amount of days to a date-time makes it greater or lets it equal because a date-time can be also a year or year-month and adding any amount of days to a year or year-month doesn't change it."
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date-time (s/gen :elm/literal-date-time)
                      days (s/gen :elm/pos-days)]
         (let [elm (elm/greater-or-equal [(elm/add [date-time days]) date-time])]
@@ -440,7 +441,7 @@
     (tu/testing-binary-null elm/divide #elm/quantity[1] #elm/decimal"1.1"))
 
   (testing "(d / d) * d = d"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/non-zero-decimal)]
         (let [elm (elm/equal [(elm/multiply [(elm/divide [decimal decimal]) decimal]) decimal])]
           (true? (core/-eval (c/compile {} elm) {} nil nil)))))))
@@ -893,7 +894,7 @@
       #elm/integer"1" {:type "Null"} nil))
 
   (testing "Subtracting identical integers results in zero"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [integer (s/gen :elm/integer)]
         (zero? (core/-eval (c/compile {} (elm/subtract [integer integer])) {} nil nil)))))
 
@@ -919,7 +920,7 @@
         #elm/decimal"-99999999999999999999.99999999" #elm/decimal"1")))
 
   (testing "Subtracting identical decimals results in zero"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/decimal)]
         (zero? (core/-eval (c/compile {} (elm/subtract [decimal decimal])) {} nil nil)))))
 
@@ -946,7 +947,7 @@
       #elm/quantity[1 "m"] #elm/quantity[1 "s"]))
 
   (testing "Subtracting identical quantities results in zero"
-    (tu/satisfies-prop
+    (satisfies-prop
       100
       (prop/for-all [quantity (gen/such-that :value (s/gen :elm/quantity) 100)]
         ;; Can't test for zero because can't extract value from quantity
@@ -972,7 +973,7 @@
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of years from a year makes it smaller"
-      (tu/satisfies-prop 100
+      (satisfies-prop 100
         (prop/for-all [year (s/gen :elm/year)
                        years (s/gen :elm/pos-years)]
           (let [elm (elm/less [(elm/subtract [year years]) year])]
@@ -980,7 +981,7 @@
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of years from a year-month makes it smaller"
-      (tu/satisfies-prop 100
+      (satisfies-prop 100
         (prop/for-all [year-month (s/gen :elm/year-month)
                        years (s/gen :elm/pos-years)]
           (let [elm (elm/less [(elm/subtract [year-month years]) year-month])]
@@ -988,7 +989,7 @@
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of years from a date makes it smaller"
-      (tu/satisfies-prop 100
+      (satisfies-prop 100
         (prop/for-all [date (s/gen :elm/literal-date)
                        years (s/gen :elm/pos-years)]
           (let [elm (elm/less [(elm/subtract [date years]) date])]
@@ -996,7 +997,7 @@
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of months from a year-month makes it smaller"
-      (tu/satisfies-prop 100
+      (satisfies-prop 100
         (prop/for-all [year-month (s/gen :elm/year-month)
                        months (s/gen :elm/pos-months)]
           (let [elm (elm/less [(elm/subtract [year-month months]) year-month])]
@@ -1004,7 +1005,7 @@
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of months from a date makes it smaller or lets it equal because a date can be also a year and subtracting a small amount of months from a year doesn't change it."
-      (tu/satisfies-prop 100
+      (satisfies-prop 100
         (prop/for-all [date (s/gen :elm/literal-date)
                        months (s/gen :elm/pos-months)]
           (let [elm (elm/less-or-equal [(elm/subtract [date months]) date])]
@@ -1012,7 +1013,7 @@
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of days from a date makes it smaller or lets it equal because a date can be also a year or year-month and subtracting any amount of days from a year or year-month doesn't change it."
-      (tu/satisfies-prop 100
+      (satisfies-prop 100
         (prop/for-all [date (s/gen :elm/literal-date)
                        days (s/gen :elm/pos-days)]
           (let [elm (elm/less-or-equal [(elm/subtract [date days]) date])]

--- a/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
@@ -10,6 +10,7 @@
     [blaze.elm.literal]
     [blaze.elm.literal-spec]
     [blaze.elm.quantity :as quantity]
+    [blaze.test-util :refer [satisfies-prop]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest testing]]
@@ -163,6 +164,6 @@
       #elm/quantity[1 "cm2"] (quantity/quantity 1 "cm2")))
 
   (testing "Periods"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [period (s/gen :elm/period)]
         (#{BigDecimal Period} (type (core/-eval (c/compile {} period) {} nil nil)))))))

--- a/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
@@ -7,6 +7,7 @@
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
     [blaze.fhir.spec.type.system :as system]
+    [blaze.test-util :refer [satisfies-prop]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest is testing]]
@@ -144,17 +145,17 @@
 
 
   (testing "an ELM year (only literals) always compiles to a Year"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year (s/gen :elm/literal-year)]
         (instance? Year (c/compile {} year)))))
 
   (testing "an ELM year-month (only literals) always compiles to a YearMonth"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [year-month (s/gen :elm/literal-year-month)]
         (instance? YearMonth (c/compile {} year-month)))))
 
   (testing "an ELM date (only literals) always compiles to something implementing Temporal"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date (s/gen :elm/literal-date)]
         (instance? Temporal (c/compile {} date))))))
 
@@ -332,7 +333,7 @@
       (system/date-time 2019 3 23 10 43 14)))
 
   (testing "an ELM date-time (only literals) always evaluates to something implementing Temporal"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [date-time (s/gen :elm/literal-date-time)]
         (instance? Temporal (core/-eval (c/compile {} date-time) {:now tu/now} nil nil))))))
 
@@ -872,7 +873,7 @@
       (is (= (date-time/local-time 12 13 14 15) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "an ELM time (only literals) always compiles to a LocalTime"
-    (tu/satisfies-prop 100
+    (satisfies-prop 100
       (prop/for-all [time (s/gen :elm/time)]
         (date-time/local-time? (c/compile {} time))))))
 

--- a/modules/cql/test/blaze/elm/compiler/test_util.clj
+++ b/modules/cql/test/blaze/elm/compiler/test_util.clj
@@ -8,7 +8,6 @@
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [is testing]]
-    [clojure.test.check :as tc]
     [cognitect.anomalies :as anom])
   (:import
     [java.time OffsetDateTime ZoneOffset]))
@@ -34,15 +33,6 @@
       {"system" (elm/string system)
        "version" (elm/string version)
        "code" (elm/string code)}])))
-
-
-(defmacro satisfies-prop [num-tests prop]
-  `(let [result# (tc/quick-check ~num-tests ~prop)]
-     (if (instance? Throwable (:result result#))
-       (throw (:result result#))
-       (if (true? (:result result#))
-         (is :success)
-         (is (clojure.pprint/pprint result#))))))
 
 
 (def patient-retrieve-elm

--- a/modules/db-tx-log-kafka/.clj-kondo/config.edn
+++ b/modules/db-tx-log-kafka/.clj-kondo/config.edn
@@ -1,6 +1,7 @@
 {:lint-as
  {blaze.anomaly/when-ok clojure.core/let
   blaze.test-util/with-system clojure.core/with-open
+  clojure.test.check.properties/for-all clojure.core/let
   prometheus.alpha/defcounter clojure.core/def
   prometheus.alpha/defhistogram clojure.core/def}
 

--- a/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka/codec.clj
+++ b/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka/codec.clj
@@ -1,0 +1,51 @@
+(ns blaze.db.tx-log.kafka.codec
+  (:require
+    [blaze.byte-string :as bs]
+    [jsonista.core :as j]
+    [taoensso.timbre :as log])
+  (:import
+    [com.fasterxml.jackson.dataformat.cbor CBORFactory]
+    [org.apache.kafka.common.serialization Serializer Deserializer]))
+
+
+(def ^:private cbor-object-mapper
+  (j/object-mapper
+    {:factory (CBORFactory.)
+     :decode-key-fn true
+     :modules [bs/object-mapper-module]}))
+
+
+(deftype CborSerializer []
+  Serializer
+  (serialize [_ _ data]
+    (j/write-value-as-bytes data cbor-object-mapper)))
+
+
+(def ^Serializer serializer (CborSerializer.))
+
+
+(defn- parse-cbor [data]
+  (try
+    (j/read-value data cbor-object-mapper)
+    (catch Exception e
+      (log/warn (format "Error while parsing tx-data: %s" (ex-message e))))))
+
+
+(defn- decode-hash [{:keys [hash] :as tx-cmd}]
+  (if hash
+    (assoc tx-cmd :hash (bs/from-byte-array hash))
+    tx-cmd))
+
+
+(defn- decode-hashes [cmds]
+  (when (sequential? cmds)
+    (mapv decode-hash cmds)))
+
+
+(deftype CborDeserializer []
+  Deserializer
+  (deserialize [_ _ data]
+    (decode-hashes (parse-cbor data))))
+
+
+(def ^Deserializer deserializer (CborDeserializer.))

--- a/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka/codec_test.clj
+++ b/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka/codec_test.clj
@@ -1,0 +1,52 @@
+(ns blaze.db.tx-log.kafka.codec-test
+  (:require
+    [blaze.db.tx-log.kafka.codec :as codec]
+    [blaze.db.tx-log.spec]
+    [blaze.test-util :refer [satisfies-prop]]
+    [clojure.spec.alpha :as s]
+    [clojure.spec.test.alpha :as st]
+    [clojure.test :as test :refer [deftest is testing]]
+    [clojure.test.check.properties :as p]))
+
+
+(st/instrument)
+
+
+(defn- fixture [f]
+  (st/instrument)
+  (f)
+  (st/unstrument))
+
+
+(test/use-fixtures :each fixture)
+
+
+(defn- serialize [tx-cmds]
+  (.serialize codec/serializer "topic-093717" tx-cmds))
+
+
+(defn- deserialize [data]
+  (.deserialize codec/deserializer "topic-094321" data))
+
+
+(deftest round-trip-test
+  (satisfies-prop 100
+    (p/for-all [tx-cmds (s/gen :blaze.db/tx-cmds)]
+      (= tx-cmds (deserialize (serialize tx-cmds))))))
+
+
+(defn- invalid-cbor-content
+  "`0xA1` is the start of a map with one entry."
+  []
+  (byte-array [0xA1]))
+
+
+(deftest deserializer-test
+  (testing "empty value"
+    (is (nil? (deserialize (byte-array 0)))))
+
+  (testing "invalid cbor value"
+    (is (nil? (deserialize (invalid-cbor-content)))))
+
+  (testing "invalid map value"
+    (is (nil? (deserialize (serialize {:a 1}))))))

--- a/modules/db-tx-log/src/blaze/db/tx_log/spec.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log/spec.clj
@@ -67,8 +67,7 @@
 (defmethod tx-cmd "delete" [_]
   (s/keys :req-un [:blaze.db.tx-cmd/op
                    :blaze.db.tx-cmd/type
-                   :blaze.resource/id
-                   :blaze.resource/hash]
+                   :blaze.resource/id]
           :opt-un [:blaze.db.tx-cmd/if-match]))
 
 

--- a/modules/db-tx-log/test/blaze/db/tx_log/spec_test.clj
+++ b/modules/db-tx-log/test/blaze/db/tx_log/spec_test.clj
@@ -52,5 +52,4 @@
     {:op "delete"
      :type "Patient"
      :id "0"
-     :hash patient-hash-0
      :if-match 1}))

--- a/modules/db/src/blaze/db/api_spec.clj
+++ b/modules/db/src/blaze/db/api_spec.clj
@@ -5,6 +5,7 @@
     [blaze.db.api :as d]
     [blaze.db.search-param-registry-spec]
     [blaze.db.spec]
+    [blaze.db.tx-log.spec]
     [blaze.fhir.spec]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]))

--- a/modules/db/src/blaze/db/impl/codec.clj
+++ b/modules/db/src/blaze/db/impl/codec.clj
@@ -377,7 +377,3 @@
 
 (defn quantity [unit value]
   (bs/concat (v-hash (or unit "")) (number value)))
-
-
-(defn deleted-resource [type id]
-  {:fhir/type (keyword "fhir" type) :id id})

--- a/modules/db/src/blaze/db/impl/index/compartment/resource.clj
+++ b/modules/db/src/blaze/db/impl/index/compartment/resource.clj
@@ -30,7 +30,7 @@
      (bs/from-byte-buffer buf))))
 
 
-(defn- resource-handles-xform [resource-handle tid]
+(defn- resource-handles-xf [resource-handle tid]
   (comp
     (keep #(resource-handle tid %))
     (remove (comp #{:delete} :op))))
@@ -76,11 +76,11 @@
   ([{:keys [cri resource-handle]} compartment tid]
    (let [seek-key (encode-seek-key compartment tid)]
      (coll/eduction
-       (resource-handles-xform resource-handle tid)
+       (resource-handles-xf resource-handle tid)
        (i/prefix-keys! cri seek-key decode-key seek-key))))
   ([{:keys [cri resource-handle]} compartment tid start-id]
    (coll/eduction
-     (resource-handles-xform resource-handle tid)
+     (resource-handles-xf resource-handle tid)
      (i/prefix-keys!
        cri
        (encode-seek-key compartment tid)

--- a/modules/db/src/blaze/db/node/transaction.clj
+++ b/modules/db/src/blaze/db/node/transaction.clj
@@ -1,7 +1,6 @@
 (ns blaze.db.node.transaction
   (:require
     [blaze.anomaly :as ba]
-    [blaze.db.impl.codec :as codec]
     [blaze.db.impl.db :as db]
     [blaze.db.impl.index.tx-error :as tx-error]
     [blaze.db.impl.index.tx-success :as tx-success]
@@ -52,15 +51,10 @@
 
 (defmethod prepare-op :delete
   [[_ type id]]
-  (let [resource (codec/deleted-resource type id)
-        hash (hash/generate resource)]
-    {:hash-resource
-     [hash resource]
-     :blaze.db/tx-cmd
-     {:op "delete"
-      :type (name (fhir-spec/fhir-type resource))
-      :id (:id resource)
-      :hash hash}}))
+  {:blaze.db/tx-cmd
+   {:op "delete"
+    :type type
+    :id id}})
 
 
 (def ^:private split

--- a/modules/db/src/blaze/db/spec.clj
+++ b/modules/db/src/blaze/db/spec.clj
@@ -4,6 +4,7 @@
     [blaze.db.impl.protocols :as p]
     [blaze.db.node.protocols :as np]
     [blaze.db.resource-store.spec]
+    [blaze.db.tx-log.spec]
     [blaze.spec]
     [clojure.spec.alpha :as s])
   (:import

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -536,7 +536,7 @@
   (testing "with failing resource indexer"
     (with-redefs
       [resource-indexer/index-resources
-       (fn [_ _ _]
+       (fn [_ _]
          (ac/completed-future {::anom/category ::anom/fault ::x ::y}))]
       (with-system [{:blaze.db/keys [node]} system]
         (given-failed-future
@@ -1099,7 +1099,10 @@
                  :birthDate #fhir/date"2019"}]
           [:put {:fhir/type :fhir/Patient
                  :id "id-4"
-                 :birthDate #fhir/date"2021"}]])
+                 :birthDate #fhir/date"2021"}]
+          [:put {:fhir/type :fhir/Patient
+                 :id "id-5"}]])
+      @(d/transact node [[:delete "Patient" "id-5"]])
 
       (testing "_id"
         (given (pull-type-query node "Patient" [["_id" "id-1"]])

--- a/modules/db/test/blaze/db/node/resource_indexer_spec.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_spec.clj
@@ -8,9 +8,16 @@
     [blaze.db.impl.search-param-spec]
     [blaze.db.kv-spec]
     [blaze.db.node.resource-indexer :as resource-indexer]
+    [blaze.db.resource-store.spec]
     [blaze.db.search-param-registry.spec]
     [blaze.fhir.spec-spec]
-    [clojure.spec.alpha :as s]))
+    [clojure.spec.alpha :as s])
+  (:import
+    [clojure.lang IAtom]))
+
+
+(s/def :blaze.db.node/tx-resource-cache
+  #(instance? IAtom %))
 
 
 (s/def :blaze.db.node/resource-indexer
@@ -20,10 +27,16 @@
      :blaze.db/kv-store]))
 
 
+(s/def ::context
+  (s/keys
+    :req-un
+    [:blaze.db.node/tx-resource-cache
+     :blaze.db/resource-store
+     :blaze.db.node/resource-indexer]))
+
+
 (s/fdef resource-indexer/index-resources
-  :args (s/cat :resource-indexer :blaze.db.node/resource-indexer
-               :last-updated inst?
-               :entries (s/map-of :blaze.resource/hash (s/nilable :blaze/resource)))
+  :args (s/cat :context ::context :tx-data :blaze.db/tx-data)
   :ret ac/completable-future?)
 
 

--- a/modules/db/test/blaze/db/node/transaction_test.clj
+++ b/modules/db/test/blaze/db/node/transaction_test.clj
@@ -64,7 +64,8 @@
     (given (tx/prepare-ops [[:delete "Patient" "0"]])
       [0 0 :op] := "delete"
       [0 0 :type] := "Patient"
-      [0 0 :id] := "0")))
+      [0 0 :id] := "0"
+      [1] := {})))
 
 
 (deftest load-tx-result-test

--- a/modules/db/test/blaze/db/node_test.clj
+++ b/modules/db/test/blaze/db/node_test.clj
@@ -167,7 +167,7 @@
     (testing "with failing resource indexer"
       (with-redefs
         [resource-indexer/index-resources
-         (fn [_ _ _]
+         (fn [_ _]
            (ac/completed-future {::anom/category ::anom/fault ::x ::y}))]
         (with-system [{:blaze.db/keys [node]} system]
           (try

--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -46,14 +46,14 @@
   {:extra-paths ["test"]
 
    :extra-deps
-   {criterium/criterium
+   {blaze/test-util
+    {:local/root "../test-util"}
+
+    criterium/criterium
     {:mvn/version "0.4.6"}
 
     lambdaisland/kaocha
     {:mvn/version "1.0.887"}
-
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}
 
     org.openjdk.jol/jol-core
     {:mvn/version "0.16"}}
@@ -65,11 +65,11 @@
   {:extra-paths ["test"]
 
    :extra-deps
-   {cloverage/cloverage
-    {:mvn/version "1.2.2"}
+   {blaze/test-util
+    {:local/root "../test-util"}
 
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}
+    cloverage/cloverage
+    {:mvn/version "1.2.2"}
 
     org.openjdk.jol/jol-core
     {:mvn/version "0.16"}}

--- a/modules/fhir-structure/src/blaze/fhir/hash/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/hash/spec.clj
@@ -1,8 +1,13 @@
 (ns blaze.fhir.hash.spec
   (:require
     [blaze.byte-string :as bs :refer [byte-string?]]
-    [clojure.spec.alpha :as s]))
+    [clojure.spec.alpha :as s]
+    [clojure.spec.gen.alpha :as gen]))
 
 
 (s/def :blaze.resource/hash
-  (s/and byte-string? #(= 32 (bs/size %))))
+  (s/with-gen
+    (s/and byte-string? #(= 32 (bs/size %)))
+    #(gen/fmap
+       (comp bs/from-byte-array byte-array)
+       (gen/vector (gen/fmap byte (gen/choose Byte/MIN_VALUE Byte/MAX_VALUE)) 32))))

--- a/modules/fhir-structure/test/blaze/fhir/hash_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/hash_test.clj
@@ -3,6 +3,7 @@
     [blaze.byte-string :as bs]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
+    [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]))
 
@@ -30,3 +31,7 @@
   (testing "hashes from different resource types are different"
     (is (not= (hash/generate {:fhir/type :fhir/Patient :id "0"})
               (hash/generate {:fhir/type :fhir/Observation :id "0"})))))
+
+
+(deftest spec-generation-test
+  (is (s/exercise :blaze.resource/hash)))

--- a/modules/interaction/test/blaze/interaction/history/instance_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/instance_test.clj
@@ -160,7 +160,7 @@
 
   (testing "returns history with one currently deleted patient"
     (with-handler [handler]
-      [[[:put {:fhir/type :fhir/Patient :id "0"}]]
+      [[[:put {:fhir/type :fhir/Patient :id "0" :active true}]]
        [[:delete "Patient" "0"]]]
 
       (let [{:keys [status body]}
@@ -193,6 +193,7 @@
             :fullUrl := #fhir/uri"base-url-135814/Patient/0"
             [:request :method] := #fhir/code"DELETE"
             [:request :url] := #fhir/uri"/Patient/0"
+            keys :!> #{:resource}
             [:response :status] := "204"
             [:response :etag] := "W/\"2\""
             [:response :lastModified] := Instant/EPOCH))
@@ -205,6 +206,7 @@
             [:resource :id] := "0"
             [:resource :fhir/type] := :fhir/Patient
             [:resource :meta :versionId] := #fhir/id"1"
+            [:resource :active] := true
             [:response :status] := "201"
             [:response :etag] := "W/\"1\""
             [:response :lastModified] := Instant/EPOCH)))))

--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -931,7 +931,25 @@
             (is (= #fhir/unsignedInt 0 (:total body))))
 
           (testing "the bundle contains no entry"
-            (is (zero? (count (:entry body)))))))))
+            (is (zero? (count (:entry body))))))))
+
+    (testing "deleted resources are not found"
+      (with-handler [handler]
+        [[[:put {:fhir/type :fhir/Patient :id "0"}]]
+         [[:delete "Patient" "0"]]]
+
+        (let [{:keys [status body]}
+              @(handler
+                 {::reitit/match patient-match
+                  :params {"_lastUpdated" "1970-01-01"}})]
+
+          (is (= 200 status))
+
+          (testing "the total count is 0"
+            (is (= #fhir/unsignedInt 0 (:total body))))
+
+          (testing "the bundle contains one entry"
+            (is (= 0 (count (:entry body)))))))))
 
   (testing "_profile search"
     (with-handler [handler]

--- a/modules/test-util/src/blaze/test_util.clj
+++ b/modules/test-util/src/blaze/test_util.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :as ba]
     [clojure.test :refer [is]]
+    [clojure.test.check :as tc]
     [integrant.core :as ig]
     [juxt.iota :refer [given]])
   (:import
@@ -61,3 +62,12 @@
   [_ ^ExecutorService executor]
   (.shutdown executor)
   (.awaitTermination executor 10 TimeUnit/SECONDS))
+
+
+(defmacro satisfies-prop [num-tests prop]
+  `(let [result# (tc/quick-check ~num-tests ~prop)]
+     (if (instance? Throwable (:result result#))
+       (throw (:result result#))
+       (if (true? (:result result#))
+         (is :success)
+         (is (clojure.pprint/pprint result#))))))


### PR DESCRIPTION
When deleting a resource, a resource content with type and id only was
stored and indexed. However, because the lastUpdated timestamp is not
part of the resource content, it was associated to the resource content
before indexing. So the lastUpdate timestamp was indexed even for the
deleted version of a resource, so that a search for _lastUpdated found
that version and returned it as match in results.

This patch completely omits storing and indexing of deleted resource
contents and uses the hash consisting of all zero bytes for the
resource handle. Pulling such a deleted resource handle will return a
resource content consisting of type and id only immediately.