### PR TITLE
Fix Resizing of Buffers at Read

### DIFF
--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -43,6 +43,9 @@
    {blaze/test-util
     {:local/root "../test-util"}
 
+    com.clojure-goes-fast/clj-java-decompiler
+    {:mvn/version "0.3.0"}
+
     lambdaisland/kaocha
     {:mvn/version "1.0.887"}}
 

--- a/modules/db/src/blaze/db/impl/arrays_support.clj
+++ b/modules/db/src/blaze/db/impl/arrays_support.clj
@@ -1,0 +1,47 @@
+(ns blaze.db.impl.arrays-support
+  "Reimplementation of some of `jdk.internal.util/ArraysSupport` functionality")
+
+
+(set! *unchecked-math* :warn-on-boxed)
+
+
+(def ^:const ^long soft-max-array-length (- Integer/MAX_VALUE 8))
+
+
+(defn- huge-length ^long [^long old-length ^long min-growth]
+  (let [min-length (+ old-length min-growth)]
+    (when (< Integer/MAX_VALUE min-length)
+      (throw (OutOfMemoryError. (format "Required array length %d + %d is too large" old-length (max min-growth min-growth)))))
+    min-length))
+
+
+(defn new-length
+  "Computes a new array length given an array's current length, a minimum growth
+  amount, and a preferred growth amount.
+
+  This method is used by objects that contain an array that might need to be
+  grown in order to fulfill some immediate need (the minimum growth amount) but
+  would also like to request more space (the preferred growth amount) in order
+  to accommodate potential future needs. The returned length is usually clamped
+  at the soft maximum length in order to avoid hitting the JVM implementation
+  limit. However, the soft maximum will be exceeded if the minimum growth amount
+  requires it.
+
+  If the preferred growth amount is less than the minimum growth amount, the
+  minimum growth amount is used as the preferred growth amount.
+
+  The preferred length is determined by adding the preferred growth amount to
+  the current length. If the preferred length does not exceed the soft maximum
+  length (`soft-max-array-length`) then the preferred length is returned.
+
+  If the preferred length exceeds the soft maximum, we use the minimum growth
+  amount. The minimum required length is determined by adding the minimum growth
+  amount to the current length. If the minimum required length exceeds
+  `Integer/MAX_VALUE`, then this method throws an `OutOfMemoryError`. Otherwise,
+  this method returns the greater of the soft maximum or the minimum required
+  length."
+  ^long [^long old-length ^long min-growth ^long pref-growth]
+  (let [pref-length (+ old-length (max min-growth pref-growth))]
+    (if (<= pref-length soft-max-array-length)
+      pref-length
+      (huge-length old-length min-growth))))

--- a/modules/db/src/blaze/db/impl/iterators.clj
+++ b/modules/db/src/blaze/db/impl/iterators.clj
@@ -19,6 +19,7 @@
   (:require
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
+    [blaze.db.impl.arrays-support :as arrays-support]
     [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.kv :as kv])
   (:import
@@ -68,16 +69,20 @@
       (reduce-iter! iter kv/prev! rf init))))
 
 
+(defn- new-capacity ^long [^long old-capacity ^long min-capacity]
+  (arrays-support/new-length old-capacity (- min-capacity old-capacity)
+                             (bit-shift-right old-capacity 1)))
+
 (defn- read!
   "Reads from `iter` using the function `read` and `buf`.
 
-  When `buf` is to small, a new direct byte buffer will be created. Returns the
+  When `buf` is too small, a new direct byte buffer will be created. Returns the
   byte buffer used to read."
   [read buf iter]
   (bb/clear! buf)
-  (let [size (read iter buf)]
-    (if (< (bb/capacity buf) ^long size)
-      (let [buf (bb/allocate-direct (* 2 (bb/capacity buf)))]
+  (let [^long size (read iter buf)]
+    (if (< (bb/capacity buf) size)
+      (let [buf (bb/allocate-direct (new-capacity (bb/capacity buf) size))]
         (read iter buf)
         buf)
       buf)))

--- a/modules/db/test/blaze/db/impl/arrays_support_test.clj
+++ b/modules/db/test/blaze/db/impl/arrays_support_test.clj
@@ -1,0 +1,17 @@
+(ns blaze.db.impl.arrays-support-test
+  (:require
+    [blaze.db.impl.arrays-support :as arrays-support]
+    [clojure.test :refer [deftest are is testing]]))
+
+
+(deftest new-length-test
+  (are [o m p n] (= n (arrays-support/new-length o m p))
+    1 1 1 2
+    1 2 1 3
+    (- Integer/MAX_VALUE 9) 1 0 (- Integer/MAX_VALUE 8)
+    (- Integer/MAX_VALUE 9) 0 1 (- Integer/MAX_VALUE 8)
+    (- Integer/MAX_VALUE 8) 0 1 (- Integer/MAX_VALUE 8)
+    (- Integer/MAX_VALUE 8) 8 0 Integer/MAX_VALUE)
+
+  (testing "throws an OutOfMemoryError because the minimum required length exceeds Integer/MAX_VALUE"
+    (is (thrown? OutOfMemoryError (arrays-support/new-length (- Integer/MAX_VALUE 8) 9 0)))))

--- a/modules/db/test/blaze/db/impl/iterators_test.clj
+++ b/modules/db/test/blaze/db/impl/iterators_test.clj
@@ -63,4 +63,15 @@
 
       (let [iter (kv/new-iterator (kv/new-snapshot kv-store))]
         (is (= [[0x00] [0x00 0x01]]
-               (into [] (i/keys! iter decode-1 (bs/from-hex "00")))))))))
+               (into [] (i/keys! iter decode-1 (bs/from-hex "00")))))))
+
+    (testing "new ByteBuffer is bigger than a two times increase"
+      (with-system [{kv-store ::kv/mem} system]
+        (kv/put!
+          kv-store
+          [[(ba 0x00) bytes/empty]
+           [(ba 0x00 0x01 0x02) bytes/empty]])
+
+        (let [iter (kv/new-iterator (kv/new-snapshot kv-store))]
+          (is (= [[0x00] [0x00 0x01 0x02]]
+                 (into [] (i/keys! iter decode-1 (bs/from-hex "00"))))))))))


### PR DESCRIPTION
In case buffers are too small, they will be resized. But we did only
double the size without taking into account the actual required amount
to resize.

We used the same algorithm as in jdk.internal.util.ArraysSupport/newLength.