### PR TITLE
Fix Memory Leak in Node

### DIFF
--- a/dev/blaze/dev/db.clj
+++ b/dev/blaze/dev/db.clj
@@ -1,0 +1,33 @@
+(ns blaze.dev.db
+  (:require
+    [blaze.core :refer [system]])
+  (:import
+    [com.github.benmanes.caffeine.cache Cache]))
+
+
+(def ^Cache resource-cache
+  (.synchronous (.-cache (:blaze.db/resource-cache system))))
+
+
+(def ^Cache resource-handle-cache
+  (:blaze.db/resource-handle-cache system))
+
+
+(def ^Cache tx-cache
+  (:blaze.db/tx-cache system))
+
+
+(def node
+  (:blaze.db/node system))
+
+
+(comment
+  (.estimatedSize resource-cache)
+  (.invalidateAll resource-cache)
+
+  (.estimatedSize resource-handle-cache)
+  (.invalidateAll resource-handle-cache)
+
+  (.estimatedSize tx-cache)
+  (.invalidateAll tx-cache)
+  )

--- a/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka.clj
+++ b/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka.clj
@@ -84,7 +84,7 @@
 
 (deftype KafkaTxLog [config ^Producer producer last-t-consumer last-t-executor]
   tx-log/TxLog
-  (-submit [_ tx-cmds]
+  (-submit [_ tx-cmds _]
     (log/trace "submit" (count tx-cmds) "tx-cmds")
     (let [timer (prom/timer duration-seconds "submit")
           future (ac/future)]

--- a/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka_test.clj
+++ b/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka_test.clj
@@ -103,7 +103,7 @@
            (close [_])))
        kafka/create-last-t-consumer no-op-consumer]
       (with-system [{tx-log ::tx-log/kafka} system]
-        (is (= 1 @(tx-log/submit tx-log [tx-cmd])))))
+        (is (= 1 @(tx-log/submit tx-log [tx-cmd] nil)))))
 
     (testing "RecordTooLargeException"
       (with-redefs
@@ -119,7 +119,7 @@
              (close [_])))
          kafka/create-last-t-consumer no-op-consumer]
         (with-system [{tx-log ::tx-log/kafka} system]
-          (given-failed-future (tx-log/submit tx-log [tx-cmd])
+          (given-failed-future (tx-log/submit tx-log [tx-cmd] nil)
             ::anom/category := ::anom/unsupported
             ::anom/message := "A transaction with 1 commands generated a Kafka message which is larger than the configured maximum of null bytes. In order to prevent this error, increase the maximum message size by setting DB_KAFKA_MAX_REQUEST_SIZE to a higher number. msg-173357"))))
 
@@ -137,7 +137,7 @@
              (close [_])))
          kafka/create-last-t-consumer no-op-consumer]
         (with-system [{tx-log ::tx-log/kafka} system]
-          (given-failed-future @(tx-log/submit tx-log [tx-cmd])
+          (given-failed-future @(tx-log/submit tx-log [tx-cmd] nil)
             ::anom/category := ::anom/fault
             ::anom/message := "msg-175337")))))
 

--- a/modules/db-tx-log/src/blaze/db/tx_log.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log.clj
@@ -9,7 +9,7 @@
 
   There might be implementations of TxLog only suitable for single node setups."
 
-  (-submit [tx-log tx-cmds])
+  (-submit [tx-log tx-cmds local-payload])
 
   (-last-t [tx-log])
 
@@ -23,11 +23,15 @@
   potentially valid transaction or complete exceptionally with an anomaly in
   case of errors.
 
+  The `local-payload` will be embedded under :local-payload in the transaction
+  data returned from `poll!` if the transaction log supports this feature and
+  the poller is on the same node as the submitter.
+
   Note: This function only ensures that the transaction is committed into the
   log and will be handled in the future. So a positive return value doesn't mean
   that the transaction itself was successful."
-  [tx-log tx-cmds]
-  (-submit tx-log tx-cmds))
+  [tx-log tx-cmds local-payload]
+  (-submit tx-log tx-cmds local-payload))
 
 
 (defn last-t
@@ -52,6 +56,9 @@
 
 (defn poll!
   "Retrieves and removes the head, a collection of transaction data, of `queue`,
-  waiting up to `timeout` if necessary for transaction data to become available."
+  waiting up to `timeout` if necessary for transaction data to become available.
+
+  Transaction data optionally contains :local-payload if the transaction was
+  submitted on the same node and the transaction log supports this feature."
   [queue timeout]
   (-poll queue timeout))

--- a/modules/db-tx-log/src/blaze/db/tx_log_spec.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log_spec.clj
@@ -10,7 +10,8 @@
 
 ;; returns a CompletableFuture of :blaze.db/t
 (s/fdef tx-log/submit
-  :args (s/cat :tx-log :blaze.db/tx-log :tx-cmds :blaze.db/tx-cmds)
+  :args (s/cat :tx-log :blaze.db/tx-log :tx-cmds :blaze.db/tx-cmds
+               :local-payload any?)
   :ret ac/completable-future?)
 
 

--- a/modules/db-tx-log/test/blaze/db/tx_log_test.clj
+++ b/modules/db-tx-log/test/blaze/db/tx_log_test.clj
@@ -29,14 +29,15 @@
 
 (deftest submit-test
   (let [tx-log (reify tx-log/TxLog
-                 (-submit [_ _]
+                 (-submit [_ _ _]
                    (ac/completed-future 1)))]
     (is (= 1 @(tx-log/submit
                 tx-log
                 [{:op "create"
                   :type "Patient"
                   :id "0"
-                  :hash patient-hash-0}])))))
+                  :hash patient-hash-0}]
+                nil)))))
 
 
 (deftest last-t-test

--- a/modules/db/src/blaze/db/tx_log/local.clj
+++ b/modules/db/src/blaze/db/tx_log/local.clj
@@ -9,6 +9,7 @@
   Uses a single thread named `local-tx-log` to increment the point in time `t`,
   store the transaction and transfers it to listening queues."
   (:require
+    [blaze.anomaly :as ba]
     [blaze.async.comp :as ac]
     [blaze.byte-string :as bs]
     [blaze.db.impl.byte-buffer :as bb]
@@ -16,18 +17,17 @@
     [blaze.db.kv :as kv]
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log.local.codec :as codec]
-    [blaze.executors :as ex]
     [blaze.module :refer [reg-collector]]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
     [java-time :as time]
-    [prometheus.alpha :as prom :refer [defhistogram]]
+    [prometheus.alpha :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
     [java.io Closeable]
     [java.time Instant]
-    [java.util.concurrent
-     ArrayBlockingQueue BlockingQueue ExecutorService TimeUnit]))
+    [java.util.concurrent ArrayBlockingQueue BlockingQueue TimeUnit]
+    [java.util.concurrent.locks Lock ReentrantLock]))
 
 
 (set! *warn-on-reflection* true)
@@ -53,7 +53,7 @@
       (into [] (take max-poll-size) (i/kvs! iter codec/decode-tx-data key)))))
 
 
-(defn- poll [^BlockingQueue queue timeout]
+(defn- poll! [^BlockingQueue queue timeout]
   (log/trace "poll in-memory queue with timeout =" timeout)
   (.poll queue (time/as timeout :millis) TimeUnit/MILLISECONDS))
 
@@ -67,7 +67,7 @@
           (when-let [tx-data (last tx-data)]
             (vreset! offset (inc (:t tx-data))))
           tx-data)
-        (poll queue timeout))))
+        (poll! queue timeout))))
 
   Closeable
   (close [_]
@@ -86,6 +86,10 @@
     (.put queue tx-data)))
 
 
+(defn- assoc-local-payload [tx-data local-payload]
+  (cond-> tx-data local-payload (assoc :local-payload local-payload)))
+
+
 (defn- submit!
   "Stores `tx-cmds` and transfers them to pollers on queues.
 
@@ -93,26 +97,28 @@
   consisting of the new `t`, the current time taken from `clock` and `tx-cmds`.
   Has to be run in a single thread in order to deliver transaction data in
   order."
-  [kv-store clock state tx-cmds]
+  [kv-store clock state tx-cmds local-payload]
   (log/trace "submit" (count tx-cmds) "tx-cmds")
   (let [{:keys [t queues]} (swap! state update :t inc)
         tx-data {:t t :instant (Instant/now clock) :tx-cmds tx-cmds}]
     (store-tx-data! kv-store tx-data)
-    (transfer-tx-data! (vals queues) [tx-data])
+    (transfer-tx-data! (vals queues) [(assoc-local-payload tx-data local-payload)])
     t))
 
 
 ;; The state contains the following keys:
 ;;  * :t - the current point in time
 ;;  * :queues - a map of queues created through `new-queue`
-(deftype LocalTxLog [kv-store clock executor state]
+(deftype LocalTxLog [kv-store clock ^Lock submit-lock state]
   tx-log/TxLog
-  (-submit [_ tx-cmds]
-    ;; ensures that the submit function is executed in a single thread
-    (ac/supply-async
-      #(with-open [_ (prom/timer duration-seconds "submit")]
-         (submit! kv-store clock state tx-cmds))
-      executor))
+  (-submit [_ tx-cmds local-payload]
+    (.lock submit-lock)
+    (try
+      (-> (submit! kv-store clock state tx-cmds local-payload)
+          ba/try-anomaly
+          ac/completed-future)
+      (finally
+        (.unlock submit-lock))))
 
   (-last-t [_]
     (ac/completed-future (:t @state)))
@@ -147,22 +153,8 @@
 (defmethod ig/init-key :blaze.db.tx-log/local
   [_ {:keys [kv-store clock]}]
   (log/info "Open local transaction log")
-  (->LocalTxLog
-    kv-store
-    clock
-    ;; it's important to have a single thread executor here. See docs of submit
-    ;; function.
-    (ex/single-thread-executor "local-tx-log")
-    (atom {:t (or (last-t kv-store) 0)})))
-
-
-(defmethod ig/halt-key! :blaze.db.tx-log/local
-  [_ tx-log]
-  (log/info "Start closing local transaction log")
-  (let [executor (.executor ^LocalTxLog tx-log)]
-    (.shutdown ^ExecutorService executor)
-    (.awaitTermination ^ExecutorService executor 10 TimeUnit/SECONDS))
-  (log/info "Done closing local transaction log"))
+  (->LocalTxLog kv-store clock (ReentrantLock.)
+                (atom {:t (or (last-t kv-store) 0)})))
 
 
 (derive :blaze.db.tx-log/local :blaze.db/tx-log)

--- a/modules/db/test/blaze/db/node/resource_indexer_spec.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_spec.clj
@@ -11,13 +11,7 @@
     [blaze.db.resource-store.spec]
     [blaze.db.search-param-registry.spec]
     [blaze.fhir.spec-spec]
-    [clojure.spec.alpha :as s])
-  (:import
-    [clojure.lang IAtom]))
-
-
-(s/def :blaze.db.node/tx-resource-cache
-  #(instance? IAtom %))
+    [clojure.spec.alpha :as s]))
 
 
 (s/def :blaze.db.node/resource-indexer
@@ -30,8 +24,7 @@
 (s/def ::context
   (s/keys
     :req-un
-    [:blaze.db.node/tx-resource-cache
-     :blaze.db/resource-store
+    [:blaze.db/resource-store
      :blaze.db.node/resource-indexer]))
 
 

--- a/modules/db/test/blaze/db/node/resource_indexer_test.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_test.clj
@@ -82,8 +82,7 @@
           hash (hash/generate resource)
           resource-indexer (new-resource-indexer search-param-registry kv-store)
           context
-          {:tx-resource-cache (atom {})
-           :resource-store resource-store
+          {:resource-store resource-store
            :resource-indexer resource-indexer}]
       @(rs/put! resource-store {hash resource})
       @(ri/index-resources
@@ -218,8 +217,7 @@
           hash (hash/generate resource)
           resource-indexer (new-resource-indexer search-param-registry kv-store)
           context
-          {:tx-resource-cache (atom {})
-           :resource-store resource-store
+          {:resource-store resource-store
            :resource-indexer resource-indexer}]
       @(rs/put! resource-store {hash resource})
       @(ri/index-resources
@@ -324,8 +322,7 @@
                  :blaze.db/keys [search-param-registry]} system]
     (let [resource-indexer (new-resource-indexer search-param-registry kv-store)
           context
-          {:tx-resource-cache (atom {})
-           :resource-store resource-store
+          {:resource-store resource-store
            :resource-indexer resource-indexer}]
       @(ri/index-resources
          context

--- a/modules/kv/src/blaze/db/kv/mem.clj
+++ b/modules/kv/src/blaze/db/kv/mem.clj
@@ -222,6 +222,8 @@
 
 
 (defmethod ig/init-key ::kv/mem
-  [_ {:keys [column-families]}]
+  [_ {:keys [column-families init-data]}]
   (log/info "Open volatile, in-memory key-value store")
-  (->MemKvStore (atom (init-db (assoc column-families :default nil)))))
+  (let [store (->MemKvStore (atom (init-db (assoc column-families :default nil))))]
+    (some->> init-data (kv/put! store))
+    store))

--- a/modules/kv/test/blaze/db/kv/mem_test.clj
+++ b/modules/kv/test/blaze/db/kv/mem_test.clj
@@ -47,9 +47,8 @@
 
 
 (defmacro with-system-data [[binding-form system] entries & body]
-  `(with-system [system# ~system]
-     (kv/put! (::kv/mem system#) ~entries)
-     (let [~binding-form system#] ~@body)))
+  `(with-system [~binding-form (assoc-in ~system [::kv/mem :init-data] ~entries)]
+     ~@body))
 
 
 (defn- ba [& bytes]


### PR DESCRIPTION
The node had a transaction resource cache that stores resources of a
transaction by t. The node puts the resources after the transaction was
submitted successfully. However sometimes the node gets back the tx-data
from the transaction log before it puts the resources in the cache.

I removed this cache completely and send the resources as local payload
through the local transaction log. The Kafka transaction log on the
other hand doesn't transfer the resources.