### PR TITLE
Fix Decoding of Delete Command

### DIFF
--- a/modules/db/src/blaze/db/tx_log/local/codec.clj
+++ b/modules/db/src/blaze/db/tx_log/local/codec.clj
@@ -44,8 +44,10 @@
       (log/warn (parse-cbor-error-msg t e)))))
 
 
-(defn- decode-hash [tx-cmd]
-  (update tx-cmd :hash bs/from-byte-array))
+(defn- decode-hash [{:keys [hash] :as tx-cmd}]
+  (if hash
+    (assoc tx-cmd :hash (bs/from-byte-array hash))
+    tx-cmd))
 
 
 (defn- decode-instant [x]

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -135,7 +135,8 @@
                       (codec/encode-tx-data
                         (Instant/ofEpochSecond 0)
                         [{:op "create" :type "Patient" :id "0"
-                          :hash patient-hash-0}])]])]
+                          :hash patient-hash-0}
+                         {:op "delete" :type "Patient" :id "1"}])]])]
 
       (testing "the last `t` is one"
         (is (= 1 @(tx-log/last-t tx-log))))


### PR DESCRIPTION
Introduced in #469 we have no longer hashed in the delete command.
However, in the local transaction log implementation, we still try to
decode the hash. This fix has to be merged into the 0.12.0 release
branch.