### PR TITLE
Improve CQL Documentation

### DIFF
--- a/modules/cql/src/blaze/elm/aggregates.clj
+++ b/modules/cql/src/blaze/elm/aggregates.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.aggregates
+  "21. Aggregate Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.protocols :as p]))
 

--- a/modules/cql/src/blaze/elm/compiler/aggregate_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/aggregate_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.aggregate-operators
-  "21. Aggregate Operators"
+  "21. Aggregate Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.aggregates :as aggregates]
     [blaze.elm.compiler.macros :refer [defaggop]]

--- a/modules/cql/src/blaze/elm/compiler/arithmetic_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/arithmetic_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.arithmetic-operators
-  "16. Arithmetic Operators"
+  "16. Arithmetic Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.clinical-operators
-  "23. Clinical Operators"
+  "23. Clinical Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.core :as core]
     [blaze.elm.protocols :as p]))

--- a/modules/cql/src/blaze/elm/compiler/clinical_values.clj
+++ b/modules/cql/src/blaze/elm/compiler/clinical_values.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.clinical-values
-  "3. Clinical Values"
+  "3. Clinical Values
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.code :as code]

--- a/modules/cql/src/blaze/elm/compiler/comparison_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/comparison_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.comparison-operators
-  "12. Comparison Operators"
+  "12. Comparison Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.core :as core]
     [blaze.elm.compiler.macros :refer [defbinop]]

--- a/modules/cql/src/blaze/elm/compiler/conditional_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/conditional_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.conditional-operators
-  "15. Conditional Operators"
+  "15. Conditional Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.core :as core]
     [blaze.elm.protocols :as p]))

--- a/modules/cql/src/blaze/elm/compiler/core.clj
+++ b/modules/cql/src/blaze/elm/compiler/core.clj
@@ -12,7 +12,9 @@
 
 
 (defprotocol Expression
-  (-eval [this context resource scope]))
+  (-eval [expression context resource scope]
+    "Evaluates `expression` on `resource` using `context` and optional `scope`
+    for scoped expressions like inside queries."))
 
 
 (defn expr? [x]

--- a/modules/cql/src/blaze/elm/compiler/date_time_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/date_time_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.date-time-operators
-  "18. Date and Time Operators"
+  "18. Date and Time Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/src/blaze/elm/compiler/external_data.clj
+++ b/modules/cql/src/blaze/elm/compiler/external_data.clj
@@ -1,7 +1,8 @@
 (ns blaze.elm.compiler.external-data
   "11. External Data
 
-  https://cql.hl7.org/04-logicalspecification.html#external-data"
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.db.api :as d]

--- a/modules/cql/src/blaze/elm/compiler/interval_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/interval_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.interval-operators
-  "19. Interval Operators"
+  "19. Interval Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.arithmetic-operators :as ao]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/src/blaze/elm/compiler/list_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/list_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.list-operators
-  "20. List Operators"
+  "20. List Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba]
     [blaze.coll.core :as coll]

--- a/modules/cql/src/blaze/elm/compiler/logical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/logical_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.logical-operators
-  "13. Logical Operators"
+  "13. Logical Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.core :as core]
     [blaze.elm.compiler.macros :refer [defunop]]))

--- a/modules/cql/src/blaze/elm/compiler/nullological_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/nullological_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.nullological-operators
-  "14. Nullological Operators"
+  "14. Nullological Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.core :as core]
     [blaze.elm.compiler.macros :refer [defunop]]))

--- a/modules/cql/src/blaze/elm/compiler/parameters.clj
+++ b/modules/cql/src/blaze/elm/compiler/parameters.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.parameters
-  "7. Parameters"
+  "7. Parameters
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.compiler.core :as core]))

--- a/modules/cql/src/blaze/elm/compiler/queries.clj
+++ b/modules/cql/src/blaze/elm/compiler/queries.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.queries
-  "10. Queries"
+  "10. Queries
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:refer-clojure :exclude [comparator])
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]

--- a/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
+++ b/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.reusing-logic
-  "9. Reusing Logic"
+  "9. Reusing Logic
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.db.api :as d]

--- a/modules/cql/src/blaze/elm/compiler/simple_values.clj
+++ b/modules/cql/src/blaze/elm/compiler/simple_values.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.simple-values
-  "1. Simple Values"
+  "1. Simple Values
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/src/blaze/elm/compiler/string_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/string_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.string-operators
-  "17. String Operators"
+  "17. String Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler.core :as core]
     [blaze.elm.compiler.macros :refer [defbinop defnaryop defternop defunop]]

--- a/modules/cql/src/blaze/elm/compiler/structured_values.clj
+++ b/modules/cql/src/blaze/elm/compiler/structured_values.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.structured-values
-  "2. Structured Values"
+  "2. Structured Values
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.coll.core :as coll]

--- a/modules/cql/src/blaze/elm/compiler/type_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/type_operators.clj
@@ -1,5 +1,8 @@
 (ns blaze.elm.compiler.type-operators
-  "22. Type Operators"
+  "22. Type Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/src/blaze/elm/expression.clj
+++ b/modules/cql/src/blaze/elm/expression.clj
@@ -4,5 +4,7 @@
     [blaze.elm.compiler.core :as core]))
 
 
-(defn eval [expression context resource scope]
-  (core/-eval expression context resource scope))
+(defn eval
+  "Evaluates `expression` on `resource` using `context`."
+  [context expression resource]
+  (core/-eval expression context resource nil))

--- a/modules/cql/src/blaze/elm/expression_spec.clj
+++ b/modules/cql/src/blaze/elm/expression_spec.clj
@@ -25,12 +25,8 @@
           :opt-un [::library-context ::parameters]))
 
 
-(s/def :blaze.elm.expression/scope
-  any?)
-
-
 (s/fdef expr/eval
-  :args (s/cat :expression :blaze.elm.compiler/expression
-               :context :blaze.elm.expression/context
-               :resource (s/nilable (s/or :resource :blaze/resource :resource-handle :blaze.db/resource-handle))
-               :scope (s/nilable :blaze.elm.expression/scope)))
+  :args (s/cat :context :blaze.elm.expression/context
+               :expression :blaze.elm.compiler/expression
+               :resource (s/nilable (s/or :resource :blaze/resource
+                                          :resource-handle :blaze.db/resource-handle))))

--- a/modules/cql/test/blaze/cql_test.clj
+++ b/modules/cql/test/blaze/cql_test.clj
@@ -39,8 +39,8 @@
     {:spec
      {`expr/eval
       (s/fspec
-        :args (s/cat :expression :blaze.elm.compiler/expression
-                     :context map? :resource nil? :scope nil?))}})
+        :args (s/cat :context map? :expression :blaze.elm.compiler/expression
+                     :resource nil?))}})
   (f)
   (st/unstrument))
 
@@ -83,7 +83,7 @@
 
 
 (defn eval-elm [now elm]
-  (expr/eval (compile {} elm) {:now now} nil nil))
+  (expr/eval {:now now} (compile {} elm) nil))
 
 
 (defn eval [now cql]

--- a/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.aggregate-operators-test
+  "21. Aggregate Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.aggregate-operators]

--- a/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.arithmetic-operators-test
+  "16. Arithmetic Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.arithmetic-operators-spec]

--- a/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.clinical-operators-test
+  "23. Clinical Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.clinical-operators]

--- a/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.clinical-values-test
+  "3. Clinical Values
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba]
     [blaze.elm.code-spec]

--- a/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.comparison-operators-test
+  "12. Comparison Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.comparison-operators]

--- a/modules/cql/test/blaze/elm/compiler/conditional_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/conditional_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.conditional-operators-test
+  "15. Conditional Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.test-util :as tu]

--- a/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.date-time-operators-test
+  "18. Date and Time Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/test/blaze/elm/compiler/external_data_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/external_data_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.external-data-test
+  "11. External Data
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.db.api :as d]
     [blaze.db.api-stub :refer [mem-node-system with-system-data]]

--- a/modules/cql/test/blaze/elm/compiler/interval_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/interval_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.interval-operators-test
+  "19. Interval Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/test/blaze/elm/compiler/list_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/list_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.list-operators-test
+  "20. List Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly-spec]
     [blaze.elm.compiler :as c]
@@ -8,8 +12,11 @@
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
     [blaze.elm.quantity :as quantity]
+    [blaze.test-util :refer [satisfies-prop]]
+    [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [are deftest testing]]))
+    [clojure.test :as test :refer [are deftest testing]]
+    [clojure.test.check.properties :as prop]))
 
 
 (st/instrument)
@@ -68,11 +75,17 @@
 ;; It is an error to invoke the Current operator outside the context of a scoped
 ;; operation.
 (deftest compile-current-test
-  (are [x] (= x (core/-eval (c/compile {} {:type "Current"}) {} nil x))
-    1)
+  (testing "default scope"
+    (satisfies-prop 100
+    (prop/for-all [x (s/gen int?)]
+      (= x (core/-eval (c/compile {} {:type "Current"}) {} nil x)))))
 
-  (are [x] (= x (core/-eval (c/compile {} {:type "Current" :scope "A"}) {} nil {"A" x}))
-    1))
+  (testing "named scope"
+    (satisfies-prop 100
+    (prop/for-all [scope (s/gen string?)
+                   x (s/gen int?)]
+      (let [expr (c/compile {} {:type "Current" :scope scope})]
+        (= x (core/-eval expr {} nil {scope x})))))))
 
 
 ;; 20.4. Distinct

--- a/modules/cql/test/blaze/elm/compiler/logical_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/logical_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.logical-operators-test
+  "13. Logical Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.logical-operators]

--- a/modules/cql/test/blaze/elm/compiler/nullological_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/nullological_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.nullological-operators-test
+  "14. Nullological Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/test/blaze/elm/compiler/parameters_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/parameters_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.parameters-test
+  "7. Parameters
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba]
     [blaze.elm.code-spec]

--- a/modules/cql/test/blaze/elm/compiler/queries_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/queries_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.queries-test
+  "10. Queries
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.db.api :as d]
     [blaze.db.api-stub :refer [mem-node-system with-system-data]]

--- a/modules/cql/test/blaze/elm/compiler/reusing_logic_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/reusing_logic_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.reusing-logic-test
+  "9. Reusing Logic
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba]
     [blaze.elm.compiler :as c]

--- a/modules/cql/test/blaze/elm/compiler/simple_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/simple_values_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.simple-values-test
+  "1. Simple Values
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.test-util :as tu]

--- a/modules/cql/test/blaze/elm/compiler/string_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/string_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.string-operators-test
+  "17. String Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.core :as core]

--- a/modules/cql/test/blaze/elm/compiler/structured_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/structured_values_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.structured-values-test
+  "2. Structured Values
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.coll.core :as coll]
     [blaze.elm.code-spec]

--- a/modules/cql/test/blaze/elm/compiler/type_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/type_operators_test.clj
@@ -1,4 +1,8 @@
 (ns blaze.elm.compiler.type-operators-test
+  "22. Type Operators
+
+  Section numbers are according to
+  https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.clinical-operators]

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
@@ -34,7 +34,7 @@
 (defn- evaluate-expression-1
   [{:keys [library-context] :as context} subject-handle expression-name]
   (try
-    (expr/eval (get library-context expression-name) context subject-handle nil)
+    (expr/eval context (get library-context expression-name) subject-handle)
     (catch Exception e
       (log/error (log/stacktrace e))
       (ba/fault

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
@@ -53,7 +53,7 @@
 
 
 (defn- failing-eval [msg]
-  (fn [_ _ _ _] (throw (Exception. ^String msg))))
+  (fn [_ _ _] (throw (Exception. ^String msg))))
 
 
 (deftest evaluate-expression-test


### PR DESCRIPTION
Removed the scope from the eval function because it is not used only internally. Also put the context first, because it is usual to have the context first.