### PR TITLE
Fix DB Sync After Failing Transaction

### DIFF
--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -30,7 +30,7 @@
   "Used to coordinate with other nodes.
 
   When called with `t`, returns a CompletionStage that completes with the
-  database value with at least the point in time `t` is available. Does not
+  database value with at least the point in time `t` available. Does not
   communicate with the transaction log. Simply waits for the database value
   becoming available.
 


### PR DESCRIPTION
If `d/sync` waits on a t that will resolve to a failed transaction, it never returned. So all reads after a failed transaction timed out.

I extended the Jepsen tests to include failing writes.