### PR TITLE
Fix Encoding of Parameters at Operation POST Requests

### DIFF
--- a/.github/scripts/evaluate-measure-subject-list.sh
+++ b/.github/scripts/evaluate-measure-subject-list.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# Usage: ./evaluate-measure-subject-list.sh -f <query>.cql <expected-count>
+
+# Takes a CQL file, creates a Library resource from it, references that from a
+# Measure resource and calls $evaluate-measure with reportType subject-list on it.
+
+library() {
+cat <<END
+{
+  "resourceType": "Library",
+  "status": "active",
+  "type" : {
+    "coding" : [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/library-type",
+        "code" : "logic-library"
+      }
+    ]
+  },
+  "content": [
+    {
+      "contentType": "text/cql"
+    }
+  ]
+}
+END
+}
+
+measure() {
+cat <<END
+{
+  "resourceType": "Measure",
+  "status": "active",
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+        "code": "cohort"
+      }
+    ]
+  },
+  "group": [
+    {
+      "population": [
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "InInitialPopulation"
+          }
+        }
+      ]
+    }
+  ]
+}
+END
+}
+
+parameters() {
+cat <<END
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "periodStart",
+      "value": "2000"
+    },
+    {
+      "name": "periodEnd",
+      "value": "2030"
+    },
+    {
+      "name": "reportType",
+      "value": "subject-list"
+    }
+  ]
+}
+END
+}
+
+create-library() {
+  library | jq -cM ".url = \"urn:uuid:$1\" | .content[0].data = \"$2\""
+}
+
+create-measure() {
+  measure | jq -cM ".url = \"urn:uuid:$1\" | .library[0] = \"urn:uuid:$2\""
+}
+
+post() {
+  curl -sH "Content-Type: application/fhir+json" -d @- "http://localhost:8080/fhir/$1"
+}
+
+evaluate-measure() {
+  parameters | curl -sH "Content-Type: application/fhir+json" -d @- "http://localhost:8080/fhir/Measure/$1/\$evaluate-measure"
+}
+
+fetch-patients() {
+  curl -s "http://localhost:8080/fhir/Patient?_list=$1&_count=100"
+}
+
+FILE=$1
+EXPECTED_COUNT=$2
+
+DATA=$(base64 "$FILE" | tr -d '\n')
+LIBRARY_URI=$(uuidgen | tr '[:upper:]' '[:lower:]')
+MEASURE_URI=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+create-library "$LIBRARY_URI" "$DATA" | post "Library" > /dev/null
+
+MEASURE_ID=$(create-measure "$MEASURE_URI" "$LIBRARY_URI" | post "Measure" | jq -r .id)
+REPORT=$(evaluate-measure "$MEASURE_ID")
+COUNT=$(echo "$REPORT" | jq -r ".group[0].population[0].count")
+
+if [ "$COUNT" = "$EXPECTED_COUNT" ]; then
+  echo "Success: count ($COUNT) equals the expected count"
+else
+  echo "Fail: count ($COUNT) != $EXPECTED_COUNT"
+  echo "Report:"
+  echo "$REPORT" | jq .
+  exit 1
+fi
+
+LIST_ID=$(echo "$REPORT" | jq -r '.group[0].population[0].subjectResults.reference | split("/")[1]')
+PATIENT_BUNDLE=$(fetch-patients "$LIST_ID")
+ID_COUNT=$(echo "$PATIENT_BUNDLE" | jq -r ".entry[].resource.id" | sort -u | wc -l | xargs | cut -d ' ' -f1)
+
+if [ "$ID_COUNT" = "$EXPECTED_COUNT" ]; then
+  echo "Success: downloaded patient count ($ID_COUNT) equals the expected count"
+else
+  echo "Fail: downloaded patient count ($ID_COUNT) != $EXPECTED_COUNT"
+  echo "Patient bundle:"
+  echo "$PATIENT_BUNDLE" | jq .
+  exit 1
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,17 +383,29 @@ jobs:
     - name: Evaluate CQL Query 1
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q1-query.cql 56
 
+    - name: Evaluate CQL Query 1 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q1-query.cql 56
+
     - name: Evaluate CQL Query 1 on Individual Patients
       run: .github/scripts/evaluate-patient-q1-measure.sh
 
     - name: Evaluate CQL Query 2
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q2-query.cql 42
 
+    - name: Evaluate CQL Query 2 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q2-query.cql 42
+
     - name: Evaluate CQL Query 7
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7-query.cql 81
 
+    - name: Evaluate CQL Query 7 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7-query.cql 81
+
     - name: Evaluate CQL Query 14
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14-query.cql 96
+
+    - name: Evaluate CQL Query 14 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14-query.cql 96
 
     - name: Forwarded Header HTTPS
       run: .github/scripts/forwarded-header.sh https
@@ -636,17 +648,29 @@ jobs:
     - name: Evaluate CQL Query 1
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q1-query.cql 56
 
+    - name: Evaluate CQL Query 1 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q1-query.cql 56
+
     - name: Evaluate CQL Query 1 on Individual Patients
       run: .github/scripts/evaluate-patient-q1-measure.sh
 
     - name: Evaluate CQL Query 2
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q2-query.cql 42
 
+    - name: Evaluate CQL Query 2 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q2-query.cql 42
+
     - name: Evaluate CQL Query 7
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7-query.cql 81
 
+    - name: Evaluate CQL Query 7 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7-query.cql 81
+
     - name: Evaluate CQL Query 14
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14-query.cql 96
+
+    - name: Evaluate CQL Query 14 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14-query.cql 96
 
     - name: Forwarded Header HTTPS
       run: .github/scripts/forwarded-header.sh https

--- a/docs/cql-queries/api.md
+++ b/docs/cql-queries/api.md
@@ -159,7 +159,7 @@ Under `group[0].population[0].count` the result of the query can be found.
 By default, the evaluation results in a MeasureReport of type `summary`. Such a MeasureReport contains only the number of resources of each population. However, if you also need the resources itself, you can have a MeasureReport of type `subject-list` generated. This works as follows:
 
 ```sh
-curl -sXPOST 'http://localhost:8080/fhir/Measure/$evaluate-measure?measure=urn:uuid:49f4c7de-3320-4208-8e60-ecc0d8824e08&periodStart=2000&periodEnd=2030&reportType=subject-list'
+curl -sd '{"resourceType": "Parameters", "parameter": [{"name": "periodStart", "value": "2000"}, {"name": "periodEnd", "value": "2030"}, {"name": "measure", "value": "urn:uuid:49f4c7de-3320-4208-8e60-ecc0d8824e08"}, {"name": "reportType", "value": "subject-list"}]}' -H "Content-Type: application/fhir+json" 'http://localhost:8080/fhir/Measure/$evaluate-measure'
 ```
 
 the result should be the following MeasureReport:

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
@@ -78,7 +78,7 @@
 
 
 (defn- find-measure-handle*
-  [db {{:keys [id]} :path-params {:strs [measure]} :params}]
+  [db {{:keys [id]} :path-params {:keys [measure]} ::params}]
   (cond
     id
     (d/resource-handle db "Measure" id)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -127,7 +127,7 @@
 
 (deftest handler-test
   (testing "Returns Not Found on Non-Existing Measure"
-    (testing "on type endpoint"
+    (testing "on instance endpoint"
       (with-handler [handler]
         []
         (let [{:keys [status body]}
@@ -143,7 +143,7 @@
             :severity := #fhir/code"error"
             :code := #fhir/code"not-found"))))
 
-    (testing "on instance endpoint"
+    (testing "on type endpoint"
       (with-handler [handler]
         []
         (let [{:keys [status body]}
@@ -443,10 +443,18 @@
           (let [{:keys [status headers body]}
                 @(handler
                   {:request-method :post
-                   :params
-                   {"measure" "url-181501"
-                    "periodStart" "2014"
-                    "periodEnd" "2015"}})]
+                   :body
+                   {:fhir/type :fhir/Parameters
+                    :parameter
+                    [{:fhir/type :fhir.Parameters/parameter
+                      :name "measure"
+                      :value "url-181501"}
+                     {:fhir/type :fhir.Parameters/parameter
+                      :name "periodStart"
+                      :value #fhir/date"2014"}
+                     {:fhir/type :fhir.Parameters/parameter
+                      :name "periodEnd"
+                      :value #fhir/date"2015"}]}})]
 
             (is (= 201 status))
 
@@ -505,9 +513,15 @@
                 @(handler
                   {:request-method :post
                    :path-params {:id "0"}
-                   :params
-                   {"periodStart" "2014"
-                    "periodEnd" "2015"}})]
+                   :body
+                   {:fhir/type :fhir/Parameters
+                    :parameter
+                    [{:fhir/type :fhir.Parameters/parameter
+                      :name "periodStart"
+                      :value #fhir/date"2014"}
+                     {:fhir/type :fhir.Parameters/parameter
+                      :name "periodEnd"
+                      :value #fhir/date"2015"}]}})]
 
             (is (= 201 status))
 

--- a/modules/rest-api/test/blaze/rest_api/routes_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/routes_test.clj
@@ -34,7 +34,6 @@
                   {:handler (fn [_] ::read)}}}]
         {:kind "resource" :name "Patient"})
       [0] := "/Patient"
-      [1 :middleware] := []
       [1 :fhir.resource/type] := "Patient"
       [2] := ["" {:name :Patient/type}]
       [3] := ["/_history" {:conflicting true}]

--- a/modules/rest-api/test/blaze/rest_api_test.clj
+++ b/modules/rest-api/test/blaze/rest_api_test.clj
@@ -167,11 +167,11 @@
       "/Patient/0/Condition" :get [:params :forwarded :db]
       "/Patient/0/Observation" :get [:params :forwarded :db]
       "/$compact-db" :get [:params :forwarded :db]
-      "/$compact-db" :post [:params :forwarded :db]
+      "/$compact-db" :post [:params :forwarded :db :resource]
       "/Measure/$evaluate-measure" :get [:params :forwarded :db]
-      "/Measure/$evaluate-measure" :post [:params :forwarded :db]
+      "/Measure/$evaluate-measure" :post [:params :forwarded :db :resource]
       "/Measure/0/$evaluate-measure" :get [:params :forwarded :db]
-      "/Measure/0/$evaluate-measure" :post [:params :forwarded :db]
+      "/Measure/0/$evaluate-measure" :post [:params :forwarded :db :resource]
       "/Measure/0" :get [:params :forwarded :db])
 
     (testing "with auth backends"
@@ -184,11 +184,11 @@
         "" :get [:params :forwarded :auth-guard :db]
         "" :post [:params :forwarded :auth-guard :resource :wrap-batch-handler]
         "/$compact-db" :get [:params :forwarded :auth-guard :db]
-        "/$compact-db" :post [:params :forwarded :auth-guard :db]
+        "/$compact-db" :post [:params :forwarded :auth-guard :db :resource]
         "/Measure/$evaluate-measure" :get [:params :forwarded :auth-guard :db]
-        "/Measure/$evaluate-measure" :post [:params :forwarded :auth-guard :db]
+        "/Measure/$evaluate-measure" :post [:params :forwarded :auth-guard :db :resource]
         "/Measure/0/$evaluate-measure" :get [:params :forwarded :auth-guard :db]
-        "/Measure/0/$evaluate-measure" :post [:params :forwarded :auth-guard :db])))
+        "/Measure/0/$evaluate-measure" :post [:params :forwarded :auth-guard :db :resource])))
 
   (testing "Patient instance POST is not allowed"
     (given @((reitit.ring/ring-handler (router []) handler-util/default-handler)


### PR DESCRIPTION
At POST the Parameters resource is used instead of URL-encoded params.