### PR TITLE
Migrate from Closeable to AutoCloseable

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,7 +39,7 @@ Such components reside in a namespace. There exists a constructor function calle
     [clojure.spec.alpha :as s]
     [integrant.core :as ig])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (defn new-node
@@ -60,10 +60,10 @@ Such components reside in a namespace. There exists a constructor function calle
 (defmethod ig/halt-key! :blaze.db/node
   [_ node]
   (log/info "Close local database node")
-  (.close ^Closeable node))
+  (.close ^AutoCloseable node))
 ```
 
-In this example, you can see the `new-node` function which gets two dependencies `dep-a` and `dep-b` which could be config values or other components. The function returns the database node itself. In our case the database node holds resources which should be freed when it is no longer needed. A common idiom is to implement `java.io.Closeable` and call the `.close` method at the end of usage.
+In this example, you can see the `new-node` function which gets two dependencies `dep-a` and `dep-b` which could be config values or other components. The function returns the database node itself. In our case the database node holds resources which should be freed when it is no longer needed. A common idiom is to implement `java.lang.AutoCloseable` and call the `.close` method at the end of usage.
 
 While the pair of the function `new-node` and the method `.close` can be used in tests, integrant is used in production. In the example, you can see the multi-method instances `ig/pre-init-spec`, `ig/init-key` and `ig/halt-key!`. First `ig/pre-init-spec` is used to provide a spec for the dependency map `ig/init-key` receives. The spec is created using the `s/keys` form in order to validate a map. Second the `ig/init-key` method will be called by integrant when the component with the :blaze.db/node key is initialized. In this method we simply call our `new-node` function, passing all dependencies from the map as arguments. In addition to that we log a meaningful message at info level in order to make the startup of Blaze transparent. It's also a good idea to log out any config values here. Last the method `ig/halt-key!` is used to free any resources our component might hold. Here we call our `.close` on the component instance passed.
 

--- a/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
+++ b/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
@@ -16,7 +16,7 @@
     [prometheus.alpha :as prom :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]
+    [java.lang AutoCloseable]
     [java.nio ByteBuffer]))
 
 
@@ -152,7 +152,7 @@
     (log/trace "put" (count entries) "entries")
     (ac/all-of (execute-multi-put session put-statement entries)))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (cass/close session)))
 
@@ -186,7 +186,7 @@
 (defmethod ig/halt-key! ::rs/cassandra
   [_ store]
   (log/info "Close Cassandra resource store")
-  (.close ^Closeable store))
+  (.close ^AutoCloseable store))
 
 
 (derive ::rs/cassandra :blaze.db/resource-store)

--- a/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka.clj
+++ b/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka.clj
@@ -15,7 +15,7 @@
     [prometheus.alpha :as prom :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]
+    [java.lang AutoCloseable]
     [java.time Duration]
     [java.util Map]
     [java.util.concurrent TimeUnit ExecutorService]
@@ -106,10 +106,10 @@
       (.seek ^Consumer consumer tx-partition ^long (dec offset))
       consumer))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (.close producer)
-    (.close ^Closeable last-t-consumer)))
+    (.close ^AutoCloseable last-t-consumer)))
 
 
 (extend-protocol tx-log/Queue
@@ -145,7 +145,7 @@
 (defmethod ig/halt-key! :blaze.db.tx-log/kafka
   [_ tx-log]
   (log/info "Closing Kafka transaction log...")
-  (.close ^Closeable tx-log)
+  (.close ^AutoCloseable tx-log)
   (log/info "Kafka transaction log was closed successfully"))
 
 

--- a/modules/db-tx-log/src/blaze/db/tx_log.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.tx-log
   "Protocols for transaction log backend implementations."
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (defprotocol TxLog
@@ -45,7 +45,7 @@
   "Returns a new queue starting at `offset`.
 
   The queue has to be closed after usage."
-  ^Closeable
+  ^AutoCloseable
   [tx-log offset]
   (-new-queue tx-log offset))
 

--- a/modules/db-tx-log/test/blaze/db/tx_log_test.clj
+++ b/modules/db-tx-log/test/blaze/db/tx_log_test.clj
@@ -8,8 +8,8 @@
     [clojure.test :as test :refer [is deftest]]
     [java-time :as time])
   (:import
-    [java.time Instant]
-    [java.io Closeable]))
+    [java.lang AutoCloseable]
+    [java.time Instant]))
 
 
 (st/instrument)
@@ -63,7 +63,7 @@
                      tx-log/Queue
                      (-poll [_ _]
                        [tx-data])
-                     Closeable
+                     AutoCloseable
                      (close [_]))))]
     (with-open [queue (tx-log/new-queue tx-log 1)]
       (is (= [tx-data] (tx-log/poll! queue (time/millis 100)))))))

--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -15,7 +15,7 @@
     [blaze.db.impl.protocols :as p]
     [blaze.db.node.protocols :as np])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (defn db
@@ -156,7 +156,7 @@
 
 
 (defn compile-type-query
-  "Same as `type-query` but in a two step process of pre-compilation and later
+  "Same as `type-query` but in a two-step process of pre-compilation and later
   execution by `execute-query`.
 
   Returns an anomaly if search parameters in clauses can't be resolved."
@@ -208,7 +208,7 @@
 
 
 (defn compile-system-query
-  "Same as `system-query` but in a two step process of pre-compilation and later
+  "Same as `system-query` but in a two-step process of pre-compilation and later
   execution by `execute-query`.
 
   Returns an anomaly if search parameters in clauses can't be resolved."
@@ -263,9 +263,9 @@
 
 
 (defn compile-compartment-query
-  "Same as `compartment-query` but in a two step process of pre-compilation and
-  later execution by `execute-query`. The `id` of the compartments resource will
-  be supplied as argument to `execute-query`.
+  "Same as `compartment-query` but in a two-step process of pre-compilation and
+  later execution by `execute-query`. The `id` of the compartments' resource
+  will be supplied as argument to `execute-query`.
 
   Returns an anomaly if search parameters in clauses can't be resolved."
   [node-or-db code type clauses]
@@ -313,7 +313,7 @@
   `type` and `id` starting as-of `db` in reverse chronological order.
 
   The history optionally starts at `start-t` which defaults to the `t` of `db`.
-  Additionally a `since` instant can be given to define a point in the past
+  Additionally, a `since` instant can be given to define a point in the past
   where the history should start into the present.
 
   History entries are resource handles. Please use `pull-many` to obtain the
@@ -350,7 +350,7 @@
   `type` starting as-of `db` in reverse chronological order.
 
   The history optionally starts at `start-t` which defaults to the `t` of `db`.
-  Additionally a `since` instant can be given to define a point in the past
+  Additionally, a `since` instant can be given to define a point in the past
   where the history should start into the present.
 
   History entries are resource handles. Please use `pull-many` to obtain the
@@ -387,7 +387,7 @@
   `db` in reverse chronological order.
 
   The history optionally starts at `start-t` which defaults to the `t` of `db`.
-  Additionally a `since` instant can be given to define a point in the past
+  Additionally, a `since` instant can be given to define a point in the past
   where the history should start into the present.
 
   History entries are resource handles. Please use `pull-many` to obtain the
@@ -457,7 +457,7 @@
 
   The batch database has to be closed after usage, because it holds resources
   that have to be freed."
-  ^Closeable
+  ^AutoCloseable
   [db]
   (p/-new-batch-db db))
 

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -20,7 +20,8 @@
     [blaze.db.impl.search-param.util :as u]
     [blaze.db.kv :as kv])
   (:import
-    [java.io Closeable Writer]
+    [java.io Writer]
+    [java.lang AutoCloseable]
     [clojure.lang IReduceInit]))
 
 
@@ -225,15 +226,15 @@
   (-pull-many [_ resource-handles]
     (p/-pull-many node resource-handles))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (let [{:keys [snapshot raoi svri rsvi cri csvri]} context]
-      (.close ^Closeable raoi)
-      (.close ^Closeable svri)
-      (.close ^Closeable rsvi)
-      (.close ^Closeable cri)
-      (.close ^Closeable csvri)
-      (.close ^Closeable snapshot))))
+      (.close ^AutoCloseable raoi)
+      (.close ^AutoCloseable svri)
+      (.close ^AutoCloseable rsvi)
+      (.close ^AutoCloseable cri)
+      (.close ^AutoCloseable csvri)
+      (.close ^AutoCloseable snapshot))))
 
 
 (defmethod print-method BatchDb [^BatchDb db ^Writer w]
@@ -294,7 +295,7 @@
   A batch database can be used instead of a normal database. It's functionally
   the same. Only the performance for multiple calls differs. It's not thread
   save and has to be closed after usage because it holds open iterators."
-  ^Closeable
+  ^AutoCloseable
   [{:keys [kv-store rh-cache] :as node} basis-t t]
   (let [snapshot (kv/new-snapshot kv-store)]
     (->BatchDb

--- a/modules/db/src/blaze/db/impl/index/system_stats.clj
+++ b/modules/db/src/blaze/db/impl/index/system_stats.clj
@@ -18,7 +18,7 @@
     [blaze.db.impl.codec :as codec]
     [blaze.db.kv :as kv])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -29,7 +29,7 @@
   "Returns the iterator of the system stats index.
 
   Has to be closed after usage."
-  ^Closeable [snapshot]
+  ^AutoCloseable [snapshot]
   (kv/new-iterator snapshot :system-stats-index))
 
 

--- a/modules/db/src/blaze/db/impl/index/type_stats.clj
+++ b/modules/db/src/blaze/db/impl/index/type_stats.clj
@@ -19,7 +19,7 @@
     [blaze.db.impl.codec :as codec]
     [blaze.db.kv :as kv])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -30,7 +30,7 @@
   "Returns the iterator of the type stats index.
 
   Has to be closed after usage."
-  ^Closeable [snapshot]
+  ^AutoCloseable [snapshot]
   (kv/new-iterator snapshot :type-stats-index))
 
 

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -35,7 +35,7 @@
     [prometheus.alpha :as prom :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]
+    [java.lang AutoCloseable]
     [java.util.concurrent TimeUnit ExecutorService CompletableFuture]))
 
 
@@ -338,7 +338,7 @@
         (ac/complete! finished true)
         (log/trace "exit indexer"))))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (log/trace "start closing")
     (vreset! run? false)
@@ -389,7 +389,7 @@
 (defmethod ig/halt-key! :blaze.db/node
   [_ node]
   (log/info "Close local database node")
-  (.close ^Closeable node))
+  (.close ^AutoCloseable node))
 
 
 (defmethod ig/init-key ::indexer-executor

--- a/modules/db/src/blaze/db/tx_log/local.clj
+++ b/modules/db/src/blaze/db/tx_log/local.clj
@@ -2,7 +2,7 @@
   "A transaction log which is suitable only for standalone (single node) setups.
 
   Uses an exclusive key-value store to persist the transaction log using the
-  default column family. The single key-value index is populated were keys are
+  default column family. The single key-value index is populated where keys are
   the point in time `t` of the transaction and the values are transaction
   commands and instants.
 
@@ -24,7 +24,7 @@
     [prometheus.alpha :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]
+    [java.lang AutoCloseable]
     [java.time Instant]
     [java.util.concurrent ArrayBlockingQueue BlockingQueue TimeUnit]
     [java.util.concurrent.locks Lock ReentrantLock]))
@@ -69,7 +69,7 @@
           tx-data)
         (poll! queue timeout))))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (log/trace "close queue")
     (unsubscribe!)))

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -24,7 +24,7 @@
     [taoensso.timbre :as log])
   (:import
     [com.fasterxml.jackson.dataformat.cbor CBORFactory]
-    [java.io Closeable]
+    [java.lang AutoCloseable]
     [java.time Instant]))
 
 
@@ -69,9 +69,9 @@
             (-seek-to-last [_])
             (-seek [_ _])
             (-valid [_] false)
-            Closeable
+            AutoCloseable
             (close [_])))
-        Closeable
+        AutoCloseable
         (close [_])))
     (-put [_ _ _]
       (throw (Exception. "put-error")))))

--- a/modules/kv/src/blaze/db/kv.clj
+++ b/modules/kv/src/blaze/db/kv.clj
@@ -4,7 +4,7 @@
   All functions block the current thread while doing I/O."
   (:refer-clojure :exclude [get key])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (defprotocol KvIterator
@@ -156,11 +156,13 @@
   "Return an iterator over the contents of the database.
 
   The result is initially invalid, so the caller must call one of the seek
-  functions with the iterator before using it."
-  (^Closeable
+  functions with the iterator before using it.
+
+  Iterators have to be closed after usage."
+  (^AutoCloseable
    [snapshot]
    (-new-iterator snapshot))
-  (^Closeable
+  (^AutoCloseable
    [snapshot column-family]
    (-new-iterator snapshot column-family)))
 
@@ -194,8 +196,10 @@
 
 
 (defn new-snapshot
-  ""
-  ^Closeable
+  "Opens a new snapshot of `store`.
+
+  Snapshots have to be closed after usage."
+  ^AutoCloseable
   [store]
   (-new-snapshot store))
 

--- a/modules/kv/src/blaze/db/kv/mem.clj
+++ b/modules/kv/src/blaze/db/kv/mem.clj
@@ -10,9 +10,9 @@
     [integrant.core :as ig]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]
     [java.util Arrays Comparator]
-    [java.nio ByteBuffer]))
+    [java.nio ByteBuffer]
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -97,7 +97,7 @@
     (check-valid iter)
     (put buf (-> @cursor :first val)))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (set! closed? true)))
 
@@ -123,7 +123,7 @@
   (-snapshot-get [_ column-family k]
     (some-> (get-in db [column-family k]) (copy)))
 
-  Closeable
+  AutoCloseable
   (close [_]))
 
 
@@ -170,7 +170,7 @@
     (kv/snapshot-get (->MemKvSnapshot @db) column-family k))
 
   (-multi-get [_ ks]
-    (with-open [snapshot ^Closeable (->MemKvSnapshot @db)]
+    (with-open [snapshot ^AutoCloseable (->MemKvSnapshot @db)]
       (reduce
         (fn [r k]
           (if-let [v (kv/snapshot-get snapshot k)]

--- a/modules/kv/src/blaze/db/kv/spec.clj
+++ b/modules/kv/src/blaze/db/kv/spec.clj
@@ -1,7 +1,9 @@
 (ns blaze.db.kv.spec
   (:require
     [blaze.db.kv :as kv]
-    [clojure.spec.alpha :as s]))
+    [clojure.spec.alpha :as s])
+  (:import
+    [java.lang AutoCloseable]))
 
 
 (s/def :blaze.db/kv-store
@@ -9,11 +11,13 @@
 
 
 (s/def :blaze.db/kv-snapshot
-  #(satisfies? kv/KvSnapshot %))
+  (s/and #(satisfies? kv/KvSnapshot %)
+         #(instance? AutoCloseable %)))
 
 
 (s/def :blaze.db/kv-iterator
-  #(satisfies? kv/KvIterator %))
+  (s/and #(satisfies? kv/KvIterator %)
+         #(instance? AutoCloseable %)))
 
 
 (s/def ::kv/put-entry-wo-cf

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
@@ -7,7 +7,7 @@
     [clojure.core.reducers :as r]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -44,7 +44,7 @@
 
 
 (defn- close-batch-db! [{:keys [db]}]
-  (.close ^Closeable db))
+  (.close ^AutoCloseable db))
 
 
 (defn- wrap-batch-db

--- a/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
+++ b/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
@@ -17,7 +17,7 @@
     [prometheus.alpha :as prom :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -100,7 +100,7 @@
       (do-sync [_ (execute-put session put-statement token clauses)]
         token)))
 
-  Closeable
+  AutoCloseable
   (close [_]
     (cass/close session)))
 
@@ -136,7 +136,7 @@
 (defmethod ig/halt-key! ::page-store/cassandra
   [_ store]
   (log/info "Close Cassandra page store")
-  (.close ^Closeable store))
+  (.close ^AutoCloseable store))
 
 
 (derive :blaze.page-store/cassandra :blaze/page-store)

--- a/src/blaze/server.clj
+++ b/src/blaze/server.clj
@@ -8,7 +8,7 @@
     [manifold.deferred :as md]
     [ring.util.response :as ring])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (defn- wrap-server [handler server]
@@ -31,4 +31,4 @@
 (defn shutdown!
   "Shuts `server` down, releasing its port."
   [server]
-  (.close ^Closeable server))
+  (.close ^AutoCloseable server))

--- a/src/blaze/server_spec.clj
+++ b/src/blaze/server_spec.clj
@@ -5,7 +5,7 @@
     [blaze.server.spec]
     [clojure.spec.alpha :as s])
   (:import
-    [java.io Closeable]))
+    [java.lang AutoCloseable]))
 
 
 (s/fdef server/init!
@@ -14,4 +14,4 @@
 
 
 (s/fdef server/shutdown!
-  :args (s/cat :server #(instance? Closeable %)))
+  :args (s/cat :server #(instance? AutoCloseable %)))


### PR DESCRIPTION
AutoCloseable is an interface introduced in Java 1.7 for the try-with-resources statement which is comparable with the with-open macro in Clojure. To be onest, both interfaces work for Clojure, but I think AutoCloseable is a bit more suitable because it has nothing to do with I/O.