### PR TITLE
Migrate from Oracle Linux to Debian

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,10 +278,18 @@ jobs:
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
 
-    - name: Scan Container Image
-      uses: azure/container-scan@v0
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
       with:
-        image-name: ghcr.io/samply/blaze:sha-${{ github.sha }}
+        image-ref: ghcr.io/samply/blaze:sha-${{ github.sha }}
+        format: template
+        template: '@/contrib/sarif.tpl'
+        output: trivy-results.sarif
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@codeql-bundle-20211115
+      with:
+        sarif_file: trivy-results.sarif
 
   integration-test:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:17-slim
 
 RUN mkdir -p /app/data && chown 1001:1001 /app/data
 COPY target/blaze-standalone.jar /app/


### PR DESCRIPTION
Today, Trivy detected 11 Critical Issues (UNKNOWN: 0, LOW: 11, MEDIUM: 25, HIGH: 9, CRITICAL: 11) in openjdk:17 which is based on oraclelinux:8.4.

However, openjdk:17-slim has only 2 Critical Issues (UNKNOWN: 0, LOW: 56, MEDIUM: 2, HIGH: 2, CRITICAL: 2). So we'll switch to Debian.

I also moved to the plain Trivy Action.