### PR TITLE
Remove Manifold from Terminology Service Module

### DIFF
--- a/modules/terminology-service/deps.edn
+++ b/modules/terminology-service/deps.edn
@@ -1,3 +1,3 @@
 {:deps
- {manifold/manifold
-  {:mvn/version "0.1.8"}}}
+ {blaze/async
+  {:local/root "../async"}}}

--- a/modules/terminology-service/src/blaze/terminology_service_spec.clj
+++ b/modules/terminology-service/src/blaze/terminology_service_spec.clj
@@ -1,8 +1,8 @@
 (ns blaze.terminology-service-spec
   (:require
+    [blaze.async.comp :as ac]
     [blaze.terminology-service :as terminology-service :refer [terminology-service?]]
-    [clojure.spec.alpha :as s]
-    [manifold.deferred :refer [deferred?]]))
+    [clojure.spec.alpha :as s]))
 
 
 (s/def ::url
@@ -23,4 +23,4 @@
 
 (s/fdef terminology-service/expand-value-set
   :args (s/cat :terminology-service terminology-service? :params expand-value-set-params)
-  :ret deferred?)
+  :ret ac/completable-future?)


### PR DESCRIPTION
The expand-value-set function returns a CompletableFuture instead of a Manifold deferred for some time now. This was just an oversight.