### PR TITLE
Update Docker Base-Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM openjdk:17
 
 RUN mkdir -p /app/data && chown 1001:1001 /app/data
 COPY target/blaze-standalone.jar /app/


### PR DESCRIPTION
Go Back to Oracle Linux as Base Image

According to Trivy, Oracle Linux 8.5 has no vulnerabilities. I opened a question https://github.com/aquasecurity/trivy/discussions/1403.