### PR TITLE
Fix Insufficient Configured Threads for the Metrics Server

### DIFF
--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -141,8 +141,7 @@
    {:port (->Cfg "METRICS_SERVER_PORT" nat-int? 8081)
     :handler (ig/ref :blaze.metrics/handler)
     :version (ig/ref :blaze/version)
-    :min-threads 1
-    :max-threads 4}})
+    :min-threads 2}})
 
 
 (defn- feature-enabled?


### PR DESCRIPTION
I was trying to save memory for the metrics server what isn't really used much. But Jetty needs some minimum number of threads. This number depends on the number of cores. With a system of 16 cores, 4 threads are not sufficient.

More: https://github.com/eclipse/jetty.project/issues/2503