### PR TITLE
Ensure Error Response on Invalid Value in FHIR Search

### DIFF
--- a/modules/db/src/blaze/db/api_spec.clj
+++ b/modules/db/src/blaze/db/api_spec.clj
@@ -80,7 +80,7 @@
   :args (s/cat :node-or-db (s/or :node :blaze.db/node :db :blaze.db/db)
                :type :fhir.type/name
                :clauses :blaze.db.query/clauses)
-  :ret :blaze.db/query)
+  :ret (s/or :query :blaze.db/query :anomaly ::anom/anomaly))
 
 
 

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -285,10 +285,11 @@
       (batch-db/->TypeQuery (codec/tid type) (seq clauses))))
 
   (-compile-type-query-lenient [_ type clauses]
-    (if-let [clauses (seq (resolve-search-params search-param-registry type
-                                                 clauses true))]
-      (batch-db/->TypeQuery (codec/tid type) clauses)
-      (batch-db/->EmptyTypeQuery (codec/tid type))))
+    (when-ok [clauses (resolve-search-params search-param-registry type clauses
+                                             true)]
+      (if-let [clauses (seq clauses)]
+        (batch-db/->TypeQuery (codec/tid type) clauses)
+        (batch-db/->EmptyTypeQuery (codec/tid type)))))
 
   (-compile-system-query [_ clauses]
     (when-ok [clauses (resolve-search-params search-param-registry "Resource"

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -57,7 +57,7 @@
        :clauses clauses})
 
     :else
-    (let [query (d/compile-type-query-lenient db type clauses)]
+    (when-ok [query (d/compile-type-query-lenient db type clauses)]
       {:handles (execute-query db query page-id)
        :clauses (d/query-clauses query)})))
 
@@ -193,7 +193,7 @@
        :clauses clauses})
 
     :else
-    (let [query (d/compile-type-query-lenient db type clauses)]
+    (when-ok [query (d/compile-type-query-lenient db type clauses)]
       {:total (count (d/execute-query db query))
        :clauses (d/query-clauses query)})))
 


### PR DESCRIPTION
In the default lenient handling, invalid search values were ignored. This is not the intended behaviour. Only unknown search parameters should be ignored, but not invalid values.