### PR TITLE
Allow Setting the Database Sync Timeout

### DIFF
--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -63,29 +63,43 @@ More information about distributed deployment are available [here](distributed.m
 
 ### Other Environment Variables
 
-| Name                                    | Default                    | Since  | Depr ¹ | Description                                                            |
-|:----------------------------------------|:---------------------------|:-------|--------|:-----------------------------------------------------------------------|
-| PROXY_HOST                              | —                          | v0.6   | —      | REMOVED: use -Dhttp.proxyHost                                          |
-| PROXY_PORT                              | —                          | v0.6   | —      | REMOVED: use -Dhttp.proxyPort                                          |
-| PROXY_USER                              | —                          | v0.6.1 | —      | REMOVED: try [SOCKS Options][1]                                        |
-| PROXY_PASSWORD                          | —                          | v0.6.1 | —      | REMOVED: try [SOCKS Options][1]                                        |
-| CONNECTION_TIMEOUT                      | 5 s                        | v0.6.3 | —      | connection timeout for outbound HTTP requests                          |
-| REQUEST_TIMEOUT                         | 30 s                       | v0.6.3 | —      | REMOVED                                                                |
-| TERM_SERVICE_URI                        | [http://tx.fhir.org/r4][6] | v0.6   | v0.11  | Base URI of the terminology service                                    |
-| BASE_URL                                | http://localhost:8080      | —      | —      | The URL under which Blaze is accessible by clients. ²                  |
-| CONTEXT_PATH                            | /fhir                      | v0.11  | —      | Context path under which the FHIR RESTful API will be accessible.      |
-| SERVER_PORT                             | 8080                       | —      | —      | The port of the main HTTP server                                       |
-| METRICS_SERVER_PORT                     | 8081                       | v0.6   | —      | The port of the Prometheus metrics server                              |
-| LOG_LEVEL                               | info                       | v0.6   | —      | one of trace, debug, info, warn or error                               |
-| JAVA_TOOL_OPTIONS                       | —                          | —      | —      | JVM options \(Docker only\)                                            |
-| FHIR_OPERATION_EVALUATE_MEASURE_THREADS | 4                          | v0.8   | —      | The maximum number of parallel $evaluate-measure executions. ³         |
-| OPENID_PROVIDER_URL                     | —                          | v0.11  | —      | [OpenID Connect][4] provider URL to enable [authentication][5]         |
-| ENFORCE_REFERENTIAL_INTEGRITY           | true                       | v0.14  | —      | Enforce referential integrity on resource create, update and delete. ⁴ |
+| Name                                    | Default                    | Since  | Depr ¹ | Description                                                                                    |
+|:----------------------------------------|:---------------------------|:-------|--------|:-----------------------------------------------------------------------------------------------|
+| PROXY_HOST                              | —                          | v0.6   | —      | REMOVED: use -Dhttp.proxyHost                                                                  |
+| PROXY_PORT                              | —                          | v0.6   | —      | REMOVED: use -Dhttp.proxyPort                                                                  |
+| PROXY_USER                              | —                          | v0.6.1 | —      | REMOVED: try [SOCKS Options][1]                                                                |
+| PROXY_PASSWORD                          | —                          | v0.6.1 | —      | REMOVED: try [SOCKS Options][1]                                                                |
+| CONNECTION_TIMEOUT                      | 5 s                        | v0.6.3 | —      | connection timeout for outbound HTTP requests                                                  |
+| REQUEST_TIMEOUT                         | 30 s                       | v0.6.3 | —      | REMOVED                                                                                        |
+| TERM_SERVICE_URI                        | [http://tx.fhir.org/r4][6] | v0.6   | v0.11  | Base URI of the terminology service                                                            |
+| BASE_URL                                | http://localhost:8080      | —      | —      | The URL under which Blaze is accessible by clients.                                            |
+| CONTEXT_PATH                            | /fhir                      | v0.11  | —      | Context path under which the FHIR RESTful API will be accessible.                              |
+| SERVER_PORT                             | 8080                       | —      | —      | The port of the main HTTP server                                                               |
+| METRICS_SERVER_PORT                     | 8081                       | v0.6   | —      | The port of the Prometheus metrics server                                                      |
+| LOG_LEVEL                               | info                       | v0.6   | —      | one of trace, debug, info, warn or error                                                       |
+| JAVA_TOOL_OPTIONS                       | —                          | —      | —      | JVM options \(Docker only\)                                                                    |
+| FHIR_OPERATION_EVALUATE_MEASURE_THREADS | 4                          | v0.8   | —      | The maximum number of parallel $evaluate-measure executions.                                   |
+| OPENID_PROVIDER_URL                     | —                          | v0.11  | —      | [OpenID Connect][4] provider URL to enable [authentication][5]                                 |
+| ENFORCE_REFERENTIAL_INTEGRITY           | true                       | v0.14  | —      | Enforce referential integrity on resource create, update and delete.                           |
+| DB_SYNC_TIMEOUT                         | 10000                      | v0.15  | —      | Timeout in milliseconds for all reading FHIR interactions acquiring the newest database state. |
 
 ¹ Deprecated
-² The [FHIR RESTful API](https://www.hl7.org/fhir/http.html) will be accessible under `BASE_URL/CONTEXT_PATH`. Possible X-Forwarded-Host, X-Forwarded-Proto and Forwarded request headers will override this URL.
-³ Not the same as the number of threads used for measure evaluation which equal to the number of available processors.
-⁴ It's enabled by default but can be disabled on proxy/middleware/secondary systems were a primary system ensures referential integrity.
+
+#### BASE_URL
+
+The [FHIR RESTful API](https://www.hl7.org/fhir/http.html) will be accessible under `BASE_URL/CONTEXT_PATH`. Possible X-Forwarded-Host, X-Forwarded-Proto and Forwarded request headers will override this URL.
+
+#### FHIR_OPERATION_EVALUATE_MEASURE_THREADS
+
+Not the same as the number of threads used for measure evaluation which equal to the number of available processors.
+
+#### ENFORCE_REFERENTIAL_INTEGRITY
+
+It's enabled by default but can be disabled on proxy/middleware/secondary systems were a primary system ensures referential integrity.
+
+#### DB_SYNC_TIMEOUT
+
+All reading FHIR interactions have to acquire the last database state known at the time the request arrived in order to ensure [consistency](../consistency.md). That database state might not be ready immediately because indexing might be still undergoing. In such a situation, the request has to wait for the database state becoming available. If the database state won't be available before the timeout expires, a 503 Service Unavailable response will be returned. Please increase this timeout if you experience such 503 responses, and you are not able to improve indexing performance or lower transaction load.  
 
 ### Common JAVA_TOOL_OPTIONS
 

--- a/modules/rest-api/src/blaze/rest_api.clj
+++ b/modules/rest-api/src/blaze/rest_api.clj
@@ -115,7 +115,8 @@
      :blaze/version
      :blaze.rest-api/structure-definitions
      :blaze.db/node
-     :blaze.db/search-param-registry]
+     :blaze.db/search-param-registry
+     :blaze.rest-api/db-sync-timeout]
     :opt-un
     [:blaze/context-path
      ::auth-backends
@@ -128,8 +129,9 @@
 
 
 (defmethod ig/init-key :blaze/rest-api
-  [_ {:keys [base-url context-path] :as context}]
-  (log/info "Init FHIR RESTful API with base URL:" (str base-url context-path))
+  [_ {:keys [base-url context-path db-sync-timeout] :as context}]
+  (log/info "Init FHIR RESTful API with base URL:" (str base-url context-path)
+            "and a database sync timeout of" db-sync-timeout "ms")
   (handler context))
 
 

--- a/modules/rest-api/src/blaze/rest_api/spec.clj
+++ b/modules/rest-api/src/blaze/rest_api/spec.clj
@@ -140,3 +140,8 @@
 
 (s/def :blaze.rest-api/structure-definitions
   (s/coll-of :fhir.un/StructureDefinition))
+
+
+;; in milliseconds
+(s/def :blaze.rest-api/db-sync-timeout
+  pos-int?)

--- a/modules/rest-api/test/blaze/rest_api_test.clj
+++ b/modules/rest-api/test/blaze/rest_api_test.clj
@@ -267,7 +267,8 @@
       [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :version))
       [:explain ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :structure-definitions))
       [:explain ::s/problems 4 :pred] := `(fn ~'[%] (contains? ~'% :node))
-      [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))))
+      [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))
+      [:explain ::s/problems 6 :pred] := `(fn ~'[%] (contains? ~'% :db-sync-timeout))))
 
   (testing "invalid enforce-referential-integrity"
     (given-thrown (ig/init {:blaze/rest-api {:enforce-referential-integrity ::invalid}})
@@ -279,8 +280,9 @@
       [:explain ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :structure-definitions))
       [:explain ::s/problems 4 :pred] := `(fn ~'[%] (contains? ~'% :node))
       [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))
-      [:explain ::s/problems 6 :pred] := `boolean?
-      [:explain ::s/problems 6 :val] := ::invalid)))
+      [:explain ::s/problems 6 :pred] := `(fn ~'[%] (contains? ~'% :db-sync-timeout))
+      [:explain ::s/problems 7 :pred] := `boolean?
+      [:explain ::s/problems 7 :val] := ::invalid)))
 
 
 (def system
@@ -291,6 +293,7 @@
      :structure-definitions []
      :node (ig/ref :blaze.db/node)
      :search-param-registry (ig/ref :blaze.db/search-param-registry)
+     :db-sync-timeout 10000
      :blaze.rest-api.json-parse/executor (ig/ref :blaze.rest-api.json-parse/executor)}
     :blaze.db/search-param-registry {}
     :blaze.rest-api.json-parse/executor {}))

--- a/modules/rest-util/src/blaze/middleware/fhir/db_spec.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/db_spec.clj
@@ -5,4 +5,4 @@
 
 
 (s/fdef db/wrap-db
-  :args (s/cat :handler ifn? :node :blaze.db/node))
+  :args (s/cat :handler ifn? :node :blaze.db/node :timeout (s/? pos-int?)))

--- a/modules/rest-util/test/blaze/middleware/fhir/db_test.clj
+++ b/modules/rest-util/test/blaze/middleware/fhir/db_test.clj
@@ -85,5 +85,15 @@
            (assert (= ::node node))
            (ac/supply-async (constantly ::db) (ac/delayed-executor 3 TimeUnit/SECONDS)))]
 
+        (given-failed-future ((db/wrap-db handler ::node 2000) {})
+          ::anom/category := ::anom/busy)))
+
+    (testing "default timeout are 10 seconds"
+      (with-redefs
+        [d/sync
+         (fn [node]
+           (assert (= ::node node))
+           (ac/supply-async (constantly ::db) (ac/delayed-executor 11 TimeUnit/SECONDS)))]
+
         (given-failed-future ((db/wrap-db handler ::node) {})
           ::anom/category := ::anom/busy)))))

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -109,6 +109,7 @@
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :auth-backends (ig/refset :blaze.auth/backend)
     :context-path (->Cfg "CONTEXT_PATH" string? "/fhir")
+    :db-sync-timeout (->Cfg "DB_SYNC_TIMEOUT" pos-int? 10000)
     :blaze.rest-api.json-parse/executor (ig/ref :blaze.rest-api.json-parse/executor)}
 
    :blaze.rest-api/requests-total {}


### PR DESCRIPTION
All reading FHIR interactions have to acquire the last database state known at the time the request arrived in order to ensure consistency. That database state might not be ready immediately because indexing might be still undergoing. In such a situation, the request has to wait for the database state becoming available. If the database state won't be available before the timeout expires, a 503 Service Unavailable response will be returned. Please increase this timeout if you experience such 503 responses, and you are not able to improve indexing performance or lower transaction load.