### PR TITLE
Improve Test Coverage Execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,17 @@ name: Build
 
 on:
   schedule:
-    - cron: '0 10 * * *' # everyday at 10am
+  - cron: '0 10 * * *' # every day at 10am
   push:
     branches:
-      - '**'
+    - master
+    - develop
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
-      - 'master'
+    - master
+    - develop
 
 jobs:
   lint:
@@ -37,6 +39,7 @@ jobs:
         module:
         - anomaly
         - async
+        - cassandra
         - coll
         - cql
         - db
@@ -102,41 +105,6 @@ jobs:
 
     needs: [ test ]
 
-    strategy:
-      max-parallel: 1
-      matrix:
-        module:
-        - anomaly
-        - async
-        - coll
-        - cql
-        - db
-        - db-resource-store
-        - db-resource-store-cassandra
-        - db-tx-log
-        - db-tx-log-kafka
-        - executor
-        - extern-terminology-service
-        - fhir-client
-        - fhir-path
-        - fhir-structure
-        - http-client
-        - interaction
-        - kv
-        - luid
-        - metrics
-        - openid-auth
-        - operation-measure-evaluate-measure
-        - page-store
-        - page-store-cassandra
-        - rest-api
-        - rest-util
-        - rocksdb
-        - scheduler
-        - search-param-registry
-        - server
-        - thread-pool-executor-collector
-
     runs-on: ubuntu-20.04
 
     steps:
@@ -158,16 +126,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-temurin-17-maven-${{ matrix.module }}-${{ hashFiles(format('modules/{0}/deps.edn', matrix.module)) }}
+        key: ${{ runner.os }}-temurin-17-maven-test-coverage-${{ hashFiles('**/deps.edn') }}
 
     - name: Test Coverage
-      run: make -C modules/${{ matrix.module }} test-coverage
+      run: make test-coverage
 
     - name: Codecov Upload
       uses: codecov/codecov-action@v2
       with:
-        name: ${{ matrix.module }}
-        file: modules/${{ matrix.module }}/target/coverage/codecov.json
+        name: codecov-umbrella
+        file: modules/**/target/coverage/codecov.json
         fail_ci_if_error: true
 
   test-root:

--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -21,7 +21,10 @@
     {:local/root "../test-util"}
 
     lambdaisland/kaocha
-    {:mvn/version "1.60.945"}}
+    {:mvn/version "1.60.945"}
+
+    org.clojars.akiel/iota
+    {:mvn/version "0.1"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
@@ -33,6 +36,10 @@
     {:local/root "../test-util"}
 
     cloverage/cloverage
-    {:mvn/version "1.2.2"}}
+    {:mvn/version "1.2.2"}
 
-   :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}
+    org.clojars.akiel/iota
+    {:mvn/version "0.1"}}
+
+   :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
+               "-e" ".+spec"]}}}

--- a/modules/cassandra/src/blaze/cassandra.clj
+++ b/modules/cassandra/src/blaze/cassandra.clj
@@ -1,18 +1,15 @@
 (ns blaze.cassandra
   (:require
     [blaze.anomaly :as ba]
+    [blaze.cassandra.session :as session]
     [clojure.string :as str]
-    [cognitect.anomalies :as anom]
-    [java-time :as time])
+    [cognitect.anomalies :as anom])
   (:import
     [com.datastax.oss.driver.api.core
      CqlSession DriverTimeoutException RequestThrottlingException]
-    [com.datastax.oss.driver.api.core.config OptionsMap TypedDriverOption]
     [com.datastax.oss.driver.api.core.cql
      AsyncResultSet PreparedStatement Row Statement SimpleStatement]
-    [com.datastax.oss.driver.api.core.servererrors WriteTimeoutException]
-    [com.datastax.oss.driver.api.core.config DriverConfigLoader]
-    [java.net InetSocketAddress]))
+    [com.datastax.oss.driver.api.core.servererrors WriteTimeoutException]))
 
 
 (set! *warn-on-reflection* true)
@@ -36,38 +33,8 @@
     {::anom/category ::anom/not-found}))
 
 
-(defn options
-  [{:keys [max-concurrent-requests max-request-queue-size
-           request-timeout]
-    :or {max-concurrent-requests 1024
-         max-request-queue-size 100000
-         request-timeout 2000}}]
-  (doto (OptionsMap/driverDefaults)
-    (.put TypedDriverOption/REQUEST_THROTTLER_CLASS "ConcurrencyLimitingRequestThrottler")
-    (.put TypedDriverOption/REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS (int max-concurrent-requests))
-    (.put TypedDriverOption/REQUEST_THROTTLER_MAX_QUEUE_SIZE (int max-request-queue-size))
-    (.put TypedDriverOption/REQUEST_TIMEOUT (time/millis request-timeout))))
-
-
-(defn build-contact-points [contact-points]
-  (map
-    #(let [[hostname port] (str/split % #":" 2)]
-       (InetSocketAddress. ^String hostname (Integer/parseInt port)))
-    (str/split contact-points #",")))
-
-
-(defn session
-  [{:keys [contact-points username password key-space]
-    :or {contact-points "localhost:9042" key-space "blaze"
-         username "cassandra" password "cassandra"}}
-   options]
-  (-> (CqlSession/builder)
-      (.withConfigLoader (DriverConfigLoader/fromMap options))
-      (.addContactPoints (build-contact-points contact-points))
-      (.withAuthCredentials username password)
-      (.withLocalDatacenter "datacenter1")
-      (.withKeyspace ^String key-space)
-      (.build)))
+(defn session [config]
+  (-> config session/session-builder session/build-session))
 
 
 (defn- format-value [k v]

--- a/modules/cassandra/src/blaze/cassandra/config.clj
+++ b/modules/cassandra/src/blaze/cassandra/config.clj
@@ -1,0 +1,30 @@
+(ns blaze.cassandra.config
+  (:require
+    [clojure.string :as str]
+    [java-time :as time])
+  (:import
+    [com.datastax.oss.driver.api.core.config OptionsMap TypedDriverOption]
+    [java.net InetSocketAddress]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn options
+  [{:keys [max-concurrent-requests max-request-queue-size
+           request-timeout]
+    :or {max-concurrent-requests 1024
+         max-request-queue-size 100000
+         request-timeout 2000}}]
+  (doto (OptionsMap/driverDefaults)
+    (.put TypedDriverOption/REQUEST_THROTTLER_CLASS "ConcurrencyLimitingRequestThrottler")
+    (.put TypedDriverOption/REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS (int max-concurrent-requests))
+    (.put TypedDriverOption/REQUEST_THROTTLER_MAX_QUEUE_SIZE (int max-request-queue-size))
+    (.put TypedDriverOption/REQUEST_TIMEOUT (time/millis request-timeout))))
+
+
+(defn build-contact-points [contact-points]
+  (map
+    #(let [[hostname port] (str/split % #":" 2)]
+       (InetSocketAddress. ^String hostname (Integer/parseInt port)))
+    (str/split contact-points #",")))

--- a/modules/cassandra/src/blaze/cassandra/session.clj
+++ b/modules/cassandra/src/blaze/cassandra/session.clj
@@ -1,0 +1,28 @@
+(ns blaze.cassandra.session
+  (:require
+    [blaze.cassandra.config :as config])
+  (:import
+    [com.datastax.oss.driver.api.core CqlSession  ]
+    [com.datastax.oss.driver.api.core.config DriverConfigLoader]
+    [com.datastax.oss.driver.api.core.session SessionBuilder]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn session-builder
+  {:arglists '([config])}
+  [{:keys [contact-points username password key-space]
+    :or {contact-points "localhost:9042" key-space "blaze"
+         username "cassandra" password "cassandra"}
+    :as config}]
+  (-> (CqlSession/builder)
+      (.withConfigLoader (DriverConfigLoader/fromMap (config/options config)))
+      (.addContactPoints (config/build-contact-points contact-points))
+      (.withAuthCredentials username password)
+      (.withLocalDatacenter "datacenter1")
+      (.withKeyspace ^String key-space)))
+
+
+(defn build-session [session-builder]
+  (.build ^SessionBuilder session-builder))

--- a/modules/cassandra/src/blaze/cassandra_spec.clj
+++ b/modules/cassandra/src/blaze/cassandra_spec.clj
@@ -34,5 +34,10 @@
   :ret (s/or :result bytes? :anomaly ::anom/anomaly))
 
 
+(s/fdef cass/session
+  :args (s/cat :config map?)
+  :ret #(instance? CqlSession %))
+
+
 (s/fdef cass/close
   :args (s/cat :session #(instance? CqlSession %)))

--- a/modules/cassandra/test/blaze/cassandra/config_test.clj
+++ b/modules/cassandra/test/blaze/cassandra/config_test.clj
@@ -1,0 +1,65 @@
+(ns blaze.cassandra.config-test
+  (:require
+    [blaze.cassandra.config :as config]
+    [clojure.spec.test.alpha :as st]
+    [clojure.test :as test :refer [deftest are testing]]
+    [java-time :as time])
+  (:import
+    [com.datastax.oss.driver.api.core.config OptionsMap TypedDriverOption]
+    [java.net InetSocketAddress]))
+
+
+(st/instrument)
+
+
+(defn- fixture [f]
+  (st/instrument)
+  (f)
+  (st/unstrument))
+
+
+(test/use-fixtures :each fixture)
+
+
+(deftest options-test
+  (testing "defaults"
+    (let [^OptionsMap options (config/options nil)]
+      (are [k v] (= v (.get options k))
+        TypedDriverOption/REQUEST_THROTTLER_CLASS
+        "ConcurrencyLimitingRequestThrottler"
+
+        TypedDriverOption/REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS
+        1024
+
+        TypedDriverOption/REQUEST_THROTTLER_MAX_QUEUE_SIZE
+        100000
+
+        TypedDriverOption/REQUEST_TIMEOUT
+        (time/millis 2000))))
+
+  (testing "custom values"
+    (let [^OptionsMap options (config/options {:max-concurrent-requests 32
+                                               :max-request-queue-size 1000
+                                               :request-timeout 5000})]
+      (are [k v] (= v (.get options k))
+        TypedDriverOption/REQUEST_THROTTLER_CLASS
+        "ConcurrencyLimitingRequestThrottler"
+
+        TypedDriverOption/REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS
+        32
+
+        TypedDriverOption/REQUEST_THROTTLER_MAX_QUEUE_SIZE
+        1000
+
+        TypedDriverOption/REQUEST_TIMEOUT
+        (time/millis 5000)))))
+
+
+(deftest build-contact-points-test
+  (are [s res] (= res (config/build-contact-points s))
+    "localhost:9042"
+    [(InetSocketAddress. "localhost" 9042)]
+
+    "node-1:9042,node-2:9042"
+    [(InetSocketAddress. "node-1" 9042)
+     (InetSocketAddress. "node-2" 9042)]))

--- a/modules/cassandra/test/blaze/cassandra/session_spec.clj
+++ b/modules/cassandra/test/blaze/cassandra/session_spec.clj
@@ -1,0 +1,16 @@
+(ns blaze.cassandra.session-spec
+  (:require
+    [blaze.cassandra.session :as session]
+    [clojure.spec.alpha :as s])
+  (:import
+    [com.datastax.oss.driver.api.core CqlSession CqlSessionBuilder]))
+
+
+(s/fdef session/session-builder
+  :args (s/cat :config map?)
+  :ret #(instance? CqlSessionBuilder %))
+
+
+(s/fdef session/build-session
+  :args #(instance? CqlSessionBuilder %)
+  :ret #(instance? CqlSession %))

--- a/modules/cassandra/test/blaze/cassandra/session_test.clj
+++ b/modules/cassandra/test/blaze/cassandra/session_test.clj
@@ -1,0 +1,57 @@
+(ns blaze.cassandra.session-test
+  (:require
+    [blaze.cassandra.session :as session]
+    [blaze.cassandra.session-spec]
+    [clojure.core.protocols :as p]
+    [clojure.datafy :as datafy]
+    [clojure.spec.test.alpha :as st]
+    [clojure.test :as test :refer [deftest]]
+    [juxt.iota :refer [given]])
+  (:import
+    [com.datastax.oss.driver.api.core CqlSessionBuilder CqlIdentifier]
+    [com.datastax.oss.driver.api.core.session SessionBuilder]
+    [com.datastax.oss.driver.api.core.metadata EndPoint]))
+
+
+(st/instrument)
+
+
+(defn- fixture [f]
+  (st/instrument)
+  (f)
+  (st/unstrument))
+
+
+(test/use-fixtures :each fixture)
+
+
+(defn- get-field
+  "Access to private or protected field where `field-name` is a symbol or
+   keyword."
+  [klass field-name obj]
+  (-> klass (.getDeclaredField (name field-name))
+      (doto (.setAccessible true))
+      (.get obj)))
+
+
+(extend-protocol p/Datafiable
+  CqlSessionBuilder
+  (datafy [builder]
+    {:contactPoints
+     (->> (get-field SessionBuilder :programmaticContactPoints builder)
+          (mapv datafy/datafy))
+     :keyspace (datafy/datafy (get-field SessionBuilder :keyspace builder))})
+
+  CqlIdentifier
+  (datafy [identifier]
+    (str identifier))
+
+  EndPoint
+  (datafy [end-point]
+    (str end-point)))
+
+
+(deftest session-test
+  (given (datafy/datafy (session/session-builder {}))
+    :keyspace := "blaze"
+    :contactPoints := ["localhost/127.0.0.1:9042"]))

--- a/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
+++ b/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
@@ -175,8 +175,7 @@
   [_ {:keys [put-consistency-level]
       :or {put-consistency-level "TWO"} :as config}]
   (log/info (init-msg config))
-  (let [options (cass/options config)
-        session (cass/session config options)]
+  (let [session (cass/session config)]
     (->CassandraResourceStore
       session
       (cass/prepare session statement/get-statement)

--- a/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
+++ b/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
@@ -4,6 +4,7 @@
     [blaze.async.comp :as ac]
     [blaze.byte-string :as bs]
     [blaze.cassandra :as cass]
+    [blaze.cassandra-spec]
     [blaze.db.resource-store :as rs]
     [blaze.db.resource-store.cassandra]
     [blaze.db.resource-store.cassandra.statement :as statement]
@@ -121,7 +122,7 @@
               (ac/completed-future (resultset-with row)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/get store hash)
             ::anom/message :# "Error while parsing resource content with hash `0000000000000000000000000000000000000000000000000000000000000000`:(.|\\s)*"
@@ -145,7 +146,7 @@
               (ac/completed-future (resultset-with row)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/get store hash)
             ::anom/message := "Error while conforming resource content with hash `0000000000000000000000000000000000000000000000000000000000000000`."
@@ -168,7 +169,7 @@
               (ac/completed-future (resultset-with nil)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (is (nil? @(rs/get store hash)))))))
 
@@ -188,7 +189,7 @@
               (ac/failed-future (Exception. "msg-141754")))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/get store hash)
             ::anom/category := ::anom/fault
@@ -211,7 +212,7 @@
               (ac/failed-future (DriverTimeoutException. "msg-115452")))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/get store hash)
             ::anom/category := ::anom/busy
@@ -237,7 +238,7 @@
               (ac/completed-future (resultset-with row)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (is (= content @(rs/get store hash)))))))
 
@@ -263,7 +264,7 @@
                 (ac/completed-future (resultset-with row))))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (is (= content @(rs/get store hash))))))))
 
@@ -286,7 +287,7 @@
               (ac/completed-future (resultset-with nil)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (is (empty? @(rs/multi-get store [hash])))))))
 
@@ -309,7 +310,7 @@
               (ac/completed-future (resultset-with row)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (is (= {hash content} @(rs/multi-get store [hash]))))))))
 
@@ -350,7 +351,7 @@
               (ac/failed-future (Exception. "error-150216")))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/put! store {hash resource})
             ::anom/message := "error-150216")))))
@@ -375,7 +376,7 @@
               (ac/failed-future (DriverTimeoutException. "msg-123234")))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/put! store {hash resource})
             ::anom/category := ::anom/busy
@@ -404,7 +405,7 @@
               (ac/failed-future (WriteTimeoutException. nil ConsistencyLevel/TWO 1 2 WriteType/SIMPLE)))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (given-failed-future (rs/put! store {hash resource})
             ::anom/category := ::anom/busy
@@ -433,6 +434,6 @@
               (ac/completed-future nil))
             (close [_]))]
 
-      (with-redefs [cass/session (fn [_ _] session)]
+      (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} {::rs/cassandra {}}]
           (is (nil? @(rs/put! store {hash resource}))))))))

--- a/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
+++ b/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
@@ -125,8 +125,7 @@
   [_ {:keys [secure-rng put-consistency-level]
       :or {put-consistency-level "TWO"} :as config}]
   (log/info (init-msg config))
-  (let [options (cass/options config)
-        session (cass/session config options)]
+  (let [session (cass/session config)]
     (->CassandraPageStore
       secure-rng
       session

--- a/modules/page-store-cassandra/test/blaze/page_store/cassandra_test.clj
+++ b/modules/page-store-cassandra/test/blaze/page_store/cassandra_test.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.async.comp :as ac]
     [blaze.cassandra :as cass]
+    [blaze.cassandra-spec]
     [blaze.page-store :as page-store]
     [blaze.page-store.cassandra]
     [blaze.page-store.cassandra.codec :as codec]
@@ -69,7 +70,7 @@
 (deftest put-test
   (testing "success"
     (with-redefs
-      [cass/session (fn [_ _] ::session)
+      [cass/session (fn [_] ::session)
        cass/prepare prepare
        cass/bind (fn [prepared-statement & params]
                    (assert (= ::prepared-put-statement prepared-statement))


### PR DESCRIPTION
Because we can execute the test coverage only sequentially, it is more efficient to do this in a single job rather than on multiple.

Also improved cassandra module test coverage in order to not lower the overall test coverage because the cassandra module was missing from the current job listing.