### PR TITLE
Upgrade Oracle Linux Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17
 
+RUN microdnf upgrade
+
 RUN mkdir -p /app/data && chown 1001:1001 /app/data
 COPY target/blaze-standalone.jar /app/
 


### PR DESCRIPTION
That should solve CVE-2021-3712 currently in Oracle Linux 8.5 and possibly many other vulnerabilities in the future.