### PR TITLE
Exclude Geometry API from Java-Driver-Core

### DIFF
--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -6,7 +6,10 @@
   {:mvn/version "0.3.3"}
 
   com.datastax.oss/java-driver-core
-  {:mvn/version "4.13.0"}
+  {:mvn/version "4.13.0"
+   ;; remove when https://github.com/datastax/java-driver/pull/1575 is solved
+   :exclusions
+   [com.esri.geometry/esri-geometry-api]}
 
   ;; current version of transitive dependency of com.datastax.oss/java-driver-core
   io.netty/netty-handler


### PR DESCRIPTION
The `com.esri.geometry/esri-geometry-api` v1.2.1 dependency is optional which is itself outdated and introduces other outdated dependencies. That dependencies are:

* `org.json/json` v20090211
* `org.codehaus.jackson/jackson-core-asl` v1.9.12