### PR TITLE
Update Google Protobuf to v3.19.2

### DIFF
--- a/modules/byte-string/deps.edn
+++ b/modules/byte-string/deps.edn
@@ -5,7 +5,7 @@
   {:mvn/version "31.0.1-jre"}
 
   com.google.protobuf/protobuf-java
-  {:mvn/version "3.19.1"}
+  {:mvn/version "3.19.2"}
 
   com.fasterxml.jackson.core/jackson-databind
   {:mvn/version "2.13.1"}}}


### PR DESCRIPTION
Fixes CVE-2021-22569