### PR TITLE
Start Implementing Compiled Query Forms

### DIFF
--- a/.github/scripts/evaluate-measure-subject-list.sh
+++ b/.github/scripts/evaluate-measure-subject-list.sh
@@ -103,7 +103,7 @@ evaluate-measure() {
 }
 
 fetch-patients() {
-  curl -s "$1/Patient?_list=$2&_count=100"
+  curl -s "$1/Patient?_list=$2&_count=200"
 }
 
 BASE="http://localhost:8080/fhir"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,7 +304,7 @@ jobs:
       run: .github/scripts/check-total-number-of-resources.sh 92114
 
     - name: Count Resources
-      run: blazectl --no-progress --server http://localhost:8080/fhir count-resources
+      run: blazectl count-resources --server http://localhost:8080/fhir
 
     - name: Download Patient Resources
       run: .github/scripts/download-resources.sh Patient
@@ -372,6 +372,12 @@ jobs:
     - name: Evaluate CQL Query 2 - Subject List
       run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q2-query.cql 42
 
+    - name: Evaluate CQL Query 4
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q4-query.cql 0
+
+    - name: Evaluate CQL Query 4 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q4-query.cql 0
+
     - name: Evaluate CQL Query 7
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7-query.cql 81
 
@@ -383,6 +389,30 @@ jobs:
 
     - name: Evaluate CQL Query 14 - Subject List
       run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14-query.cql 96
+
+    - name: Evaluate CQL Query 15
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q15-query.cql 31
+
+    - name: Evaluate CQL Query 15 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q15-query.cql 31
+
+    - name: Evaluate CQL Query 17
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q17-query.cql 120
+
+    - name: Evaluate CQL Query 17 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q17-query.cql 120
+
+    - name: Evaluate CQL Query 36
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q36-parameter-query.cql 86
+
+    - name: Evaluate CQL Query 36 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q36-parameter-query.cql 86
+
+    - name: Evaluate CQL Query 34
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q37-overlaps-query.cql 24
+
+    - name: Evaluate CQL Query 34 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q37-overlaps-query.cql 24
 
     - name: Forwarded Header HTTPS
       run: .github/scripts/forwarded-header.sh https
@@ -658,7 +688,7 @@ jobs:
       run: .github/scripts/check-total-number-of-resources.sh 92114
 
     - name: Count Resources
-      run: blazectl --no-progress --server http://localhost:8080/fhir count-resources
+      run: blazectl count-resources --server http://localhost:8080/fhir
 
     - name: Download Patient Resources
       run: .github/scripts/download-resources.sh Patient
@@ -726,6 +756,12 @@ jobs:
     - name: Evaluate CQL Query 2 - Subject List
       run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q2-query.cql 42
 
+    - name: Evaluate CQL Query 4
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q4-query.cql 0
+
+    - name: Evaluate CQL Query 4 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q4-query.cql 0
+
     - name: Evaluate CQL Query 7
       run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7-query.cql 81
 
@@ -737,6 +773,30 @@ jobs:
 
     - name: Evaluate CQL Query 14 - Subject List
       run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14-query.cql 96
+
+    - name: Evaluate CQL Query 15
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q15-query.cql 31
+
+    - name: Evaluate CQL Query 15 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q15-query.cql 31
+
+    - name: Evaluate CQL Query 17
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q17-query.cql 120
+
+    - name: Evaluate CQL Query 17 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q17-query.cql 120
+
+    - name: Evaluate CQL Query 36
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q36-parameter-query.cql 86
+
+    - name: Evaluate CQL Query 36 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q36-parameter-query.cql 86
+
+    - name: Evaluate CQL Query 34
+      run: .github/scripts/evaluate-measure.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q37-overlaps-query.cql 24
+
+    - name: Evaluate CQL Query 34 - Subject List
+      run: .github/scripts/evaluate-measure-subject-list.sh modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q37-overlaps-query.cql 24
 
     - name: Forwarded Header HTTPS
       run: .github/scripts/forwarded-header.sh https

--- a/modules/cql/src/blaze/cql_translator_spec.clj
+++ b/modules/cql/src/blaze/cql_translator_spec.clj
@@ -3,9 +3,10 @@
     [blaze.anomaly-spec]
     [blaze.cql-translator :as cql-translator]
     [blaze.elm.spec]
-    [clojure.spec.alpha :as s]))
+    [clojure.spec.alpha :as s]
+    [cognitect.anomalies :as anom]))
 
 
 (s/fdef cql-translator/translate
   :args (s/cat :cql string? :opts (s/* some?))
-  :ret :elm/library)
+  :ret (s/or :library :elm/library :anomaly ::anom/anomaly))

--- a/modules/cql/src/blaze/elm/compiler.clj
+++ b/modules/cql/src/blaze/elm/compiler.clj
@@ -42,3 +42,7 @@
   Use `compile-library` to compile a whole library."
   [context expression]
   (core/compile* context expression))
+
+
+(defn form [expression]
+  (core/-form expression))

--- a/modules/cql/src/blaze/elm/compiler/core.clj
+++ b/modules/cql/src/blaze/elm/compiler/core.clj
@@ -14,7 +14,8 @@
 (defprotocol Expression
   (-eval [expression context resource scope]
     "Evaluates `expression` on `resource` using `context` and optional `scope`
-    for scoped expressions like inside queries."))
+    for scoped expressions like inside queries.")
+  (-form [expression]))
 
 
 (defn expr? [x]
@@ -23,12 +24,16 @@
 
 (extend-protocol Expression
   nil
-  (-eval [this _ _ _]
-    this)
+  (-eval [expr _ _ _]
+    expr)
+  (-form [_]
+    'nil)
 
   Object
-  (-eval [this _ _ _]
-    this))
+  (-eval [expr _ _ _]
+    expr)
+  (-form [expr]
+    expr))
 
 
 (defn static? [x]

--- a/modules/cql/src/blaze/elm/compiler/external_data.clj
+++ b/modules/cql/src/blaze/elm/compiler/external_data.clj
@@ -21,10 +21,12 @@
     (d/list-compartment-resource-handles db context id data-type)))
 
 
-(defrecord CompartmentQueryRetrieveExpression [query]
+(defrecord CompartmentQueryRetrieveExpression [query data-type clauses]
   core/Expression
   (-eval [_ {:keys [db]} {:keys [id]} _]
-    (d/execute-query db query id)))
+    (d/execute-query db query id))
+  (-form [_]
+    `(~'compartment-query-retrieve ~data-type ~clauses)))
 
 
 (defn- code->clause-value [{:keys [system code]}]
@@ -45,7 +47,7 @@
   [node context data-type property codes]
   (let [clauses [(into [property] (map code->clause-value) codes)]
         query (d/compile-compartment-query node context data-type clauses)]
-    (->CompartmentQueryRetrieveExpression query)))
+    (->CompartmentQueryRetrieveExpression query data-type clauses)))
 
 
 (defn- split-reference [s]
@@ -155,7 +157,9 @@
   (if (empty? codes)
     (reify core/Expression
       (-eval [_ {:keys [db]} _ _]
-        (into [] (d/type-list db data-type))))
+        (into [] (d/type-list db data-type)))
+      (-form [_]
+        `(~'retrieve ~data-type)))
     (let [clauses [(into [code-property] (map code->clause-value) codes)]]
       (if-ok [query (d/compile-type-query node data-type clauses)]
         (reify core/Expression

--- a/modules/cql/src/blaze/elm/compiler/interval_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/interval_operators.clj
@@ -118,7 +118,7 @@
 
 
 ;; 19.7. Ends
-(defbinop ends [x y _]
+(defbinopp ends [x y _]
   (and (p/greater-or-equal (:start x) (:start y))
        (p/equal (:end x) (:end y))))
 
@@ -126,6 +126,9 @@
 ;; 19.10. Except
 (defbinop except [x y]
   (p/except x y))
+
+
+;; TODO 19.11. Expand
 
 
 ;; 19.12. In
@@ -221,7 +224,7 @@
 
 
 ;; 19.30. Starts
-(defbinop starts [x y _]
+(defbinopp starts [x y _]
   (and (p/equal (:start x) (:start y))
        (p/less-or-equal (:end x) (:end y))))
 

--- a/modules/cql/src/blaze/elm/compiler/logical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/logical_operators.clj
@@ -9,50 +9,53 @@
 
 
 ;; 13.1. And
-
-;; static-a is either true or nil but not false
-(defrecord StaticAndOperatorExpression [static-a b]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [b (core/-eval b context resource scope)]
-      (cond
-        (false? b) false
-        (and (true? static-a) (true? b)) true))))
+(defn- nil-and-expr [x]
+  (reify core/Expression
+    (-eval [_ context resource scope]
+      (when (false? (core/-eval x context resource scope))
+        false))
+    (-form [_]
+      (list 'and nil (core/-form x)))))
 
 
-(defn- and-static [static-a b]
-  (if (core/static? b)
-    (cond
-      (false? b) false
-      (and (true? static-a) (true? b)) true)
-    (->StaticAndOperatorExpression static-a b)))
+(defn- nil-and
+  "Creates an and-expression where one operand is known to be nil."
+  [x]
+  (case x
+    (true nil) nil
+    false false
+    (nil-and-expr x)))
 
 
-(defrecord AndOperatorExpression [a b]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [a (core/-eval a context resource scope)]
-      (if (false? a)
-        false
-        (let [b (core/-eval b context resource scope)]
-          (cond
-            (false? b) false
-            (and (true? a) (true? b)) true))))))
+(defn- dynamic-and
+  "Creates an and-expression where `a` is known to be dynamic and `b` could be
+  static or dynamic."
+  [a b]
+  (case b
+    true a
+    false false
+    nil (nil-and-expr a)
+    (reify core/Expression
+      (-eval [_ context resource scope]
+        (let [a (core/-eval a context resource scope)]
+          (if (false? a)
+            false
+            (let [b (core/-eval b context resource scope)]
+              (cond
+                (false? b) false
+                (and (true? a) (true? b)) true)))))
+      (-form [_]
+        (list 'and (core/-form a) (core/-form b))))))
 
 
 (defmethod core/compile* :elm.compiler.type/and
   [context {[a b] :operand}]
   (let [a (core/compile* context a)]
-    (if (core/static? a)
-      (if (false? a)
-        false
-        (and-static a (core/compile* context b)))
-      (let [b (core/compile* context b)]
-        (if (core/static? b)
-          (if (false? b)
-            false
-            (and-static b a))
-          (->AndOperatorExpression a b))))))
+    (case a
+      true (core/compile* context b)
+      false false
+      nil (nil-and (core/compile* context b))
+      (dynamic-and a (core/compile* context b)))))
 
 
 ;; 13.2 Implies
@@ -68,104 +71,85 @@
 
 
 ;; 13.4. Or
-
-;; static-a is either false or nil but not true
-(defrecord StaticOrOperatorExpression [static-a b]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [b (core/-eval b context resource scope)]
-      (cond
-        (true? b) true
-        (and (false? static-a) (false? b)) false))))
+(defn- nil-or-expr [x]
+  (reify core/Expression
+    (-eval [_ context resource scope]
+      (when (true? (core/-eval x context resource scope))
+        true))
+    (-form [_]
+      (list 'or nil (core/-form x)))))
 
 
-(defn- or-static [static-a b]
-  (if (core/static? b)
-    (cond
-      (true? b) true
-      (and (false? static-a) (false? b)) false)
-    (->StaticOrOperatorExpression static-a b)))
+(defn- nil-or
+  "Creates an or-expression where one operand is known to be nil."
+  [x]
+  (case x
+    true true
+    (false nil) nil
+    (nil-or-expr x)))
 
 
-(defrecord OrOperatorExpression [a b]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [a (core/-eval a context resource scope)]
-      (if (true? a)
-        true
-        (let [b (core/-eval b context resource scope)]
-          (cond
-            (true? b) true
-            (and (false? a) (false? b)) false))))))
+(defn- dynamic-or
+  "Creates an or-expression where `a` is known to be dynamic and `b` could be
+  static or dynamic."
+  [a b]
+  (case b
+    true true
+    false a
+    nil (nil-or-expr a)
+    (reify core/Expression
+      (-eval [_ context resource scope]
+        (let [a (core/-eval a context resource scope)]
+          (if (true? a)
+            true
+            (let [b (core/-eval b context resource scope)]
+              (cond
+                (true? b) true
+                (and (false? a) (false? b)) false)))))
+      (-form [_]
+        (list 'or (core/-form a) (core/-form b))))))
 
 
 (defmethod core/compile* :elm.compiler.type/or
   [context {[a b] :operand}]
   (let [a (core/compile* context a)]
-    (if (core/static? a)
-      (if (true? a)
-        true
-        (or-static a (core/compile* context b)))
-      (let [operand-2 (core/compile* context b)]
-        (if (core/static? operand-2)
-          (if (true? operand-2)
-            true
-            (or-static operand-2 a))
-          (->OrOperatorExpression a operand-2))))))
+    (case a
+      true true
+      false (core/compile* context b)
+      nil (nil-or (core/compile* context b))
+      (dynamic-or a (core/compile* context b)))))
 
 
 ;; 13.5 Xor
-(defrecord StaticXOrOperatorExpression [static-a b]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [b (core/-eval b context resource scope)]
-      (cond
-        (or (and (true? static-a) (true? b))
-            (and (false? static-a) (false? b)))
-        false
-        (or (and (true? static-a) (false? b))
-            (and (false? static-a) (true? b)))
-        true))))
-
-
-(defn- xor-static [static-a b]
-  (if (core/static? b)
-    (cond
-      (or (and (true? static-a) (true? b))
-          (and (false? static-a) (false? b)))
-      false
-      (or (and (true? static-a) (false? b))
-          (and (false? static-a) (true? b)))
-      true)
-    (->StaticXOrOperatorExpression static-a b)))
-
-
-(defrecord XOrOperatorExpression [a b]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [a (core/-eval a context resource scope)]
-      (if (nil? a)
-        nil
-        (let [b (core/-eval b context resource scope)]
-          (cond
-            (or (and (true? a) (true? b))
-                (and (false? a) (false? b)))
-            false
-            (or (and (true? a) (false? b))
-                (and (false? a) (true? b)))
-            true))))))
+(defn- dynamic-xor
+  "Creates an xor-expression where `a` is known to be dynamic and `b` could be
+  static or dynamic."
+  [a b]
+  (case b
+    true
+    (reify core/Expression
+      (-eval [_ context resource scope]
+        (let [a (core/-eval a context resource scope)]
+          (when (some? a)
+            (not a))))
+      (-form [_]
+        (list 'not (core/-form a))))
+    false a
+    nil nil
+    (reify core/Expression
+      (-eval [_ context resource scope]
+        (when-some [a (core/-eval a context resource scope)]
+          (when-some [b (core/-eval b context resource scope)]
+            (if a (not b) b))))
+      (-form [_]
+        (list 'xor (core/-form a) (core/-form b))))))
 
 
 (defmethod core/compile* :elm.compiler.type/xor
   [context {[a b] :operand}]
   (let [a (core/compile* context a)]
-    (if (core/static? a)
-      (if (nil? a)
-        nil
-        (xor-static a (core/compile* context b)))
-      (let [b (core/compile* context b)]
-        (if (core/static? b)
-          (if (nil? b)
-            nil
-            (xor-static b a))
-          (->XOrOperatorExpression a b))))))
+    (case a
+      true (core/compile* context {:type "Not" :operand b})
+      false (core/compile* context b)
+      nil nil
+      (dynamic-xor a (core/compile* context b)))))

--- a/modules/cql/src/blaze/elm/compiler/macros.clj
+++ b/modules/cql/src/blaze/elm/compiler/macros.clj
@@ -1,11 +1,6 @@
 (ns blaze.elm.compiler.macros
   (:require
-    [blaze.elm.compiler.core :as core]
-    [cuerdas.core :as cuerdas]))
-
-
-(defn- record-name [s]
-  (str (cuerdas/capital (cuerdas/camel (name s))) "OperatorExpression"))
+    [blaze.elm.compiler.core :as core]))
 
 
 (defmacro defunop
@@ -14,30 +9,33 @@
   (let [attr-map (when (map? (first more)) (first more))
         more (if (map? (first more)) (next more) more)
         [[operand-binding expr-binding] & body] more]
-    `(do
-       ~(if expr-binding
-          `(defrecord ~(symbol (record-name name)) [~'operand ~'expr]
-             core/Expression
-             (-eval [~'_ context# resource# scope#]
-               (let [~operand-binding (core/-eval ~'operand context# resource# scope#)
-                     ~expr-binding ~'expr]
-                 ~@body)))
-          `(defrecord ~(symbol (record-name name)) [~'operand]
-             core/Expression
-             (-eval [~'_ context# resource# scope#]
-               (let [~operand-binding (core/-eval ~'operand context# resource# scope#)]
-                 ~@body))))
-
-       (defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
-         [context# ~'expr]
-         (let [~'operand (core/compile* (merge context# ~attr-map) (:operand ~'expr))]
-           (if (core/static? ~'operand)
-             (let [~operand-binding ~'operand
-                   ~(or expr-binding '_) ~'expr]
+    (if expr-binding
+      `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+         [context# expr#]
+         (let [operand# (core/compile* (merge context# ~attr-map) (:operand expr#))]
+           (if (core/static? operand#)
+             (let [~operand-binding operand#
+                   ~expr-binding expr#]
                ~@body)
-             ~(if expr-binding
-                `(~(symbol (str "->" (record-name name))) ~'operand ~'expr)
-                `(~(symbol (str "->" (record-name name))) ~'operand))))))))
+             (reify core/Expression
+               (-eval [~'_ context# resource# scope#]
+                 (let [~operand-binding (core/-eval operand# context# resource# scope#)
+                       ~expr-binding expr#]
+                   ~@body))
+               (-form [~'_]
+                 (list (quote ~name) (core/-form operand#)))))))
+      `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+         [context# expr#]
+         (let [operand# (core/compile* (merge context# ~attr-map) (:operand expr#))]
+           (if (core/static? operand#)
+             (let [~operand-binding operand#]
+               ~@body)
+             (reify core/Expression
+               (-eval [~'_ context# resource# scope#]
+                 (let [~operand-binding (core/-eval operand# context# resource# scope#)]
+                   ~@body))
+               (-form [~'_]
+                 (list (quote ~name) (core/-form operand#))))))))))
 
 
 (defmacro defbinop
@@ -46,22 +44,22 @@
   (let [attr-map (when (map? (first more)) (first more))
         more (if (map? (first more)) (next more) more)
         [[op-1-binding op-2-binding] & body] more]
-    `(do
-       (defrecord ~(symbol (record-name name)) [~'operand-1 ~'operand-2]
-         core/Expression
-         (-eval [~'_ context# resource# scope#]
-           (let [~op-1-binding (core/-eval ~'operand-1 context# resource# scope#)
-                 ~op-2-binding (core/-eval ~'operand-2 context# resource# scope#)]
-             ~@body)))
-
-       (defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
-         [context# {[operand-1# operand-2#] :operand}]
-         (let [context# (merge context# ~attr-map)
-               ~op-1-binding (core/compile* context# operand-1#)
-               ~op-2-binding (core/compile* context# operand-2#)]
-           (if (and (core/static? ~op-1-binding) (core/static? ~op-2-binding))
-             ~@body
-             (~(symbol (str "->" (record-name name))) ~op-1-binding ~op-2-binding)))))))
+    `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+       [context# {[operand-1# operand-2#] :operand}]
+       (let [context# (merge context# ~attr-map)
+             operand-1# (core/compile* context# operand-1#)
+             operand-2# (core/compile* context# operand-2#)]
+         (if (and (core/static? operand-1#) (core/static? operand-2#))
+           (let [~op-1-binding operand-1#
+                 ~op-2-binding operand-2#]
+             ~@body)
+           (reify core/Expression
+             (-eval [~'_ context# resource# scope#]
+               (let [~op-1-binding (core/-eval operand-1# context# resource# scope#)
+                     ~op-2-binding (core/-eval operand-2# context# resource# scope#)]
+                 ~@body))
+             (-form [~'_]
+               (list (quote ~name) (core/-form operand-1#) (core/-form operand-2#)))))))))
 
 
 (defmacro defternop
@@ -83,17 +81,13 @@
 (defmacro defnaryop
   {:arglists '([name bindings & body])}
   [name [operands-binding] & body]
-  `(do
-     (defrecord ~(symbol (record-name name)) [~'operands]
-       core/Expression
-       (-eval [~'_ context# resource# scope#]
-         (let [~operands-binding (mapv #(core/-eval % context# resource# scope#) ~'operands)]
-           ~@body)))
-
-     (defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
-       [context# {~'operands :operand}]
-       (let [~'operands (mapv #(core/compile* context# %) ~'operands)]
-         (~(symbol (str "->" (record-name name))) ~'operands)))))
+  `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+     [context# {operands# :operand}]
+     (let [operands# (mapv #(core/compile* context# %) operands#)]
+       (reify core/Expression
+         (-eval [~'_ context# resource# scope#]
+           (let [~operands-binding (mapv #(core/-eval % context# resource# scope#) operands#)]
+             ~@body))))))
 
 
 (defmacro defaggop
@@ -108,36 +102,6 @@
              ~@body))))))
 
 
-(defmacro defbinopp
-  {:arglists '([name attr-map? bindings & body])}
-  [name & more]
-  (let [attr-map (when (map? (first more)) (first more))
-        more (if (map? (first more)) (next more) more)
-        [[op-1-binding op-2-binding precision-binding] & body] more]
-    `(do
-       (defrecord ~(symbol (record-name name)) [~'operand-1 ~'operand-2 ~'precision]
-         core/Expression
-         (-eval [~'_ context# resource# scope#]
-           (let [~op-1-binding (core/-eval ~'operand-1 context# resource# scope#)
-                 ~op-2-binding (core/-eval ~'operand-2 context# resource# scope#)
-                 ~precision-binding ~'precision]
-             ~@body)))
-
-       (defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
-         [context# {[operand-1# operand-2#] :operand precision# :precision}]
-         (let [context# (merge context# ~attr-map)
-               operand-1# (core/compile* context# operand-1#)
-               operand-2# (core/compile* context# operand-2#)
-               precision# (some-> precision# core/to-chrono-unit)]
-           (if (and (core/static? operand-1#) (core/static? operand-2#))
-             (let [~op-1-binding operand-1#
-                   ~op-2-binding operand-2#
-                   ~precision-binding precision#]
-               ~@body)
-             (~(symbol (str "->" (record-name name)))
-               operand-1# operand-2# precision#)))))))
-
-
 (defmacro defunopp
   {:arglists '([name bindings & body])}
   [name [operand-binding precision-binding expr-binding] & body]
@@ -149,4 +113,34 @@
        (reify core/Expression
          (-eval [~'_ context# resource# scope#]
            (let [~operand-binding (core/-eval operand# context# resource# scope#)]
-             ~@body))))))
+             ~@body))
+         (-form [~'_]
+           (list (quote ~name) (core/-form operand#) precision#))))))
+
+
+(defmacro defbinopp
+  {:arglists '([name attr-map? bindings & body])}
+  [name & more]
+  (let [attr-map (when (map? (first more)) (first more))
+        more (if (map? (first more)) (next more) more)
+        [[op-1-binding op-2-binding precision-binding] & body] more]
+    `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+       [context# {[operand-1# operand-2#] :operand precision# :precision}]
+       (let [context# (merge context# ~attr-map)
+             operand-1# (core/compile* context# operand-1#)
+             operand-2# (core/compile* context# operand-2#)
+             chrono-precision# (some-> precision# core/to-chrono-unit)]
+         (if (and (core/static? operand-1#) (core/static? operand-2#))
+           (let [~op-1-binding operand-1#
+                 ~op-2-binding operand-2#
+                 ~precision-binding chrono-precision#]
+             ~@body)
+           (reify core/Expression
+             (-eval [~'_ context# resource# scope#]
+               (let [~op-1-binding (core/-eval operand-1# context# resource# scope#)
+                     ~op-2-binding (core/-eval operand-2# context# resource# scope#)
+                     ~precision-binding chrono-precision#]
+                 ~@body))
+             (-form [~'_]
+               (list (quote ~name) (core/-form operand-1#) (core/-form operand-2#)
+                     precision#))))))))

--- a/modules/cql/src/blaze/elm/compiler/parameters.clj
+++ b/modules/cql/src/blaze/elm/compiler/parameters.clj
@@ -26,7 +26,9 @@
     (let [value (get parameters name ::not-found)]
       (if (identical? ::not-found value)
         (throw-anom (parameter-value-not-found-anom context name))
-        value))))
+        value)))
+  (-form [_]
+    `(~'param-ref ~name)))
 
 
 (defn- find-parameter-def

--- a/modules/cql/src/blaze/elm/compiler/structured_values.clj
+++ b/modules/cql/src/blaze/elm/compiler/structured_values.clj
@@ -92,19 +92,25 @@
 (defrecord SourcePropertyExpression [source key]
   core/Expression
   (-eval [_ {:keys [db] :as context} resource scope]
-    (get-property db key (core/-eval source context resource scope))))
+    (get-property db key (core/-eval source context resource scope)))
+  (-form [_]
+    `(~key ~(core/-form source))))
 
 
 (defrecord SingleScopePropertyExpression [key]
   core/Expression
   (-eval [_ {:keys [db]} _ value]
-    (get-property db key value)))
+    (get-property db key value))
+  (-form [_]
+    `(~key ~'default)))
 
 
 (defrecord ScopePropertyExpression [scope-key key]
   core/Expression
   (-eval [_ {:keys [db]} _ scope]
-    (get-property db key (get scope scope-key))))
+    (get-property db key (get scope scope-key)))
+  (-form [_]
+    `(~key ~(symbol (name scope-key)))))
 
 
 (defn- path->key [path]

--- a/modules/cql/src/blaze/elm/date_time.clj
+++ b/modules/cql/src/blaze/elm/date_time.clj
@@ -6,11 +6,13 @@
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.protocols :as p]
+    [blaze.fhir.spec.type]
     [blaze.fhir.spec.type.system :as system]
     [java-time :as time])
   (:import
+    [blaze.fhir.spec.type OffsetInstant]
     [blaze.fhir.spec.type.system DateTimeYear DateTimeYearMonth DateTimeYearMonthDay]
-    [java.time LocalDate LocalDateTime LocalTime OffsetDateTime Year YearMonth]
+    [java.time LocalDate LocalDateTime LocalTime OffsetDateTime Year YearMonth Instant]
     [java.time.temporal ChronoField ChronoUnit Temporal TemporalAccessor]
     [java.util Map]))
 
@@ -1278,6 +1280,15 @@
 (extend-protocol p/ToDateTime
   nil
   (to-date-time [_ _])
+
+  Instant
+  (to-date-time [this now]
+    (-> (.atOffset this (.getOffset ^OffsetDateTime now))
+        (.toLocalDateTime)))
+
+  OffsetInstant
+  (to-date-time [this now]
+    (p/to-date-time (.value this) now))
 
   Year
   (to-date-time [this _]

--- a/modules/cql/src/blaze/elm/decimal.clj
+++ b/modules/cql/src/blaze/elm/decimal.clj
@@ -232,7 +232,8 @@
 (extend-protocol p/Round
   BigDecimal
   (round [x precision]
-    (.setScale x ^long precision RoundingMode/HALF_UP)))
+    (let [new-scale (or precision 0)]
+      (.setScale x ^int new-scale RoundingMode/HALF_UP))))
 
 
 ;; 16.20. Subtract

--- a/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
@@ -42,9 +42,9 @@
 (deftest compile-all-true-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/all-true source)) {} nil nil))
-      #elm/list [#elm/boolean"true" #elm/boolean"false"] false
-      #elm/list [#elm/boolean"false"] false
-      #elm/list [#elm/boolean"true"] true
+      #elm/list [#elm/boolean "true" #elm/boolean "false"] false
+      #elm/list [#elm/boolean "false"] false
+      #elm/list [#elm/boolean "true"] true
 
       #elm/list [{:type "Null"}] true
       #elm/list [] true
@@ -64,9 +64,9 @@
 (deftest compile-any-true-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/any-true source)) {} nil nil))
-      #elm/list [#elm/boolean"true" #elm/boolean"false"] true
-      #elm/list [#elm/boolean"false"] false
-      #elm/list [#elm/boolean"true"] true
+      #elm/list [#elm/boolean "true" #elm/boolean "false"] true
+      #elm/list [#elm/boolean "false"] false
+      #elm/list [#elm/boolean "true"] true
 
       #elm/list [{:type "Null"}] false
       #elm/list [] false
@@ -86,9 +86,9 @@
 (deftest compile-avg-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/avg source)) {} nil nil))
-      #elm/list [#elm/decimal"1" #elm/decimal"2"] 1.5M
-      #elm/list [#elm/integer"1" #elm/integer"2"] 1.5M
-      #elm/list [#elm/integer"1"] 1M
+      #elm/list [#elm/decimal "1" #elm/decimal "2"] 1.5M
+      #elm/list [#elm/integer "1" #elm/integer "2"] 1.5M
+      #elm/list [#elm/integer "1"] 1M
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -108,8 +108,8 @@
 (deftest compile-count-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/count source)) {} nil nil))
-      #elm/list [#elm/integer"1"] 1
-      #elm/list [#elm/integer"1" #elm/integer"1"] 2
+      #elm/list [#elm/integer "1"] 1
+      #elm/list [#elm/integer "1" #elm/integer "1"] 2
 
       #elm/list [{:type "Null"}] 0
       #elm/list [] 0
@@ -130,9 +130,9 @@
 (deftest compile-geometric-mean-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/geometric-mean source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"8"] 4M
-      #elm/list [#elm/integer"2" #elm/integer"8"] 4M
-      #elm/list [#elm/integer"1"] 1M
+      #elm/list [#elm/decimal "2" #elm/decimal "8"] 4M
+      #elm/list [#elm/integer "2" #elm/integer "8"] 4M
+      #elm/list [#elm/integer "1"] 1M
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -153,9 +153,9 @@
 (deftest compile-product-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/product source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"8"] 16M
-      #elm/list [#elm/integer"2" #elm/integer"8"] 16
-      #elm/list [#elm/integer"1"] 1
+      #elm/list [#elm/decimal "2" #elm/decimal "8"] 16M
+      #elm/list [#elm/integer "2" #elm/integer "8"] 16
+      #elm/list [#elm/integer "1"] 1
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -177,9 +177,9 @@
 (deftest compile-max-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/max source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"8"] 8M
-      #elm/list [#elm/integer"2" #elm/integer"8"] 8
-      #elm/list [#elm/integer"1"] 1
+      #elm/list [#elm/decimal "2" #elm/decimal "8"] 8M
+      #elm/list [#elm/integer "2" #elm/integer "8"] 8
+      #elm/list [#elm/integer "1"] 1
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -199,10 +199,10 @@
 (deftest compile-median-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/median source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"10" #elm/decimal"8"] 8M
-      #elm/list [#elm/integer"2" #elm/integer"10" #elm/integer"8"] 8
-      #elm/list [#elm/integer"1" #elm/integer"2"] 1.5M
-      #elm/list [#elm/integer"1"] 1
+      #elm/list [#elm/decimal "2" #elm/decimal "10" #elm/decimal "8"] 8M
+      #elm/list [#elm/integer "2" #elm/integer "10" #elm/integer "8"] 8
+      #elm/list [#elm/integer "1" #elm/integer "2"] 1.5M
+      #elm/list [#elm/integer "1"] 1
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -224,9 +224,9 @@
 (deftest compile-min-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/min source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"8"] 2M
-      #elm/list [#elm/integer"2" #elm/integer"8"] 2
-      #elm/list [#elm/integer"1"] 1
+      #elm/list [#elm/decimal "2" #elm/decimal "8"] 2M
+      #elm/list [#elm/integer "2" #elm/integer "8"] 2
+      #elm/list [#elm/integer "1"] 1
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -246,10 +246,10 @@
 (deftest compile-mode-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/mode source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"2" #elm/decimal"8"] 2M
-      #elm/list [#elm/integer"2" #elm/integer"2" #elm/integer"8"] 2
-      #elm/list [#elm/integer"1"] 1
-      #elm/list [#elm/integer"1" {:type "Null"} {:type "Null"}] 1
+      #elm/list [#elm/decimal "2" #elm/decimal "2" #elm/decimal "8"] 2M
+      #elm/list [#elm/integer "2" #elm/integer "2" #elm/integer "8"] 2
+      #elm/list [#elm/integer "1"] 1
+      #elm/list [#elm/integer "1" {:type "Null"} {:type "Null"}] 1
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -270,7 +270,7 @@
 (deftest compile-population-variance-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/population-variance source)) {} nil nil))
-      #elm/list [#elm/decimal"1" #elm/decimal"2" #elm/decimal"3" #elm/decimal"4" #elm/decimal"5"] 2M
+      #elm/list [#elm/decimal "1" #elm/decimal "2" #elm/decimal "3" #elm/decimal "4" #elm/decimal "5"] 2M
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -291,7 +291,7 @@
 (deftest compile-population-std-dev-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/population-std-dev source)) {} nil nil))
-      #elm/list [#elm/decimal"1" #elm/decimal"2" #elm/decimal"3" #elm/decimal"4" #elm/decimal"5"] 1.41421356M
+      #elm/list [#elm/decimal "1" #elm/decimal "2" #elm/decimal "3" #elm/decimal "4" #elm/decimal "5"] 1.41421356M
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -311,9 +311,9 @@
 (deftest compile-sum-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/sum source)) {} nil nil))
-      #elm/list [#elm/decimal"2" #elm/decimal"8"] 10M
-      #elm/list [#elm/integer"2" #elm/integer"8"] 10
-      #elm/list [#elm/integer"1"] 1
+      #elm/list [#elm/decimal "2" #elm/decimal "8"] 10M
+      #elm/list [#elm/integer "2" #elm/integer "8"] 10
+      #elm/list [#elm/integer "1"] 1
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -334,7 +334,7 @@
 (deftest compile-std-dev-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/std-dev source)) {} nil nil))
-      #elm/list [#elm/decimal"1" #elm/decimal"2" #elm/decimal"3" #elm/decimal"4" #elm/decimal"5"] 1.58113883M
+      #elm/list [#elm/decimal "1" #elm/decimal "2" #elm/decimal "3" #elm/decimal "4" #elm/decimal "5"] 1.58113883M
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
@@ -355,7 +355,7 @@
 (deftest compile-variance-test
   (testing "Without path"
     (are [source res] (= res (core/-eval (c/compile {} (elm/variance source)) {} nil nil))
-      #elm/list [#elm/decimal"1" #elm/decimal"2" #elm/decimal"3" #elm/decimal"4" #elm/decimal"5"] 2.5M
+      #elm/list [#elm/decimal "1" #elm/decimal "2" #elm/decimal "3" #elm/decimal "4" #elm/decimal "5"] 2.5M
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil

--- a/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
@@ -86,7 +86,9 @@
         [0M "m"] (quantity/quantity 0M "m")
         [1M "m"] (quantity/quantity 1M "m"))))
 
-  (tu/testing-unary-null elm/abs))
+  (tu/testing-unary-null elm/abs)
+
+  (tu/testing-unary-form elm/abs))
 
 
 ;; 16.2. Add
@@ -137,25 +139,25 @@
         "1" "0" 1
         "1" "1" 2))
 
-    (tu/testing-binary-null elm/add #elm/integer"1"))
+    (tu/testing-binary-null elm/add #elm/integer "1"))
 
   (testing "Adding zero integer to any integer or decimal doesn't change it"
     (satisfies-prop 100
       (prop/for-all [operand (s/gen (s/or :i :elm/integer :d :elm/decimal))]
-        (let [elm (elm/equal [(elm/add [operand #elm/integer"0"]) operand])]
+        (let [elm (elm/equal [(elm/add [operand #elm/integer "0"]) operand])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding zero decimal to any decimal doesn't change it"
     (satisfies-prop 100
       (prop/for-all [operand (s/gen :elm/decimal)]
-        (let [elm (elm/equal [(elm/add [operand #elm/decimal"0"]) operand])]
+        (let [elm (elm/equal [(elm/add [operand #elm/decimal "0"]) operand])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding identical integers equals multiplying the same integer by two"
     (satisfies-prop 100
       (prop/for-all [integer (s/gen :elm/integer)]
         (let [elm (elm/equivalent [(elm/add [integer integer])
-                                   (elm/multiply [integer #elm/integer"2"])])]
+                                   (elm/multiply [integer #elm/integer "2"])])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Decimal"
@@ -167,37 +169,37 @@
         "1.1" "0" 1.1M
         "1.1" "1.1" 2.2M)
 
-      (tu/testing-binary-null elm/add #elm/decimal"1.1"))
+      (tu/testing-binary-null elm/add #elm/decimal "1.1"))
 
     (testing "Mix with integer"
       (are [x y res] (= res (c/compile {} (elm/add [x y])))
-        #elm/decimal"1.1" #elm/integer"1" 2.1M
-        #elm/integer"1" #elm/decimal"1.1" 2.1M)
+        #elm/decimal "1.1" #elm/integer "1" 2.1M
+        #elm/integer "1" #elm/decimal "1.1" 2.1M)
 
-      (tu/testing-binary-null elm/add #elm/integer"1" #elm/decimal"1.1")
-      (tu/testing-binary-null elm/add #elm/decimal"1.1" #elm/integer"1"))
+      (tu/testing-binary-null elm/add #elm/integer "1" #elm/decimal "1.1")
+      (tu/testing-binary-null elm/add #elm/decimal "1.1" #elm/integer "1"))
 
     (testing "Trailing zeros are preserved"
       (are [x y res] (= res (str (core/-eval (c/compile {} (elm/add [x y])) {} nil nil)))
-        #elm/decimal"1.23" #elm/decimal"1.27" "2.50"))
+        #elm/decimal "1.23" #elm/decimal "1.27" "2.50"))
 
     (testing "Arithmetic overflow results in nil"
       (are [x y] (nil? (core/-eval (c/compile {} (elm/add [x y])) {} nil nil))
-        #elm/decimal"99999999999999999999" #elm/decimal"1"
-        #elm/decimal"99999999999999999999.99999999" #elm/decimal"1")))
+        #elm/decimal "99999999999999999999" #elm/decimal "1"
+        #elm/decimal "99999999999999999999.99999999" #elm/decimal "1")))
 
   (testing "Adding identical decimals equals multiplying the same decimal by two"
     (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/decimal)]
         (let [elm (elm/equal [(elm/add [decimal decimal])
-                              (elm/multiply [decimal #elm/integer"2"])])]
+                              (elm/multiply [decimal #elm/integer "2"])])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding identical decimals and dividing by two results in the same decimal"
     (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/decimal)]
         (let [elm (elm/equal [(elm/divide [(elm/add [decimal decimal])
-                                           #elm/integer"2"])
+                                           #elm/integer "2"])
                               decimal])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
@@ -228,7 +230,7 @@
       100
       (prop/for-all [quantity (gen/such-that :value (s/gen :elm/quantity) 100)]
         (let [elm (elm/equal [(elm/add [quantity quantity])
-                              (elm/multiply [quantity #elm/integer"2"])])]
+                              (elm/multiply [quantity #elm/integer "2"])])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Adding identical quantities and dividing by two results in the same quantity"
@@ -236,24 +238,24 @@
       100
       (prop/for-all [quantity (gen/such-that :value (s/gen :elm/quantity) 100)]
         (let [elm (elm/equal [(elm/divide [(elm/add [quantity quantity])
-                                           #elm/integer"2"])
+                                           #elm/integer "2"])
                               quantity])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
   (testing "Date + Quantity"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/add [x y])) {} nil nil))
-      #elm/date"2019" #elm/quantity[1 "year"] (system/date 2020)
-      #elm/date"2019" #elm/quantity[13 "months"] (system/date 2020)
+      #elm/date "2019" #elm/quantity [1 "year"] (system/date 2020)
+      #elm/date "2019" #elm/quantity [13 "months"] (system/date 2020)
 
-      #elm/date"2019-01" #elm/quantity[1 "month"] (system/date 2019 2)
-      #elm/date"2019-01" #elm/quantity[12 "month"] (system/date 2020 1)
-      #elm/date"2019-01" #elm/quantity[13 "month"] (system/date 2020 2)
-      #elm/date"2019-01" #elm/quantity[1 "year"] (system/date 2020 1)
+      #elm/date "2019-01" #elm/quantity [1 "month"] (system/date 2019 2)
+      #elm/date "2019-01" #elm/quantity [12 "month"] (system/date 2020 1)
+      #elm/date "2019-01" #elm/quantity [13 "month"] (system/date 2020 2)
+      #elm/date "2019-01" #elm/quantity [1 "year"] (system/date 2020 1)
 
-      #elm/date"2019-01-01" #elm/quantity[1 "year"] (system/date 2020 1 1)
-      #elm/date"2012-02-29" #elm/quantity[1 "year"] (system/date 2013 2 28)
-      #elm/date"2019-01-01" #elm/quantity[1 "month"] (system/date 2019 2 1)
-      #elm/date"2019-01-01" #elm/quantity[1 "day"] (system/date 2019 1 2)))
+      #elm/date "2019-01-01" #elm/quantity [1 "year"] (system/date 2020 1 1)
+      #elm/date "2012-02-29" #elm/quantity [1 "year"] (system/date 2013 2 28)
+      #elm/date "2019-01-01" #elm/quantity [1 "month"] (system/date 2019 2 1)
+      #elm/date "2019-01-01" #elm/quantity [1 "day"] (system/date 2019 1 2)))
 
   (testing "Adding a positive amount of years to a year makes it greater"
     (satisfies-prop 100
@@ -336,19 +338,21 @@
 
   (testing "DateTime + Quantity"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/add [x y])) {} nil nil))
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "year"] (system/date-time 2020 1 1 0 0 0)
-      #elm/date-time"2012-02-29T00" #elm/quantity[1 "year"] (system/date-time 2013 2 28 0 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "month"] (system/date-time 2019 2 1 0 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "day"] (system/date-time 2019 1 2 0 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "hour"] (system/date-time 2019 1 1 1 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "minute"] (system/date-time 2019 1 1 0 1 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "second"] (system/date-time 2019 1 1 0 0 1)))
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "year"] (system/date-time 2020 1 1 0 0 0)
+      #elm/date-time "2012-02-29T00" #elm/quantity [1 "year"] (system/date-time 2013 2 28 0 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "month"] (system/date-time 2019 2 1 0 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "day"] (system/date-time 2019 1 2 0 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "hour"] (system/date-time 2019 1 1 1 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "minute"] (system/date-time 2019 1 1 0 1 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "second"] (system/date-time 2019 1 1 0 0 1)))
 
   (testing "Time + Quantity"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/add [x y])) {} nil nil))
-      #elm/time"00:00:00" #elm/quantity[1 "hour"] (date-time/local-time 1 0 0)
-      #elm/time"00:00:00" #elm/quantity[1 "minute"] (date-time/local-time 0 1 0)
-      #elm/time"00:00:00" #elm/quantity[1 "second"] (date-time/local-time 0 0 1))))
+      #elm/time "00:00:00" #elm/quantity [1 "hour"] (date-time/local-time 1 0 0)
+      #elm/time "00:00:00" #elm/quantity [1 "minute"] (date-time/local-time 0 1 0)
+      #elm/time "00:00:00" #elm/quantity [1 "second"] (date-time/local-time 0 0 1)))
+
+  (tu/testing-binary-form elm/add))
 
 
 ;; 16.3. Ceiling
@@ -359,10 +363,12 @@
 ;; If the argument is null, the result is null.
 (deftest compile-ceiling-test
   (are [x res] (= res (c/compile {} (elm/ceiling x)))
-    #elm/integer"1" 1
-    #elm/decimal"1.1" 2)
+    #elm/integer "1" 1
+    #elm/decimal "1.1" 2)
 
-  (tu/testing-unary-null elm/ceiling))
+  (tu/testing-unary-null elm/ceiling)
+
+  (tu/testing-unary-form elm/ceiling))
 
 
 ;; 16.4. Divide
@@ -391,7 +397,7 @@
         "1" "0" nil
         "1" "0.0" nil))
 
-    (tu/testing-binary-null elm/divide #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/divide #elm/decimal "1.1"))
 
   (testing "Integer"
     (testing "Static"
@@ -401,7 +407,7 @@
 
         "1" "0" nil))
 
-    (tu/testing-binary-null elm/divide #elm/integer"1"))
+    (tu/testing-binary-null elm/divide #elm/integer "1"))
 
   (testing "Decimal/Integer"
     (testing "Static"
@@ -410,7 +416,7 @@
 
         "1" "0" nil))
 
-    (tu/testing-binary-null elm/divide #elm/decimal"1.1" #elm/integer"1"))
+    (tu/testing-binary-null elm/divide #elm/decimal "1.1" #elm/integer "1"))
 
   (testing "Integer/Decimal"
     (testing "Static"
@@ -420,7 +426,7 @@
         "1" "0" nil
         "1" "0.0" nil))
 
-    (tu/testing-binary-null elm/divide #elm/integer"1" #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/divide #elm/integer "1" #elm/decimal "1.1"))
 
   (testing "Quantity"
     (testing "Static"
@@ -430,27 +436,29 @@
 
         [12 "cm2"] [3 "cm"] (quantity/quantity 4 "cm")))
 
-    (tu/testing-binary-null elm/divide #elm/quantity[1]))
+    (tu/testing-binary-null elm/divide #elm/quantity [1]))
 
   (testing "Quantity/Integer"
     (testing "Static"
       (are [x y res] (p/equal res (tu/compile-binop elm/divide elm/quantity elm/integer x y))
         [1M "m"] "2" (quantity/quantity 0.5M "m")))
 
-    (tu/testing-binary-null elm/divide #elm/quantity[1] #elm/integer"1"))
+    (tu/testing-binary-null elm/divide #elm/quantity [1] #elm/integer "1"))
 
   (testing "Quantity/Decimal"
     (testing "Static"
       (are [x y res] (p/equal res (tu/compile-binop elm/divide elm/quantity elm/decimal x y))
         [2.5M "m"] "2.5" (quantity/quantity 1M "m")))
 
-    (tu/testing-binary-null elm/divide #elm/quantity[1] #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/divide #elm/quantity [1] #elm/decimal "1.1"))
 
   (testing "(d / d) * d = d"
     (satisfies-prop 100
       (prop/for-all [decimal (s/gen :elm/non-zero-decimal)]
         (let [elm (elm/equal [(elm/multiply [(elm/divide [decimal decimal]) decimal]) decimal])]
-          (true? (core/-eval (c/compile {} elm) {} nil nil)))))))
+          (true? (core/-eval (c/compile {} elm) {} nil nil))))))
+
+  (tu/testing-binary-form elm/divide))
 
 
 ;; 16.5. Exp
@@ -460,10 +468,12 @@
 ;; If the argument is null, the result is null.
 (deftest compile-exp-test
   (are [x res] (= res (c/compile {} (elm/exp x)))
-    #elm/integer"0" 1M
-    #elm/decimal"0" 1M)
+    #elm/integer "0" 1M
+    #elm/decimal "0" 1M)
 
-  (tu/testing-unary-null elm/exp))
+  (tu/testing-unary-null elm/exp)
+
+  (tu/testing-unary-form elm/exp))
 
 
 ;; 16.6. Floor
@@ -474,10 +484,12 @@
 ;; If the argument is null, the result is null.
 (deftest compile-floor-test
   (are [x res] (= res (c/compile {} (elm/floor x)))
-    #elm/integer"1" 1
-    #elm/decimal"1.1" 1)
+    #elm/integer "1" 1
+    #elm/decimal "1.1" 1)
 
-  (tu/testing-unary-null elm/floor))
+  (tu/testing-unary-null elm/floor)
+
+  (tu/testing-unary-form elm/floor))
 
 
 ;; 16.7. HighBoundary
@@ -506,20 +518,22 @@
 (deftest compile-log-test
   (testing "Integer"
     (are [x base res] (= res (c/compile {} (elm/log [x base])))
-      #elm/integer"16" #elm/integer"2" 4M
+      #elm/integer "16" #elm/integer "2" 4M
 
-      #elm/integer"0" #elm/integer"2" nil)
+      #elm/integer "0" #elm/integer "2" nil)
 
-    (tu/testing-binary-null elm/log #elm/integer"1"))
+    (tu/testing-binary-null elm/log #elm/integer "1"))
 
   (testing "Decimal"
     (are [x base res] (= res (c/compile {} (elm/log [x base])))
-      #elm/decimal"100" #elm/decimal"10" 2M
-      #elm/decimal"1" #elm/decimal"1" nil
+      #elm/decimal "100" #elm/decimal "10" 2M
+      #elm/decimal "1" #elm/decimal "1" nil
 
-      #elm/decimal"0" #elm/integer"2" nil)
+      #elm/decimal "0" #elm/integer "2" nil)
 
-    (tu/testing-binary-null elm/log #elm/decimal"1.1")))
+    (tu/testing-binary-null elm/log #elm/decimal "1.1"))
+
+  (tu/testing-binary-form elm/log))
 
 
 ;; 16.9. LowBoundary
@@ -548,20 +562,22 @@
 ;; If the result of the operation cannot be represented, the result is null.
 (deftest compile-ln-test
   (are [x res] (= res (c/compile {} (elm/ln x)))
-    #elm/integer"1" 0M
-    #elm/integer"2" 0.69314718M
-    #elm/integer"3" 1.09861229M
+    #elm/integer "1" 0M
+    #elm/integer "2" 0.69314718M
+    #elm/integer "3" 1.09861229M
 
-    #elm/decimal"1" 0M
-    #elm/decimal"1.1" 0.09531018M
+    #elm/decimal "1" 0M
+    #elm/decimal "1.1" 0.09531018M
 
-    #elm/integer"0" nil
-    #elm/decimal"0" nil
+    #elm/integer "0" nil
+    #elm/decimal "0" nil
 
-    #elm/integer"-1" nil
-    #elm/decimal"-1" nil)
+    #elm/integer "-1" nil
+    #elm/decimal "-1" nil)
 
-  (tu/testing-unary-null elm/ln))
+  (tu/testing-unary-null elm/ln)
+
+  (tu/testing-unary-form elm/ln))
 
 
 ;; 16.11. MaxValue
@@ -671,7 +687,7 @@
       "3" "2" 1
       "5" "3" 2)
 
-    (tu/testing-binary-null elm/modulo #elm/integer"1"))
+    (tu/testing-binary-null elm/modulo #elm/integer "1"))
 
   (testing "Decimal"
     (are [x div res] (= res (tu/compile-binop elm/modulo elm/decimal x div))
@@ -681,12 +697,14 @@
 
       "2.5" "2" 0.5M)
 
-    (tu/testing-binary-null elm/modulo #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/modulo #elm/decimal "1.1"))
 
   (testing "Mixed Integer and Decimal"
     (are [x div res] (= res (core/-eval (c/compile {} (elm/modulo [x div])) {} nil nil))
-      #elm/integer"1" #elm/integer"0" nil
-      #elm/decimal"1" #elm/decimal"0" nil)))
+      #elm/integer "1" #elm/integer "0" nil
+      #elm/decimal "1" #elm/decimal "0" nil))
+
+  (tu/testing-binary-form elm/modulo))
 
 
 ;; 16.14. Multiply
@@ -707,7 +725,7 @@
       "1" "2" 2
       "2" "2" 4)
 
-    (tu/testing-binary-null elm/multiply #elm/integer"1"))
+    (tu/testing-binary-null elm/multiply #elm/integer "1"))
 
   (testing "Decimal"
     (testing "Decimal"
@@ -715,7 +733,7 @@
         "1" "2" 2M
         "1.23456" "1.23456" 1.52413839M)
 
-      (tu/testing-binary-null elm/multiply #elm/decimal"1.1"))
+      (tu/testing-binary-null elm/multiply #elm/decimal "1.1"))
 
     (testing "Arithmetic overflow results in nil"
       (are [x y] (nil? (tu/compile-binop elm/multiply elm/decimal x y))
@@ -724,10 +742,12 @@
 
   (testing "Quantity"
     (are [x y res] (p/equal res (core/-eval (c/compile {} (elm/multiply [x y])) {} nil nil))
-      #elm/quantity[1 "m"] #elm/integer"2" (quantity/quantity 2 "m")
-      #elm/quantity[1 "m"] #elm/quantity[2 "m"] (quantity/quantity 2 "m2"))
+      #elm/quantity [1 "m"] #elm/integer "2" (quantity/quantity 2 "m")
+      #elm/quantity [1 "m"] #elm/quantity [2 "m"] (quantity/quantity 2 "m2"))
 
-    (tu/testing-binary-null elm/multiply #elm/quantity[1])))
+    (tu/testing-binary-null elm/multiply #elm/quantity [1]))
+
+  (tu/testing-binary-form elm/multiply))
 
 
 ;; 16.15. Negate
@@ -750,12 +770,14 @@
 
   (testing "Quantity"
     (are [x res] (= res (c/compile {} (elm/negate x)))
-      #elm/quantity[1] (quantity/quantity -1 "1")
-      #elm/quantity[1M] (quantity/quantity -1M "1")
-      #elm/quantity[1 "m"] (quantity/quantity -1 "m")
-      #elm/quantity[1M "m"] (quantity/quantity -1M "m")))
+      #elm/quantity [1] (quantity/quantity -1 "1")
+      #elm/quantity [1M] (quantity/quantity -1M "1")
+      #elm/quantity [1 "m"] (quantity/quantity -1 "m")
+      #elm/quantity [1M "m"] (quantity/quantity -1M "m")))
 
-  (tu/testing-unary-null elm/negate))
+  (tu/testing-unary-null elm/negate)
+
+  (tu/testing-unary-form elm/negate))
 
 
 ;; 16.16. Power
@@ -773,7 +795,7 @@
       "10" "2" 100
       "2" "-2" 0.25M)
 
-    (tu/testing-binary-null elm/power #elm/integer"1"))
+    (tu/testing-binary-null elm/power #elm/integer "1"))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/power elm/decimal x y))
@@ -781,13 +803,15 @@
       "10" "2" 100M
       "4" "0.5" 2M)
 
-    (tu/testing-binary-null elm/power #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/power #elm/decimal "1.1"))
 
   (testing "Mixed"
     (are [x y res] (= res (c/compile {} (elm/power [x y])))
-      #elm/decimal"2.5" #elm/integer"2" 6.25M
-      #elm/decimal"10" #elm/integer"2" 100M
-      #elm/decimal"10" #elm/integer"2" 100M)))
+      #elm/decimal "2.5" #elm/integer "2" 6.25M
+      #elm/decimal "10" #elm/integer "2" 100M
+      #elm/decimal "10" #elm/integer "2" 100M))
+
+  (tu/testing-binary-form elm/power))
 
 
 ;; 16.17. Precision
@@ -831,35 +855,37 @@
 (deftest compile-predecessor-test
   (testing "Integer"
     (are [x res] (= res (c/compile {} (elm/predecessor x)))
-      #elm/integer"0" -1))
+      #elm/integer "0" -1))
 
   (testing "Decimal"
     (are [x res] (= res (c/compile {} (elm/predecessor x)))
-      #elm/decimal"0" -1E-8M))
+      #elm/decimal "0" -1E-8M))
 
   (testing "Date"
     (are [x res] (= res (c/compile {} (elm/predecessor x)))
-      #elm/date"2019" (system/date 2018)
-      #elm/date"2019-01" (system/date 2018 12)
-      #elm/date"2019-01-01" (system/date 2018 12 31)))
+      #elm/date "2019" (system/date 2018)
+      #elm/date "2019-01" (system/date 2018 12)
+      #elm/date "2019-01-01" (system/date 2018 12 31)))
 
   (testing "DateTime"
     (are [x res] (= res (c/compile {} (elm/predecessor x)))
-      #elm/date-time"2019" (system/date-time 2018)
-      #elm/date-time"2019-01" (system/date-time 2018 12)
-      #elm/date-time"2019-01-01" (system/date-time 2018 12 31)
-      #elm/date-time"2019-01-01T00" (system/date-time 2018 12 31 23 59 59 999)))
+      #elm/date-time "2019" (system/date-time 2018)
+      #elm/date-time "2019-01" (system/date-time 2018 12)
+      #elm/date-time "2019-01-01" (system/date-time 2018 12 31)
+      #elm/date-time "2019-01-01T00" (system/date-time 2018 12 31 23 59 59 999)))
 
   (testing "Time"
     (are [x res] (= res (c/compile {} (elm/predecessor x)))
-      #elm/time"12:00" (date-time/local-time 11 59)))
+      #elm/time "12:00" (date-time/local-time 11 59)))
 
   (testing "Quantity"
     (are [x res] (= res (c/compile {} (elm/predecessor x)))
-      #_#_#elm/quantity[0 "m"] (quantity/quantity -1 "m")   ; TODO: implement
-      #elm/quantity[0M "m"] (quantity/quantity -1E-8M "m")))
+      #_#_#elm/quantity [0 "m"] (quantity/quantity -1 "m")   ; TODO: implement
+      #elm/quantity [0M "m"] (quantity/quantity -1E-8M "m")))
 
   (tu/testing-unary-null elm/predecessor)
+
+  (tu/testing-unary-form elm/predecessor)
 
   (testing "throws error if the argument is already the minimum value"
     (are [x]
@@ -867,14 +893,14 @@
          (::anom/category (ba/try-anomaly (c/compile {} (elm/predecessor x)))))
 
       (elm/decimal (str decimal/min))
-      #elm/date"0001"
-      #elm/date"0001-01"
-      #elm/date"0001-01-01"
-      #elm/time"00:00:00.0"
-      #elm/date-time"0001"
-      #elm/date-time"0001-01"
-      #elm/date-time"0001-01-01"
-      #elm/date-time"0001-01-01T00:00:00.0"
+      #elm/date "0001"
+      #elm/date "0001-01"
+      #elm/date "0001-01-01"
+      #elm/time "00:00:00.0"
+      #elm/date-time "0001"
+      #elm/date-time "0001-01"
+      #elm/date-time "0001-01-01"
+      #elm/date-time "0001-01-01T00:00:00.0"
       (elm/quantity [decimal/min]))))
 
 
@@ -889,40 +915,49 @@
 ;; Precision determines the decimal place at which the rounding will occur. If
 ;; precision is not specified or null, 0 is assumed.
 (deftest compile-round-test
-  (testing "Without precision"
-    (testing "Static"
+  (testing "without precision"
+    (testing "static"
       (are [x res] (= res (c/compile {} (elm/round [x])))
-        #elm/integer"1" 1M
-        #elm/decimal"1" 1M
-        #elm/decimal"0.5" 1M
-        #elm/decimal"0.4" 0M
-        #elm/decimal"-0.4" 0M
-        #elm/decimal"-0.5" -1M
-        #elm/decimal"-0.6" -1M
-        #elm/decimal"-1.1" -1M
-        #elm/decimal"-1.5" -2M
-        #elm/decimal"-1.6" -2M
+        #elm/integer "1" 1M
+        #elm/decimal "1" 1M
+        #elm/decimal "0.5" 1M
+        #elm/decimal "0.4" 0M
+        #elm/decimal "-0.4" 0M
+        #elm/decimal "-0.5" -1M
+        #elm/decimal "-0.6" -1M
+        #elm/decimal "-1.1" -1M
+        #elm/decimal "-1.5" -2M
+        #elm/decimal "-1.6" -2M
         {:type "Null"} nil))
 
-    (testing "Dynamic Null"
+    (testing "dynamic null"
       (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}
-            elm #elm/round[#elm/parameter-ref"x"]
+            elm #elm/round [#elm/parameter-ref "x"]
             expr (c/compile compile-ctx elm)
             eval-ctx {:parameters {"x" nil}}]
         (is (nil? (core/-eval expr eval-ctx nil nil))))))
 
-  (testing "With precision"
+  (testing "with precision"
     (testing "Static"
       (are [x precision res] (= res (c/compile {} (elm/round [x precision])))
-        #elm/decimal"3.14159" #elm/integer"3" 3.142M
-        {:type "Null"} #elm/integer"3" nil))
+        #elm/decimal "3.14159" #elm/integer "3" 3.142M
+        {:type "Null"} #elm/integer "3" nil))
 
-    (testing "Dynamic Null"
+    (testing "dynamic null"
       (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}
-            elm #elm/round[#elm/parameter-ref"x" #elm/integer"3"]
+            elm #elm/round [#elm/parameter-ref "x" #elm/integer "3"]
             expr (c/compile compile-ctx elm)
             eval-ctx {:parameters {"x" nil}}]
-        (is (nil? (core/-eval expr eval-ctx nil nil)))))))
+        (is (nil? (core/-eval expr eval-ctx nil nil))))))
+
+  (testing "form"
+    (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}]
+      (are [elm form] (= form (core/-form (c/compile compile-ctx elm)))
+        #elm/round [#elm/parameter-ref "x"]
+        '(round (param-ref "x"))
+
+        #elm/round [#elm/parameter-ref "x" #elm/integer "3"]
+        '(round (param-ref "x") 3)))))
 
 
 ;; 16.20. Subtract
@@ -960,14 +995,14 @@
 (deftest compile-subtract-test
   (testing "Integer"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-      #elm/integer"-1" #elm/integer"-1" 0
-      #elm/integer"-1" #elm/integer"0" -1
-      #elm/integer"1" #elm/integer"1" 0
-      #elm/integer"1" #elm/integer"0" 1
-      #elm/integer"1" #elm/integer"-1" 2
+      #elm/integer "-1" #elm/integer "-1" 0
+      #elm/integer "-1" #elm/integer "0" -1
+      #elm/integer "1" #elm/integer "1" 0
+      #elm/integer "1" #elm/integer "0" 1
+      #elm/integer "1" #elm/integer "-1" 2
 
-      {:type "Null"} #elm/integer"1" nil
-      #elm/integer"1" {:type "Null"} nil))
+      {:type "Null"} #elm/integer "1" nil
+      #elm/integer "1" {:type "Null"} nil))
 
   (testing "Subtracting identical integers results in zero"
     (satisfies-prop 100
@@ -977,23 +1012,23 @@
   (testing "Decimal"
     (testing "Decimal"
       (are [x y res] (= res (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-        #elm/decimal"-1" #elm/decimal"-1" 0M
-        #elm/decimal"-1" #elm/decimal"0" -1M
-        #elm/decimal"1" #elm/decimal"1" 0M
-        #elm/decimal"1" #elm/decimal"0" 1M
-        #elm/decimal"1" #elm/decimal"-1" 2M
+        #elm/decimal "-1" #elm/decimal "-1" 0M
+        #elm/decimal "-1" #elm/decimal "0" -1M
+        #elm/decimal "1" #elm/decimal "1" 0M
+        #elm/decimal "1" #elm/decimal "0" 1M
+        #elm/decimal "1" #elm/decimal "-1" 2M
 
-        {:type "Null"} #elm/decimal"1.1" nil
-        #elm/decimal"1.1" {:type "Null"} nil))
+        {:type "Null"} #elm/decimal "1.1" nil
+        #elm/decimal "1.1" {:type "Null"} nil))
 
     (testing "Mix with integer"
       (are [x y res] (= res (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-        #elm/decimal"1" #elm/integer"1" 0M))
+        #elm/decimal "1" #elm/integer "1" 0M))
 
     (testing "Arithmetic overflow results in nil"
       (are [x y] (nil? (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-        #elm/decimal"-99999999999999999999" #elm/decimal"1"
-        #elm/decimal"-99999999999999999999.99999999" #elm/decimal"1")))
+        #elm/decimal "-99999999999999999999" #elm/decimal "1"
+        #elm/decimal "-99999999999999999999.99999999" #elm/decimal "1")))
 
   (testing "Subtracting identical decimals results in zero"
     (satisfies-prop 100
@@ -1002,25 +1037,25 @@
 
   (testing "Time-based quantity"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-      #elm/quantity[1 "year"] #elm/quantity[1 "year"] (date-time/period 0 0 0)
-      #elm/quantity[1 "year"] #elm/quantity[1 "month"] (date-time/period 0 11 0)
-      #elm/quantity[1 "year"] #elm/quantity[1 "day"] (date-time/period 1 0 (- (* 24 3600 1000)))
+      #elm/quantity [1 "year"] #elm/quantity [1 "year"] (date-time/period 0 0 0)
+      #elm/quantity [1 "year"] #elm/quantity [1 "month"] (date-time/period 0 11 0)
+      #elm/quantity [1 "year"] #elm/quantity [1 "day"] (date-time/period 1 0 (- (* 24 3600 1000)))
 
-      #elm/quantity[1 "day"] #elm/quantity[1 "day"] (date-time/period 0 0 0)
-      #elm/quantity[1 "day"] #elm/quantity[1 "hour"] (date-time/period 0 0 (* 23 3600 1000))
+      #elm/quantity [1 "day"] #elm/quantity [1 "day"] (date-time/period 0 0 0)
+      #elm/quantity [1 "day"] #elm/quantity [1 "hour"] (date-time/period 0 0 (* 23 3600 1000))
 
-      #elm/quantity[1 "year"] #elm/quantity[1.1M "year"] (date-time/period -0.1M 0 0)
-      #elm/quantity[1 "year"] #elm/quantity[13.1M "month"] (date-time/period 0 -1.1M 0)))
+      #elm/quantity [1 "year"] #elm/quantity [1.1M "year"] (date-time/period -0.1M 0 0)
+      #elm/quantity [1 "year"] #elm/quantity [13.1M "month"] (date-time/period 0 -1.1M 0)))
 
   (testing "UCUM quantity"
     (are [x y res] (p/equal res (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-      #elm/quantity[1 "m"] #elm/quantity[1 "m"] (quantity/quantity 0 "m")
-      #elm/quantity[1 "m"] #elm/quantity[1 "cm"] (quantity/quantity 0.99 "m")))
+      #elm/quantity [1 "m"] #elm/quantity [1 "m"] (quantity/quantity 0 "m")
+      #elm/quantity [1 "m"] #elm/quantity [1 "cm"] (quantity/quantity 0.99 "m")))
 
   (testing "Incompatible UCUM Quantity Subtractions"
     (are [x y] (thrown? UnconvertibleException (core/-eval (c/compile {} (elm/subtract [x y])) {} nil nil))
-      #elm/quantity[1 "cm2"] #elm/quantity[1 "cm"]
-      #elm/quantity[1 "m"] #elm/quantity[1 "s"]))
+      #elm/quantity [1 "cm2"] #elm/quantity [1 "cm"]
+      #elm/quantity [1 "m"] #elm/quantity [1 "s"]))
 
   (testing "Subtracting identical quantities results in zero"
     (satisfies-prop
@@ -1034,18 +1069,18 @@
 
   (testing "Date - Quantity"
     (are [x y res] (= res (c/compile {} (elm/subtract [x y])))
-      #elm/date"2019" #elm/quantity[1 "year"] (system/date 2018)
-      #elm/date"2019" #elm/quantity[13 "months"] (system/date 2018)
+      #elm/date "2019" #elm/quantity [1 "year"] (system/date 2018)
+      #elm/date "2019" #elm/quantity [13 "months"] (system/date 2018)
 
-      #elm/date"2019-01" #elm/quantity[1 "month"] (system/date 2018 12)
-      #elm/date"2019-01" #elm/quantity[12 "month"] (system/date 2018 1)
-      #elm/date"2019-01" #elm/quantity[13 "month"] (system/date 2017 12)
-      #elm/date"2019-01" #elm/quantity[1 "year"] (system/date 2018 1)
+      #elm/date "2019-01" #elm/quantity [1 "month"] (system/date 2018 12)
+      #elm/date "2019-01" #elm/quantity [12 "month"] (system/date 2018 1)
+      #elm/date "2019-01" #elm/quantity [13 "month"] (system/date 2017 12)
+      #elm/date "2019-01" #elm/quantity [1 "year"] (system/date 2018 1)
 
-      #elm/date"2019-01-01" #elm/quantity[1 "year"] (system/date 2018 1 1)
-      #elm/date"2012-02-29" #elm/quantity[1 "year"] (system/date 2011 2 28)
-      #elm/date"2019-01-01" #elm/quantity[1 "month"] (system/date 2018 12 1)
-      #elm/date"2019-01-01" #elm/quantity[1 "day"] (system/date 2018 12 31)))
+      #elm/date "2019-01-01" #elm/quantity [1 "year"] (system/date 2018 1 1)
+      #elm/date "2012-02-29" #elm/quantity [1 "year"] (system/date 2011 2 28)
+      #elm/date "2019-01-01" #elm/quantity [1 "month"] (system/date 2018 12 1)
+      #elm/date "2019-01-01" #elm/quantity [1 "day"] (system/date 2018 12 31)))
 
   ;; TODO: find a solution to avoid overflow
   #_(testing "Subtracting a positive amount of years from a year makes it smaller"
@@ -1097,31 +1132,33 @@
 
   (testing "DateTime - Quantity"
     (are [x y res] (= res (c/compile {} (elm/subtract [x y])))
-      #elm/date-time"2019" #elm/quantity[1 "year"] (system/date-time 2018)
-      #elm/date-time"2019" #elm/quantity[13 "months"] (system/date-time 2018)
+      #elm/date-time "2019" #elm/quantity [1 "year"] (system/date-time 2018)
+      #elm/date-time "2019" #elm/quantity [13 "months"] (system/date-time 2018)
 
-      #elm/date-time"2019-01" #elm/quantity[1 "month"] (system/date-time 2018 12)
-      #elm/date-time"2019-01" #elm/quantity[12 "month"] (system/date-time 2018 1)
-      #elm/date-time"2019-01" #elm/quantity[13 "month"] (system/date-time 2017 12)
-      #elm/date-time"2019-01" #elm/quantity[1 "year"] (system/date-time 2018 1)
+      #elm/date-time "2019-01" #elm/quantity [1 "month"] (system/date-time 2018 12)
+      #elm/date-time "2019-01" #elm/quantity [12 "month"] (system/date-time 2018 1)
+      #elm/date-time "2019-01" #elm/quantity [13 "month"] (system/date-time 2017 12)
+      #elm/date-time "2019-01" #elm/quantity [1 "year"] (system/date-time 2018 1)
 
-      #elm/date-time"2019-01-01" #elm/quantity[1 "year"] (system/date-time 2018 1 1)
-      #elm/date-time"2012-02-29" #elm/quantity[1 "year"] (system/date-time 2011 2 28)
-      #elm/date-time"2019-01-01" #elm/quantity[1 "month"] (system/date-time 2018 12 1)
-      #elm/date-time"2019-01-01" #elm/quantity[1 "day"] (system/date-time 2018 12 31)
+      #elm/date-time "2019-01-01" #elm/quantity [1 "year"] (system/date-time 2018 1 1)
+      #elm/date-time "2012-02-29" #elm/quantity [1 "year"] (system/date-time 2011 2 28)
+      #elm/date-time "2019-01-01" #elm/quantity [1 "month"] (system/date-time 2018 12 1)
+      #elm/date-time "2019-01-01" #elm/quantity [1 "day"] (system/date-time 2018 12 31)
 
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "year"] (system/date-time 2018 1 1 0 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "month"] (system/date-time 2018 12 1 0 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "day"] (system/date-time 2018 12 31 0 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "hour"] (system/date-time 2018 12 31 23 0 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "minute"] (system/date-time 2018 12 31 23 59 0)
-      #elm/date-time"2019-01-01T00" #elm/quantity[1 "second"] (system/date-time 2018 12 31 23 59 59)))
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "year"] (system/date-time 2018 1 1 0 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "month"] (system/date-time 2018 12 1 0 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "day"] (system/date-time 2018 12 31 0 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "hour"] (system/date-time 2018 12 31 23 0 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "minute"] (system/date-time 2018 12 31 23 59 0)
+      #elm/date-time "2019-01-01T00" #elm/quantity [1 "second"] (system/date-time 2018 12 31 23 59 59)))
 
   (testing "Time - Quantity"
     (are [x y res] (= res (c/compile {} (elm/subtract [x y])))
-      #elm/time"00:00:00" #elm/quantity[1 "hour"] (date-time/local-time 23 0 0)
-      #elm/time"00:00:00" #elm/quantity[1 "minute"] (date-time/local-time 23 59 0)
-      #elm/time"00:00:00" #elm/quantity[1 "second"] (date-time/local-time 23 59 59))))
+      #elm/time "00:00:00" #elm/quantity [1 "hour"] (date-time/local-time 23 0 0)
+      #elm/time "00:00:00" #elm/quantity [1 "minute"] (date-time/local-time 23 59 0)
+      #elm/time "00:00:00" #elm/quantity [1 "second"] (date-time/local-time 23 59 59)))
+
+  (tu/testing-binary-form elm/subtract))
 
 
 ;; 16.21. Successor
@@ -1152,46 +1189,48 @@
 (deftest compile-successor-test
   (testing "Integer"
     (are [x res] (= res (c/compile {} (elm/successor x)))
-      #elm/integer"0" 1))
+      #elm/integer "0" 1))
 
   (testing "Decimal"
     (are [x res] (= res (c/compile {} (elm/successor x)))
-      #elm/decimal"0" 1E-8M))
+      #elm/decimal "0" 1E-8M))
 
   (testing "Date"
     (are [x res] (= res (c/compile {} (elm/successor x)))
-      #elm/date"2019" (system/date 2020)
-      #elm/date"2019-01" (system/date 2019 2)
-      #elm/date"2019-01-01" (system/date 2019 1 2)))
+      #elm/date "2019" (system/date 2020)
+      #elm/date "2019-01" (system/date 2019 2)
+      #elm/date "2019-01-01" (system/date 2019 1 2)))
 
   (testing "DateTime"
     (are [x res] (= res (c/compile {} (elm/successor x)))
-      #elm/date-time"2019" (system/date-time 2020)
-      #elm/date-time"2019-01" (system/date-time 2019 2)
-      #elm/date-time"2019-01-01" (system/date-time 2019 1 2)
-      #elm/date-time"2019-01-01T00" (system/date-time 2019 1 1 0 0 0 1)))
+      #elm/date-time "2019" (system/date-time 2020)
+      #elm/date-time "2019-01" (system/date-time 2019 2)
+      #elm/date-time "2019-01-01" (system/date-time 2019 1 2)
+      #elm/date-time "2019-01-01T00" (system/date-time 2019 1 1 0 0 0 1)))
 
   (testing "Time"
     (are [x res] (= res (c/compile {} (elm/successor x)))
-      #elm/time"00:00:00" (date-time/local-time 0 0 1)))
+      #elm/time "00:00:00" (date-time/local-time 0 0 1)))
 
   (testing "Quantity"
     (are [x res] (= res (c/compile {} (elm/successor x)))
-      #_#_#elm/quantity[0 "m"] (quantity/quantity 1 "m")    ; TODO: implement
-      #elm/quantity[0M "m"] (quantity/quantity 1E-8M "m")))
+      #_#_#elm/quantity [0 "m"] (quantity/quantity 1 "m")    ; TODO: implement
+      #elm/quantity [0M "m"] (quantity/quantity 1E-8M "m")))
 
   (tu/testing-unary-null elm/successor)
 
   (are [x] (thrown? Exception (core/-eval (c/compile {} (elm/successor x)) {} nil nil))
     (elm/decimal (str decimal/max))
-    #elm/date"9999"
-    #elm/date"9999-12"
-    #elm/date"9999-12-31"
-    #elm/time"23:59:59.999"
-    #elm/date-time"9999"
-    #elm/date-time"9999-12"
-    #elm/date-time"9999-12-31"
-    #elm/date-time"9999-12-31T23:59:59.999"))
+    #elm/date "9999"
+    #elm/date "9999-12"
+    #elm/date "9999-12-31"
+    #elm/time "23:59:59.999"
+    #elm/date-time "9999"
+    #elm/date-time "9999-12"
+    #elm/date-time "9999-12-31"
+    #elm/date-time "9999-12-31T23:59:59.999")
+
+  (tu/testing-unary-form elm/successor))
 
 
 ;; 16.22. Truncate
@@ -1202,10 +1241,12 @@
 (deftest compile-truncate-test
   (testing "Static"
     (are [x res] (= res (c/compile {} (elm/truncate x)))
-      #elm/integer"1" 1
-      #elm/decimal"1.1" 1))
+      #elm/integer "1" 1
+      #elm/decimal "1.1" 1))
 
-  (tu/testing-unary-null elm/truncate))
+  (tu/testing-unary-null elm/truncate)
+
+  (tu/testing-unary-form elm/truncate))
 
 
 ;; 16.23. TruncatedDivide
@@ -1228,7 +1269,7 @@
         "1" "0" nil
         "1" "0.0" nil))
 
-    (tu/testing-binary-null elm/truncated-divide #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/truncated-divide #elm/decimal "1.1"))
 
   (testing "Integer"
     (testing "Static"
@@ -1239,7 +1280,7 @@
 
         "1" "0" nil))
 
-    (tu/testing-binary-null elm/truncated-divide #elm/integer"1"))
+    (tu/testing-binary-null elm/truncated-divide #elm/integer "1"))
 
   (testing "Decimal/Integer"
     (testing "Static"
@@ -1250,8 +1291,8 @@
 
         "1" "0" nil))
 
-    (tu/testing-binary-null elm/truncated-divide #elm/decimal"1.1"
-                            #elm/integer"1"))
+    (tu/testing-binary-null elm/truncated-divide #elm/decimal "1.1"
+                            #elm/integer "1"))
 
   (testing "Integer/Decimal"
     (testing "Static"
@@ -1263,5 +1304,7 @@
         "1" "0" nil
         "1" "0.0" nil))
 
-    (tu/testing-binary-null elm/truncated-divide #elm/integer"1"
-                            #elm/decimal"1.1")))
+    (tu/testing-binary-null elm/truncated-divide #elm/integer "1"
+                            #elm/decimal "1.1"))
+
+  (tu/testing-binary-form elm/truncated-divide))

--- a/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
@@ -58,18 +58,18 @@
 (deftest compile-calculate-age-at-test
   (testing "Year"
     (are [elm res] (= res (core/-eval (c/compile {} elm) {:now tu/now} nil nil))
-      {:type "CalculateAgeAt" :operand [#elm/date"2018" #elm/date"2019"]
+      {:type "CalculateAgeAt" :operand [#elm/date "2018" #elm/date "2019"]
        :precision "Year"}
       1
-      {:type "CalculateAgeAt" :operand [#elm/date"2018" #elm/date"2018"]
+      {:type "CalculateAgeAt" :operand [#elm/date "2018" #elm/date "2018"]
        :precision "Year"}
       0
 
-      {:type "CalculateAgeAt" :operand [#elm/date"2018" #elm/date"2018"]
+      {:type "CalculateAgeAt" :operand [#elm/date "2018" #elm/date "2018"]
        :precision "Month"}
       nil))
 
-  (tu/testing-binary-null elm/calculate-age-at #elm/date"2018"))
+  (tu/testing-binary-null elm/calculate-age-at #elm/date "2018"))
 
 
 ;; 23.5. Equal

--- a/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
@@ -49,7 +49,7 @@
           {:library
            {:codeSystems
             {:def [{:name "sys-def-115852" :id "system-115910"}]}}}]
-      (given (c/compile context #elm/code["sys-def-115852" "code-115927"])
+      (given (c/compile context #elm/code ["sys-def-115852" "code-115927"])
         type := Code
         :system := "system-115910"
         :code := "code-115927")))
@@ -62,7 +62,7 @@
              [{:name "sys-def-120434"
                :id "system-120411"
                :version "version-120408"}]}}}]
-      (given (c/compile context #elm/code["sys-def-120434" "code-120416"])
+      (given (c/compile context #elm/code ["sys-def-120434" "code-120416"])
         type := Code
         :system := "system-120411"
         :version := "version-120408"
@@ -70,7 +70,7 @@
 
   (testing "missing code system"
     (let [context {:library {:codeSystems {:def []}}}]
-      (given (ba/try-anomaly (c/compile context #elm/code["sys-def-112249" "code-112253"]))
+      (given (ba/try-anomaly (c/compile context #elm/code ["sys-def-112249" "code-112253"]))
         ::anom/category := ::anom/not-found
         ::anom/message := "Can't find the code system `sys-def-112249`."))))
 
@@ -97,7 +97,7 @@
              [{:name "code-def-125054"
                :id "code-125340"
                :codeSystem {:name "sys-def-125149"}}]}}}]
-      (given (c/compile context #elm/code-ref"code-def-125054")
+      (given (c/compile context #elm/code-ref "code-def-125054")
         type := Code
         :system := "system-name-125213"
         :code := "code-125340")))
@@ -115,7 +115,7 @@
              [{:name "code-def-125054"
                :id "code-125354"
                :codeSystem {:name "sys-def-125149"}}]}}}]
-      (given (c/compile context #elm/code-ref"code-def-125054")
+      (given (c/compile context #elm/code-ref "code-def-125054")
         type := Code
         :system := "system-name-125213"
         :version := "version-125222"
@@ -147,25 +147,25 @@
   (testing "Examples"
     (are [elm res] (= res (c/compile {} elm))
       {:type "Quantity"} nil
-      #elm/quantity[1] (quantity/quantity 1 "")
-      #elm/quantity[1 "year"] (date-time/period 1 0 0)
-      #elm/quantity[2 "years"] (date-time/period 2 0 0)
-      #elm/quantity[1 "month"] (date-time/period 0 1 0)
-      #elm/quantity[2 "months"] (date-time/period 0 2 0)
-      #elm/quantity[1 "week"] (date-time/period 0 0 (* 7 24 60 60 1000))
-      #elm/quantity[2 "weeks"] (date-time/period 0 0 (* 2 7 24 60 60 1000))
-      #elm/quantity[1 "day"] (date-time/period 0 0 (* 24 60 60 1000))
-      #elm/quantity[2 "days"] (date-time/period 0 0 (* 2 24 60 60 1000))
-      #elm/quantity[1 "hour"] (date-time/period 0 0 (* 60 60 1000))
-      #elm/quantity[2 "hours"] (date-time/period 0 0 (* 2 60 60 1000))
-      #elm/quantity[1 "minute"] (date-time/period 0 0 (* 60 1000))
-      #elm/quantity[2 "minutes"] (date-time/period 0 0 (* 2 60 1000))
-      #elm/quantity[1 "second"] (date-time/period 0 0 1000)
-      #elm/quantity[2 "seconds"] (date-time/period 0 0 2000)
-      #elm/quantity[1 "millisecond"] (date-time/period 0 0 1)
-      #elm/quantity[2 "milliseconds"] (date-time/period 0 0 2)
-      #elm/quantity[1 "s"] (quantity/quantity 1 "s")
-      #elm/quantity[1 "cm2"] (quantity/quantity 1 "cm2")))
+      #elm/quantity [1] (quantity/quantity 1 "")
+      #elm/quantity [1 "year"] (date-time/period 1 0 0)
+      #elm/quantity [2 "years"] (date-time/period 2 0 0)
+      #elm/quantity [1 "month"] (date-time/period 0 1 0)
+      #elm/quantity [2 "months"] (date-time/period 0 2 0)
+      #elm/quantity [1 "week"] (date-time/period 0 0 (* 7 24 60 60 1000))
+      #elm/quantity [2 "weeks"] (date-time/period 0 0 (* 2 7 24 60 60 1000))
+      #elm/quantity [1 "day"] (date-time/period 0 0 (* 24 60 60 1000))
+      #elm/quantity [2 "days"] (date-time/period 0 0 (* 2 24 60 60 1000))
+      #elm/quantity [1 "hour"] (date-time/period 0 0 (* 60 60 1000))
+      #elm/quantity [2 "hours"] (date-time/period 0 0 (* 2 60 60 1000))
+      #elm/quantity [1 "minute"] (date-time/period 0 0 (* 60 1000))
+      #elm/quantity [2 "minutes"] (date-time/period 0 0 (* 2 60 1000))
+      #elm/quantity [1 "second"] (date-time/period 0 0 1000)
+      #elm/quantity [2 "seconds"] (date-time/period 0 0 2000)
+      #elm/quantity [1 "millisecond"] (date-time/period 0 0 1)
+      #elm/quantity [2 "milliseconds"] (date-time/period 0 0 2)
+      #elm/quantity [1 "s"] (quantity/quantity 1 "s")
+      #elm/quantity [1 "cm2"] (quantity/quantity 1 "cm2")))
 
   (testing "Periods"
     (satisfies-prop 100

--- a/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
@@ -83,7 +83,7 @@
       "1" "2" false
       "2" "1" false)
 
-    (tu/testing-binary-null elm/equal #elm/integer"1"))
+    (tu/testing-binary-null elm/equal #elm/integer "1"))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/decimal x y))
@@ -94,22 +94,22 @@
       "1.1" "1.10" true
       "1.10" "1.1" true)
 
-    (tu/testing-binary-null elm/equal #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/equal #elm/decimal "1.1"))
 
   (testing "Mixed Integer Decimal"
     (are [x y res] (= res (c/compile {} (elm/equal [x y])))
-      #elm/integer"1" #elm/decimal"1" true
-      #elm/decimal"1" #elm/integer"1" true))
+      #elm/integer "1" #elm/decimal "1" true
+      #elm/decimal "1" #elm/integer "1" true))
 
   (testing "Mixed Integer String"
     (are [x y res] (= res (c/compile {} (elm/equal [x y])))
-      #elm/integer"1" #elm/string"1" false
-      #elm/string"1" #elm/integer"1" false))
+      #elm/integer "1" #elm/string "1" false
+      #elm/string "1" #elm/integer "1" false))
 
   (testing "Mixed Decimal String"
     (are [x y res] (= res (c/compile {} (elm/equal [x y])))
-      #elm/decimal"1" #elm/string"1" false
-      #elm/string"1" #elm/decimal"1" false))
+      #elm/decimal "1" #elm/string "1" false
+      #elm/string "1" #elm/decimal "1" false))
 
   (testing "String"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/string x y))
@@ -130,39 +130,39 @@
       [1 "s"] [2 "s"] false
       [1 "s"] [1 "m"] false)
 
-    (tu/testing-binary-null elm/equal #elm/quantity[1]))
+    (tu/testing-binary-null elm/equal #elm/quantity [1]))
 
   ;; TODO: Ratio
 
   (testing "Tuple"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/tuple x y))
       {} {} true
-      {"id" #elm/string"1"} {"id" #elm/string"1"} true
-      {"id" #elm/string"1"} {"id" #elm/string"2"} false
-      {"id" #elm/string"1"} {"foo" #elm/string"1"} false))
+      {"id" #elm/string "1"} {"id" #elm/string "1"} true
+      {"id" #elm/string "1"} {"id" #elm/string "2"} false
+      {"id" #elm/string "1"} {"foo" #elm/string "1"} false))
 
   (testing "List"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/list x y))
-      [#elm/integer"1"] [#elm/integer"1"] true
+      [#elm/integer "1"] [#elm/integer "1"] true
       [] [] true
 
-      [#elm/integer"1"] [] false
-      [#elm/integer"1"] [#elm/integer"2"] false
-      [#elm/integer"1" #elm/integer"1"]
-      [#elm/integer"1" #elm/integer"2"] false
+      [#elm/integer "1"] [] false
+      [#elm/integer "1"] [#elm/integer "2"] false
+      [#elm/integer "1" #elm/integer "1"]
+      [#elm/integer "1" #elm/integer "2"] false
 
-      [#elm/integer"1" {:type "Null"}] [#elm/integer"1" {:type "Null"}] nil
+      [#elm/integer "1" {:type "Null"}] [#elm/integer "1" {:type "Null"}] nil
       [{:type "Null"}] [{:type "Null"}] nil
-      [#elm/date"2019"] [#elm/date"2019-01"] nil)
+      [#elm/date "2019"] [#elm/date "2019-01"] nil)
 
     (tu/testing-binary-null elm/equal #elm/list []))
 
   (testing "Interval"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/interval x y))
-      [#elm/integer"1" #elm/integer"2"]
-      [#elm/integer"1" #elm/integer"2"] true)
+      [#elm/integer "1" #elm/integer "2"]
+      [#elm/integer "1" #elm/integer "2"] true)
 
-    (tu/testing-binary-null elm/equal #elm/interval [#elm/integer"1" #elm/integer"2"]))
+    (tu/testing-binary-null elm/equal #elm/interval [#elm/integer "1" #elm/integer "2"]))
 
   (testing "Date with year precision"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -170,7 +170,7 @@
       "2012" "2013" false
       "2013" "2012" false)
 
-    (tu/testing-binary-null elm/equal #elm/date"2013"))
+    (tu/testing-binary-null elm/equal #elm/date "2013"))
 
   (testing "Date with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -178,7 +178,7 @@
       "2013-01" "2013-02" false
       "2013-02" "2013-01" false)
 
-    (tu/testing-binary-null elm/equal #elm/date"2013-01"))
+    (tu/testing-binary-null elm/equal #elm/date "2013-01"))
 
   (testing "Date with full precision"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -186,7 +186,7 @@
       "2013-01-01" "2013-01-02" false
       "2013-01-02" "2013-01-01" false)
 
-    (tu/testing-binary-null elm/equal #elm/date"2013-01-01"))
+    (tu/testing-binary-null elm/equal #elm/date "2013-01-01"))
 
   (testing "Date with differing precisions"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -204,7 +204,7 @@
 
       "2013-01-01T00" "2013-01-01T00:00:00" true)
 
-    (tu/testing-binary-null elm/equal #elm/date-time"2013-01-01"))
+    (tu/testing-binary-null elm/equal #elm/date-time "2013-01-01"))
 
   (testing "Time"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/time x y))
@@ -216,7 +216,7 @@
 
       "12:00" "12" nil)
 
-    (tu/testing-binary-null elm/equal #elm/time"12:30:15"))
+    (tu/testing-binary-null elm/equal #elm/time "12:30:15"))
 
   (testing "Code"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equal [x y])) {} nil nil))
@@ -230,7 +230,9 @@
       (tu/code "a" "2010" "0") (tu/code "a" "2020" "0") false
       (tu/code "a" "2020" "0") (tu/code "a" "2010" "0") false)
 
-    (tu/testing-binary-null elm/equal (tu/code "a" "0"))))
+    (tu/testing-binary-null elm/equal (tu/code "a" "0")))
+
+  (tu/testing-binary-form elm/equal))
 
 
 ;; 12.2. Equivalent
@@ -296,64 +298,64 @@
 
   (testing "Boolean"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equivalent [x y])) {} nil nil))
-      #elm/boolean"true" #elm/boolean"true" true
-      #elm/boolean"true" #elm/boolean"false" false
+      #elm/boolean "true" #elm/boolean "true" true
+      #elm/boolean "true" #elm/boolean "false" false
 
-      {:type "Null"} #elm/boolean"true" false
-      #elm/boolean"true" {:type "Null"} false))
+      {:type "Null"} #elm/boolean "true" false
+      #elm/boolean "true" {:type "Null"} false))
 
   (testing "Integer"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equivalent [x y])) {} nil nil))
-      #elm/integer"1" #elm/integer"1" true
-      #elm/integer"1" #elm/integer"2" false
+      #elm/integer "1" #elm/integer "1" true
+      #elm/integer "1" #elm/integer "2" false
 
-      {:type "Null"} #elm/integer"1" false
-      #elm/integer"1" {:type "Null"} false))
+      {:type "Null"} #elm/integer "1" false
+      #elm/integer "1" {:type "Null"} false))
 
   (testing "Decimal"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equivalent [x y])) {} nil nil))
-      #elm/decimal"1.1" #elm/decimal"1.1" true
-      #elm/decimal"1.1" #elm/decimal"2.1" false
+      #elm/decimal "1.1" #elm/decimal "1.1" true
+      #elm/decimal "1.1" #elm/decimal "2.1" false
 
-      {:type "Null"} #elm/decimal"1.1" false
-      #elm/decimal"1.1" {:type "Null"} false))
+      {:type "Null"} #elm/decimal "1.1" false
+      #elm/decimal "1.1" {:type "Null"} false))
 
   (testing "Mixed Integer Decimal"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equivalent [x y])) {} nil nil))
-      #elm/integer"1" #elm/decimal"1" true
-      #elm/decimal"1" #elm/integer"1" true))
+      #elm/integer "1" #elm/decimal "1" true
+      #elm/decimal "1" #elm/integer "1" true))
 
   (testing "Quantity"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equivalent [x y])) {} nil nil))
-      #elm/quantity[1] #elm/quantity[1] true
-      #elm/quantity[1] #elm/quantity[2] false
+      #elm/quantity [1] #elm/quantity [1] true
+      #elm/quantity [1] #elm/quantity [2] false
 
-      #elm/quantity[1 "s"] #elm/quantity[1 "s"] true
-      #elm/quantity[1 "m"] #elm/quantity[1 "m"] true
-      #elm/quantity[100 "cm"] #elm/quantity[1 "m"] true
-      #elm/quantity[1 "s"] #elm/quantity[2 "s"] false
-      #elm/quantity[1 "s"] #elm/quantity[1 "m"] false
+      #elm/quantity [1 "s"] #elm/quantity [1 "s"] true
+      #elm/quantity [1 "m"] #elm/quantity [1 "m"] true
+      #elm/quantity [100 "cm"] #elm/quantity [1 "m"] true
+      #elm/quantity [1 "s"] #elm/quantity [2 "s"] false
+      #elm/quantity [1 "s"] #elm/quantity [1 "m"] false
 
-      {:type "Null"} #elm/quantity[1] false
-      #elm/quantity[1] {:type "Null"} false
+      {:type "Null"} #elm/quantity [1] false
+      #elm/quantity [1] {:type "Null"} false
 
-      {:type "Null"} #elm/quantity[1 "s"] false
-      #elm/quantity[1 "s"] {:type "Null"} false))
+      {:type "Null"} #elm/quantity [1 "s"] false
+      #elm/quantity [1 "s"] {:type "Null"} false))
 
   (testing "List"
     (are [x y res] (= res (core/-eval (c/compile {} (elm/equivalent [x y])) {} nil nil))
-      #elm/list [#elm/integer"1"] #elm/list [#elm/integer"1"] true
+      #elm/list [#elm/integer "1"] #elm/list [#elm/integer "1"] true
       #elm/list [] #elm/list [] true
 
-      #elm/list [#elm/integer"1"] #elm/list [] false
-      #elm/list [#elm/integer"1"] #elm/list [#elm/integer"2"] false
-      #elm/list [#elm/integer"1" #elm/integer"1"]
-      #elm/list [#elm/integer"1" #elm/integer"2"] false
+      #elm/list [#elm/integer "1"] #elm/list [] false
+      #elm/list [#elm/integer "1"] #elm/list [#elm/integer "2"] false
+      #elm/list [#elm/integer "1" #elm/integer "1"]
+      #elm/list [#elm/integer "1" #elm/integer "2"] false
 
-      #elm/list [#elm/integer"1" {:type "Null"}]
-      #elm/list [#elm/integer"1" {:type "Null"}] true
+      #elm/list [#elm/integer "1" {:type "Null"}]
+      #elm/list [#elm/integer "1" {:type "Null"}] true
       #elm/list [{:type "Null"}] #elm/list [{:type "Null"}] true
-      #elm/list [#elm/date"2019"] #elm/list [#elm/date"2019-01"] false
+      #elm/list [#elm/date "2019"] #elm/list [#elm/date "2019-01"] false
 
       {:type "Null"} #elm/list [] false
       #elm/list [] {:type "Null"} false))
@@ -371,7 +373,9 @@
       (tu/code "a" "2020" "0") (tu/code "a" "2010" "0") true
 
       {:type "Null"} (tu/code "a" "0") false
-      (tu/code "a" "0") {:type "Null"} false)))
+      (tu/code "a" "0") {:type "Null"} false))
+
+  (tu/testing-binary-form elm/equivalent))
 
 
 ;; 12.3. Greater
@@ -405,14 +409,14 @@
       "2" "1" true
       "1" "1" false)
 
-    (tu/testing-binary-null elm/greater #elm/integer"1"))
+    (tu/testing-binary-null elm/greater #elm/integer "1"))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/decimal x y))
       "2.1" "1.1" true
       "1.1" "1.1" false)
 
-    (tu/testing-binary-null elm/greater #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/greater #elm/decimal "1.1"))
 
   (testing "String"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/string x y))
@@ -433,35 +437,35 @@
       [1 "m"] [1 "m"] false
       [100 "cm"] [1 "m"] false)
 
-    (tu/testing-binary-null elm/greater #elm/quantity[1]))
+    (tu/testing-binary-null elm/greater #elm/quantity [1]))
 
   (testing "Date with year precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date x y))
       "2014" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/greater #elm/date"2013"))
+    (tu/testing-binary-null elm/greater #elm/date "2013"))
 
   (testing "DateTime with year precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date-time x y))
       "2014" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/greater #elm/date-time"2013"))
+    (tu/testing-binary-null elm/greater #elm/date-time "2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date-time x y))
       "2013-07" "2013-06" true
       "2013-06" "2013-06" false)
 
-    (tu/testing-binary-null elm/greater #elm/date-time"2013-06"))
+    (tu/testing-binary-null elm/greater #elm/date-time "2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date-time x y))
       "2013-06-16" "2013-06-15" true
       "2013-06-15" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/greater #elm/date-time"2013-06-15"))
+    (tu/testing-binary-null elm/greater #elm/date-time "2013-06-15"))
 
   (testing "Comparing dates with mixed precisions (year and year-month) results in null."
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date x y))
@@ -473,7 +477,9 @@
       "00:00:01" "00:00:00" true
       "00:00:00" "00:00:00" false)
 
-    (tu/testing-binary-null elm/greater #elm/time"00:00:00")))
+    (tu/testing-binary-null elm/greater #elm/time "00:00:00"))
+
+  (tu/testing-binary-form elm/greater))
 
 
 ;; 12.4. GreaterOrEqual
@@ -508,7 +514,7 @@
       "2" "1" true
       "1" "2" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/integer"1"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/integer "1"))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/decimal x y))
@@ -516,7 +522,7 @@
       "2.1" "1.1" true
       "1.1" "2.1" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/decimal "1.1"))
 
   (testing "String"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/string x y))
@@ -532,7 +538,7 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-14" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013-06-15"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013-06-15"))
 
   (testing "DateTime with year precision"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -540,7 +546,7 @@
       "2013" "2013" true
       "2012" "2013" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -548,7 +554,7 @@
       "2013-06" "2013-06" true
       "2013-05" "2013-06" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013-06"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -556,7 +562,7 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-14" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013-06-15"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013-06-15"))
 
   (testing "Time"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/time x y))
@@ -564,7 +570,7 @@
       "00:00:01" "00:00:00" true
       "00:00:00" "00:00:01" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/time"00:00:00"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/time "00:00:00"))
 
   (testing "Quantity"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/quantity x y))
@@ -580,7 +586,9 @@
       [100 "cm"] [1 "m"] true
       [1 "m"] [101 "cm"] false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/quantity[1])))
+    (tu/testing-binary-null elm/greater-or-equal #elm/quantity [1]))
+
+  (tu/testing-binary-form elm/greater-or-equal))
 
 
 ;; 12.5. Less
@@ -612,14 +620,14 @@
       "1" "2" true
       "1" "1" false)
 
-    (tu/testing-binary-null elm/less #elm/integer"1"))
+    (tu/testing-binary-null elm/less #elm/integer "1"))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/less elm/decimal x y))
       "1.1" "2.1" true
       "1.1" "1.1" false)
 
-    (tu/testing-binary-null elm/less #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/less #elm/decimal "1.1"))
 
   (testing "String"
     (are [x y res] (= res (tu/compile-binop elm/less elm/string x y))
@@ -633,7 +641,7 @@
       "2012" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/less #elm/date"2013"))
+    (tu/testing-binary-null elm/less #elm/date "2013"))
 
   (testing "Comparing dates with mixed precisions (year and year-month) results in null."
     (are [x y res] (= res (tu/compile-binop elm/less elm/date x y))
@@ -645,7 +653,7 @@
       "2013-06-14" "2013-06-15" true
       "2013-06-15" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less #elm/date"2013-06-15"))
+    (tu/testing-binary-null elm/less #elm/date "2013-06-15"))
 
   (testing "Comparing dates with mixed precisions (year-month and full) results in null."
     (are [x y res] (= res (tu/compile-binop elm/less elm/date x y))
@@ -657,35 +665,35 @@
       "2012" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time"2013"))
+    (tu/testing-binary-null elm/less #elm/date-time "2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/less elm/date-time x y))
       "2013-05" "2013-06" true
       "2013-06" "2013-06" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time"2013-06"))
+    (tu/testing-binary-null elm/less #elm/date-time "2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/less elm/date-time x y))
       "2013-06-14" "2013-06-15" true
       "2013-06-15" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time"2013-06-15"))
+    (tu/testing-binary-null elm/less #elm/date-time "2013-06-15"))
 
   (testing "DateTime with full precision (there is only one precision)"
     (are [x y res] (= res (tu/compile-binop elm/less elm/date-time x y))
       "2013-06-15T11" "2013-06-15T12" true
       "2013-06-15T12" "2013-06-15T12" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time"2013-06-15T12"))
+    (tu/testing-binary-null elm/less #elm/date-time "2013-06-15T12"))
 
   (testing "Time with full precision (there is only one precision)"
     (are [x y res] (= res (tu/compile-binop elm/less elm/time x y))
       "12:30:14" "12:30:15" true
       "12:30:15" "12:30:15" false)
 
-    (tu/testing-binary-null elm/less #elm/time"12:30:15"))
+    (tu/testing-binary-null elm/less #elm/time "12:30:15"))
 
   (testing "Quantity"
     (are [x y res] (= res (tu/compile-binop elm/less elm/quantity x y))
@@ -698,7 +706,9 @@
       [1 "m"] [101 "cm"] true
       [1 "m"] [100 "cm"] false)
 
-    (tu/testing-binary-null elm/less #elm/quantity[1])))
+    (tu/testing-binary-null elm/less #elm/quantity [1]))
+
+  (tu/testing-binary-form elm/less))
 
 
 ;; 12.6. LessOrEqual
@@ -733,7 +743,7 @@
       "1" "2" true
       "2" "1" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/integer"1"))
+    (tu/testing-binary-null elm/less-or-equal #elm/integer "1"))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/decimal x y))
@@ -741,7 +751,7 @@
       "1.1" "2.1" true
       "2.1" "1.1" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/decimal"1.1"))
+    (tu/testing-binary-null elm/less-or-equal #elm/decimal "1.1"))
 
   (testing "Date with full precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date x y))
@@ -749,12 +759,12 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-16" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date"2013-06-15"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date "2013-06-15"))
 
   (testing "Mixed Date and DateTime"
     (are [x y res] (= res (c/compile {} (elm/less-or-equal [x y])))
-      #elm/date"2013-06-15" #elm/date-time"2013-06-15T00" nil
-      #elm/date-time"2013-06-15T00" #elm/date"2013-06-15" nil))
+      #elm/date "2013-06-15" #elm/date-time "2013-06-15T00" nil
+      #elm/date-time "2013-06-15T00" #elm/date "2013-06-15" nil))
 
   (testing "DateTime with year precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date-time x y))
@@ -762,7 +772,7 @@
       "2013" "2013" true
       "2014" "2013" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date"2013"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date "2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date-time x y))
@@ -770,7 +780,7 @@
       "2013-06" "2013-06" true
       "2013-07" "2013-06" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date"2013-06"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date "2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date-time x y))
@@ -778,7 +788,7 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-16" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date"2013-06-15"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date "2013-06-15"))
 
   (testing "Time"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/time x y))
@@ -786,7 +796,7 @@
       "00:00:00" "00:00:01" true
       "00:00:01" "00:00:00" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/time"00:00:00"))
+    (tu/testing-binary-null elm/less-or-equal #elm/time "00:00:00"))
 
   (testing "Quantity"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/quantity x y))
@@ -802,7 +812,9 @@
       [1 "m"] [100 "cm"] true
       [101 "cm"] [1 "m"] false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/quantity[1])))
+    (tu/testing-binary-null elm/less-or-equal #elm/quantity [1]))
+
+  (tu/testing-binary-form elm/less-or-equal))
 
 
 ;; 12.7. NotEqual
@@ -810,183 +822,3 @@
 ;; Normalized to Not Equal
 (deftest compile-not-equal-test
   (tu/unsupported-binary-operand "NotEqual"))
-
-
-
-;; 13. Logical Operators
-
-;; 13.1. And
-;;
-;; The And operator returns the logical conjunction of its arguments. Note that
-;; this operator is defined using 3-valued logic semantics. This means that if
-;; either argument is false, the result is false; if both arguments are true,
-;; the result is true; otherwise, the result is null. Note also that ELM does
-;; not prescribe short-circuit evaluation.
-(deftest compile-and-test
-  (testing "Static"
-    (are [x y res] (= res (c/compile {} (elm/and [x y])))
-      #elm/boolean"true" #elm/boolean"true" true
-      #elm/boolean"true" #elm/boolean"false" false
-      #elm/boolean"true" {:type "Null"} nil
-
-      #elm/boolean"false" #elm/boolean"true" false
-      #elm/boolean"false" #elm/boolean"false" false
-      #elm/boolean"false" {:type "Null"} false
-
-      {:type "Null"} #elm/boolean"true" nil
-      {:type "Null"} #elm/boolean"false" false
-      {:type "Null"} {:type "Null"} nil))
-
-  (testing "Dynamic"
-    (are [x y res] (= res (tu/dynamic-compile-eval (elm/and [x y])))
-      #elm/boolean"true" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" #elm/boolean"true" true
-      #elm/parameter-ref"true" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" {:type "Null"} nil
-      {:type "Null"} #elm/parameter-ref"true" nil
-
-      #elm/boolean"true" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" #elm/boolean"true" false
-      #elm/parameter-ref"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" {:type "Null"} false
-      {:type "Null"} #elm/parameter-ref"false" false
-
-      #elm/boolean"false" #elm/parameter-ref"nil" false
-      #elm/parameter-ref"nil" #elm/boolean"false" false
-      #elm/boolean"true" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"true" nil
-      #elm/parameter-ref"nil" #elm/parameter-ref"nil" nil)))
-
-
-;; 13.2. Implies
-;;
-;; The Implies operator returns the logical implication of its arguments. Note
-;; that this operator is defined using 3-valued logic semantics. This means that
-;; if the left operand evaluates to true, this operator returns the boolean
-;; evaluation of the right operand. If the left operand evaluates to false, this
-;; operator returns true. Otherwise, this operator returns true if the right
-;; operand evaluates to true, and null otherwise.
-;;
-;; Note that implies may use short-circuit evaluation in the case that the first
-;; operand evaluates to false.
-(deftest compile-implies-test
-  (are [x y res] (= res (core/-eval (c/compile {} {:type "Or" :operand [{:type "Not" :operand x} y]}) {} nil nil))
-    #elm/boolean"true" #elm/boolean"true" true
-    #elm/boolean"true" #elm/boolean"false" false
-    #elm/boolean"true" {:type "Null"} nil
-
-    #elm/boolean"false" #elm/boolean"true" true
-    #elm/boolean"false" #elm/boolean"false" true
-    #elm/boolean"false" {:type "Null"} true
-
-    {:type "Null"} #elm/boolean"true" true
-    {:type "Null"} #elm/boolean"false" nil
-    {:type "Null"} {:type "Null"} nil))
-
-
-;; 13.3. Not
-;;
-;; The Not operator returns the logical negation of its argument. If the
-;; argument is true, the result is false; if the argument is false, the result
-;; is true; otherwise, the result is null.
-(deftest compile-not-test
-  (testing "Static"
-    (are [x res] (= res (c/compile {} (elm/not x)))
-      #elm/boolean"true" false
-      #elm/boolean"false" true
-      {:type "Null"} nil))
-
-  (testing "Dynamic"
-    (are [x res] (= res (tu/dynamic-compile-eval (elm/not x)))
-      #elm/parameter-ref"true" false
-      #elm/parameter-ref"false" true
-      #elm/parameter-ref"nil" nil)))
-
-
-;; 13.4. Or
-;;
-;; The Or operator returns the logical disjunction of its arguments. Note that
-;; this operator is defined using 3-valued logic semantics. This means that if
-;; either argument is true, the result is true; if both arguments are false, the
-;; result is false; otherwise, the result is null. Note also that ELM does not
-;; prescribe short-circuit evaluation.
-(deftest compile-or-test
-  (testing "Static"
-    (are [x y res] (= res (c/compile {} (elm/or [x y])))
-      #elm/boolean"true" #elm/boolean"true" true
-      #elm/boolean"true" #elm/boolean"false" true
-      #elm/boolean"true" {:type "Null"} true
-
-      #elm/boolean"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/boolean"false" false
-      #elm/boolean"false" {:type "Null"} nil
-
-      {:type "Null"} #elm/boolean"true" true
-      {:type "Null"} #elm/boolean"false" nil
-      {:type "Null"} {:type "Null"} nil))
-
-  (testing "Dynamic"
-    (are [x y res] (= res (tu/dynamic-compile-eval (elm/or [x y])))
-      #elm/boolean"false" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" #elm/boolean"false" true
-      #elm/parameter-ref"true" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" {:type "Null"} true
-      {:type "Null"} #elm/parameter-ref"true" true
-
-      #elm/boolean"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" #elm/boolean"false" false
-      #elm/parameter-ref"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" {:type "Null"} nil
-      {:type "Null"} #elm/parameter-ref"false" nil
-
-      #elm/boolean"true" #elm/parameter-ref"nil" true
-      #elm/parameter-ref"nil" #elm/boolean"true" true
-      #elm/boolean"false" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"false" nil
-      #elm/parameter-ref"nil" #elm/parameter-ref"nil" nil)))
-
-
-;; 13.5. Xor
-;;
-;; The Xor operator returns the exclusive or of its arguments. Note that this
-;; operator is defined using 3-valued logic semantics. This means that the
-;; result is true if and only if one argument is true and the other is false,
-;; and that the result is false if and only if both arguments are true or both
-;; arguments are false. If either or both arguments are null, the result is
-;; null.
-(deftest compile-xor-test
-  (testing "Static"
-    (are [x y res] (= res (c/compile {} (elm/xor [x y])))
-      #elm/boolean"true" #elm/boolean"true" false
-      #elm/boolean"true" #elm/boolean"false" true
-      #elm/boolean"true" {:type "Null"} nil
-
-      #elm/boolean"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/boolean"false" false
-      #elm/boolean"false" {:type "Null"} nil
-
-      {:type "Null"} #elm/boolean"true" nil
-      {:type "Null"} #elm/boolean"false" nil
-      {:type "Null"} {:type "Null"} nil))
-
-  (testing "Dynamic"
-    (are [x y res] (= res (tu/dynamic-compile-eval (elm/xor [x y])))
-      #elm/boolean"true" #elm/parameter-ref"true" false
-      #elm/parameter-ref"true" #elm/boolean"true" false
-      #elm/boolean"false" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" #elm/boolean"false" true
-      #elm/parameter-ref"true" #elm/parameter-ref"true" false
-
-      #elm/boolean"true" #elm/parameter-ref"false" true
-      #elm/parameter-ref"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" #elm/boolean"false" false
-      #elm/parameter-ref"false" #elm/parameter-ref"false" false
-
-      #elm/boolean"true" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"true" nil
-      #elm/boolean"false" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"false" nil
-      {:type "Null"} #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" {:type "Null"} nil
-      #elm/parameter-ref"nil" #elm/parameter-ref"nil" nil)))

--- a/modules/cql/test/blaze/elm/compiler/conditional_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/conditional_operators_test.clj
@@ -35,12 +35,12 @@
 (deftest compile-if-test
   (testing "Static"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/if[#elm/boolean "true" #elm/integer"1" #elm/integer"2"] 1
-      #elm/if[#elm/boolean "false" #elm/integer"1" #elm/integer"2"] 2
-      #elm/if[{:type "Null"} #elm/integer"1" #elm/integer"2"] 2))
+      #elm/if [#elm/boolean "true" #elm/integer "1" #elm/integer "2"] 1
+      #elm/if [#elm/boolean "false" #elm/integer "1" #elm/integer "2"] 2
+      #elm/if [{:type "Null"} #elm/integer "1" #elm/integer "2"] 2))
 
   (testing "Dynamic"
     (are [elm res] (= res (tu/dynamic-compile-eval elm))
-      #elm/if[#elm/parameter-ref"true" #elm/integer"1" #elm/integer"2"] 1
-      #elm/if[#elm/parameter-ref"false" #elm/integer"1" #elm/integer"2"] 2
-      #elm/if[#elm/parameter-ref"nil" #elm/integer"1" #elm/integer"2"] 2)))
+      #elm/if [#elm/parameter-ref "true" #elm/integer "1" #elm/integer "2"] 1
+      #elm/if [#elm/parameter-ref "false" #elm/integer "1" #elm/integer "2"] 2
+      #elm/if [#elm/parameter-ref "nil" #elm/integer "1" #elm/integer "2"] 2)))

--- a/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
@@ -73,55 +73,55 @@
 ;; null, but if it is, day must be null as well.
 (deftest compile-date-test
   (testing "Static Null year"
-    (is (nil? (c/compile {} #elm/date[{:type "null"}]))))
+    (is (nil? (c/compile {} #elm/date [{:type "null"}]))))
 
   (testing "Static year"
-    (is (= (system/date 2019) (c/compile {} #elm/date"2019"))))
+    (is (= (system/date 2019) (c/compile {} #elm/date "2019"))))
 
   (testing "Static year over 10.000"
-    (given (ba/try-anomaly (c/compile {} #elm/date"10001"))
+    (given (ba/try-anomaly (c/compile {} #elm/date "10001"))
       ::anom/category := ::anom/incorrect
       ::anom/message := "Year `10001` out of range."))
 
   (testing "Dynamic year has type :system/date"
     (let [compile-ctx {:library {:parameters {:def [{:name "year"}]}}}
-          elm #elm/date[#elm/parameter-ref"year"]]
+          elm #elm/date [#elm/parameter-ref "year"]]
       (is (= :system/date (system/type (c/compile compile-ctx elm))))))
 
   (testing "Dynamic Null year"
     (let [compile-ctx {:library {:parameters {:def [{:name "year"}]}}}
-          elm #elm/date[#elm/parameter-ref"year"]
+          elm #elm/date [#elm/parameter-ref "year"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"year" nil}}]
       (is (nil? (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Dynamic year"
     (let [compile-ctx {:library {:parameters {:def [{:name "year"}]}}}
-          elm #elm/date[#elm/parameter-ref"year"]
+          elm #elm/date [#elm/parameter-ref "year"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"year" 2019}}]
       (is (= (system/date 2019) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Dynamic Null month"
     (let [compile-ctx {:library {:parameters {:def [{:name "month"}]}}}
-          elm #elm/date[#elm/integer"2018" #elm/parameter-ref"month"]
+          elm #elm/date [#elm/integer "2018" #elm/parameter-ref "month"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"month" nil}}]
       (is (= (system/date 2018) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static year-month"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date"2019-03"
+      #elm/date "2019-03"
       (system/date 2019 3)))
 
   (testing "Dynamic year-month has type :system/date"
     (let [compile-ctx {:library {:parameters {:def [{:name "month"}]}}}
-          elm #elm/date[#elm/integer"2019" #elm/parameter-ref"month"]]
+          elm #elm/date [#elm/integer "2019" #elm/parameter-ref "month"]]
       (is (= :system/date (system/type (c/compile compile-ctx elm))))))
 
   (testing "Dynamic year-month"
     (let [compile-ctx {:library {:parameters {:def [{:name "month"}]}}}
-          elm #elm/date[#elm/integer"2019" #elm/parameter-ref"month"]
+          elm #elm/date [#elm/integer "2019" #elm/parameter-ref "month"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"month" 3}}]
       (is (= (system/date 2019 3) (core/-eval expr eval-ctx nil nil)))))
@@ -129,39 +129,39 @@
   (testing "Dynamic Null month and day"
     (let [compile-ctx {:library
                        {:parameters {:def [{:name "month"} {:name "day"}]}}}
-          elm #elm/date[#elm/integer"2020"
-                        #elm/parameter-ref"month"
-                        #elm/parameter-ref"day"]
+          elm #elm/date [#elm/integer "2020"
+                        #elm/parameter-ref "month"
+                        #elm/parameter-ref "day"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"month" nil "day" nil}}]
       (is (= (system/date 2020) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Dynamic date has type :system/date"
     (let [compile-ctx {:library {:parameters {:def [{:name "day"}]}}}
-          elm #elm/date[#elm/integer"2018"
-                        #elm/integer"5"
-                        #elm/parameter-ref"day"]]
+          elm #elm/date [#elm/integer "2018"
+                        #elm/integer "5"
+                        #elm/parameter-ref "day"]]
       (is (= :system/date (system/type (c/compile compile-ctx elm))))))
 
   (testing "Dynamic Null day"
     (let [compile-ctx {:library {:parameters {:def [{:name "day"}]}}}
-          elm #elm/date[#elm/integer"2018"
-                        #elm/integer"5"
-                        #elm/parameter-ref"day"]
+          elm #elm/date [#elm/integer "2018"
+                        #elm/integer "5"
+                        #elm/parameter-ref "day"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"day" nil}}]
       (is (= (system/date 2018 5) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static date"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date"2019-03-23"
+      #elm/date "2019-03-23"
       (system/date 2019 3 23)))
 
   (testing "Dynamic date"
     (let [compile-ctx {:library {:parameters {:def [{:name "day"}]}}}
-          elm #elm/date[#elm/integer"2019"
-                        #elm/integer"3"
-                        #elm/parameter-ref"day"]
+          elm #elm/date [#elm/integer "2019"
+                        #elm/integer "3"
+                        #elm/parameter-ref "day"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"day" 23}}]
       (is (= (system/date 2019 3 23) (core/-eval expr eval-ctx nil nil)))))
@@ -189,11 +189,13 @@
 ;;
 ;; If the argument is null, the result is null.
 (deftest compile-date-from-test
-  (are [x res] (= res (core/-eval (c/compile {} (elm/date-from x)) {:now tu/now} nil nil))
-    #elm/date"2019-04-17" (system/date 2019 4 17)
-    #elm/date-time"2019-04-17T12:48" (system/date 2019 4 17))
+  (are [x res] (= res (c/compile {} (elm/date-from x)))
+    #elm/date "2019-04-17" (system/date 2019 4 17)
+    #elm/date-time "2019-04-17T12:48" (system/date 2019 4 17))
 
-  (tu/testing-unary-null elm/date-from))
+  (tu/testing-unary-null elm/date-from)
+
+  (tu/testing-unary-form elm/date-from))
 
 
 ;; 18.8. DateTime
@@ -212,37 +214,37 @@
     (is (nil? (c/compile {} #elm/date-time[{:type "null"}]))))
 
   (testing "Static year"
-    (is (= (system/date-time 2019) (c/compile {} #elm/date-time"2019"))))
+    (is (= (system/date-time 2019) (c/compile {} #elm/date-time "2019"))))
 
   (testing "Dynamic Null year"
     (let [compile-ctx {:library {:parameters {:def [{:name "year"}]}}}
-          elm #elm/date-time[#elm/parameter-ref"year"]
+          elm #elm/date-time[#elm/parameter-ref "year"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"year" nil}}]
       (is (nil? (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Dynamic year"
     (let [compile-ctx {:library {:parameters {:def [{:name "year"}]}}}
-          elm #elm/date-time[#elm/parameter-ref"year"]
+          elm #elm/date-time[#elm/parameter-ref "year"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"year" 2019}}]
       (is (= (system/date-time 2019) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Dynamic Null month"
     (let [compile-ctx {:library {:parameters {:def [{:name "month"}]}}}
-          elm #elm/date-time[#elm/integer"2018" #elm/parameter-ref"month"]
+          elm #elm/date-time[#elm/integer "2018" #elm/parameter-ref "month"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"month" nil}}]
       (is (= (system/date-time 2018) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static year-month"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date-time"2019-03"
+      #elm/date-time "2019-03"
       (system/date-time 2019 3)))
 
   (testing "Dynamic year-month"
     (let [compile-ctx {:library {:parameters {:def [{:name "month"}]}}}
-          elm #elm/date-time[#elm/integer"2019" #elm/parameter-ref"month"]
+          elm #elm/date-time[#elm/integer "2019" #elm/parameter-ref "month"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"month" 3}}]
       (is (= (system/date-time 2019 3) (core/-eval expr eval-ctx nil nil)))))
@@ -250,47 +252,47 @@
   (testing "Dynamic Null month and day"
     (let [compile-ctx {:library
                        {:parameters {:def [{:name "month"} {:name "day"}]}}}
-          elm #elm/date-time[#elm/integer"2020"
-                             #elm/parameter-ref"month"
-                             #elm/parameter-ref"day"]
+          elm #elm/date-time[#elm/integer "2020"
+                             #elm/parameter-ref "month"
+                             #elm/parameter-ref "day"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"month" nil "day" nil}}]
       (is (= (system/date-time 2020) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Dynamic Null day"
     (let [compile-ctx {:library {:parameters {:def [{:name "day"}]}}}
-          elm #elm/date-time[#elm/integer"2018"
-                             #elm/integer"5"
-                             #elm/parameter-ref"day"]
+          elm #elm/date-time[#elm/integer "2018"
+                             #elm/integer "5"
+                             #elm/parameter-ref "day"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"day" nil}}]
       (is (= (system/date-time 2018 5) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static date"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date-time"2019-03-23"
+      #elm/date-time "2019-03-23"
       (system/date-time 2019 3 23)))
 
   (testing "Dynamic date"
     (let [compile-ctx {:library {:parameters {:def [{:name "day"}]}}}
-          elm #elm/date-time[#elm/integer"2019"
-                             #elm/integer"3"
-                             #elm/parameter-ref"day"]
+          elm #elm/date-time[#elm/integer "2019"
+                             #elm/integer "3"
+                             #elm/parameter-ref "day"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"day" 23}}]
       (is (= (system/date-time 2019 3 23) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static hour"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date-time"2019-03-23T12"
+      #elm/date-time "2019-03-23T12"
       (system/date-time 2019 3 23 12 0 0)))
 
   (testing "Dynamic hour"
     (let [compile-ctx {:library {:parameters {:def [{:name "hour"}]}}}
-          elm #elm/date-time[#elm/integer"2019"
-                             #elm/integer"3"
-                             #elm/integer"23"
-                             #elm/parameter-ref"hour"]
+          elm #elm/date-time[#elm/integer "2019"
+                             #elm/integer "3"
+                             #elm/integer "23"
+                             #elm/parameter-ref "hour"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"hour" 12}}]
       (is (= (system/date-time 2019 3 23 12 0 0)
@@ -298,60 +300,60 @@
 
   (testing "minute"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date-time"2019-03-23T12:13"
+      #elm/date-time "2019-03-23T12:13"
       (system/date-time 2019 3 23 12 13 0)))
 
   (testing "second"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date-time"2019-03-23T12:13:14"
+      #elm/date-time "2019-03-23T12:13:14"
       (system/date-time 2019 3 23 12 13 14)))
 
   (testing "millisecond"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/date-time"2019-03-23T12:13:14.1"
+      #elm/date-time "2019-03-23T12:13:14.1"
       (system/date-time 2019 3 23 12 13 14 1)))
 
   (testing "Invalid DateTime above max value"
     (are [elm] (thrown? Exception (c/compile {} elm))
-      #elm/date-time"10000-12-31T23:59:59.999"))
+      #elm/date-time "10000-12-31T23:59:59.999"))
 
   (testing "with offset"
     (are [elm res] (= res (core/-eval (c/compile {} elm) {:now tu/now} nil nil))
-      #elm/date-time[#elm/integer"2019" #elm/integer"3" #elm/integer"23"
-                     #elm/integer"12" #elm/integer"13" #elm/integer"14" #elm/integer"0"
-                     #elm/decimal"-2"]
+      #elm/date-time[#elm/integer "2019" #elm/integer "3" #elm/integer "23"
+                     #elm/integer "12" #elm/integer "13" #elm/integer "14" #elm/integer "0"
+                     #elm/decimal "-2"]
       (system/date-time 2019 3 23 14 13 14)
 
-      #elm/date-time[#elm/integer"2019" #elm/integer"3" #elm/integer"23"
-                     #elm/integer"12" #elm/integer"13" #elm/integer"14" #elm/integer"0"
-                     #elm/decimal"-1"]
+      #elm/date-time[#elm/integer "2019" #elm/integer "3" #elm/integer "23"
+                     #elm/integer "12" #elm/integer "13" #elm/integer "14" #elm/integer "0"
+                     #elm/decimal "-1"]
       (system/date-time 2019 3 23 13 13 14)
 
-      #elm/date-time[#elm/integer"2019" #elm/integer"3" #elm/integer"23"
-                     #elm/integer"12" #elm/integer"13" #elm/integer"14" #elm/integer"0"
-                     #elm/decimal"0"]
+      #elm/date-time[#elm/integer "2019" #elm/integer "3" #elm/integer "23"
+                     #elm/integer "12" #elm/integer "13" #elm/integer "14" #elm/integer "0"
+                     #elm/decimal "0"]
       (system/date-time 2019 3 23 12 13 14)
 
-      #elm/date-time[#elm/integer"2019" #elm/integer"3" #elm/integer"23"
-                     #elm/integer"12" #elm/integer"13" #elm/integer"14" #elm/integer"0"
-                     #elm/decimal"1"]
+      #elm/date-time[#elm/integer "2019" #elm/integer "3" #elm/integer "23"
+                     #elm/integer "12" #elm/integer "13" #elm/integer "14" #elm/integer "0"
+                     #elm/decimal "1"]
       (system/date-time 2019 3 23 11 13 14)
 
-      #elm/date-time[#elm/integer"2019" #elm/integer"3" #elm/integer"23"
-                     #elm/integer"12" #elm/integer"13" #elm/integer"14" #elm/integer"0"
-                     #elm/decimal"2"]
+      #elm/date-time[#elm/integer "2019" #elm/integer "3" #elm/integer "23"
+                     #elm/integer "12" #elm/integer "13" #elm/integer "14" #elm/integer "0"
+                     #elm/decimal "2"]
       (system/date-time 2019 3 23 10 13 14)
 
-      #elm/date-time[#elm/integer"2012" #elm/integer"3" #elm/integer"10"
-                     #elm/integer"10" #elm/integer"20" #elm/integer"0" #elm/integer"999"
-                     #elm/decimal"7"]
+      #elm/date-time[#elm/integer "2012" #elm/integer "3" #elm/integer "10"
+                     #elm/integer "10" #elm/integer "20" #elm/integer "0" #elm/integer "999"
+                     #elm/decimal "7"]
       (system/date-time 2012 3 10 3 20 0 999)))
 
   (testing "with decimal offset"
     (are [elm res] (= res (core/-eval (c/compile {} elm) {:now tu/now} nil nil))
-      #elm/date-time[#elm/integer"2019" #elm/integer"3" #elm/integer"23"
-                     #elm/integer"12" #elm/integer"13" #elm/integer"14" #elm/integer"0"
-                     #elm/decimal"1.5"]
+      #elm/date-time[#elm/integer "2019" #elm/integer "3" #elm/integer "23"
+                     #elm/integer "12" #elm/integer "13" #elm/integer "14" #elm/integer "0"
+                     #elm/decimal "1.5"]
       (system/date-time 2019 3 23 10 43 14)))
 
   (testing "an ELM date-time (only literals) always evaluates to something implementing Temporal"
@@ -387,7 +389,10 @@
         "2019-04-17" "Day" 17))
 
     (are [x precision res] (= res (eval (compile elm/date-time x precision)))
-      "2019-04-17T12:48" "Hour" 12)))
+      "2019-04-17T12:48" "Hour" 12))
+
+  (tu/testing-unary-precision-form elm/date-time-component-from "Year" "Month"
+                                   "Day" "Hour" "Minute" "Second" "Millisecond"))
 
 
 ;; 18.10. DifferenceBetween
@@ -454,7 +459,9 @@
 
           "2018" "2018" "Month"
           "2018-01" "2018-01" "Day"
-          "2018-01-01" "2018-01-01" "Hour")))))
+          "2018-01-01" "2018-01-01" "Hour"))))
+
+  (tu/testing-binary-precision-form elm/difference-between "Year" "Month" "Day"))
 
 
 ;; 18.11. DurationBetween
@@ -520,12 +527,32 @@
 
           "2018" "2018" "Month"
           "2018-01" "2018-01" "Day"
-          "2018-01-01" "2018-01-01" "Hour")))))
+          "2018-01-01" "2018-01-01" "Hour"))))
+
+  (tu/testing-binary-precision-form elm/duration-between "Year" "Month" "Day"))
 
 
 ;; 18.12. Not Equal
 ;;
 ;; See 12.7. NotEqual
+
+
+;; 18.13. Now
+;;
+;; The Now operator returns the date and time of the start timestamp associated
+;; with the evaluation request. Now is defined in this way for two reasons:
+;;
+;; 1) The operation will always return the same value within any given
+;; evaluation, ensuring that the result of an expression containing Now will
+;; always return the same result.
+;;
+;; 2) The operation will return the timestamp associated with the evaluation
+;; request, allowing the evaluation to be performed with the same timezone
+;; offset information as the data delivered with the evaluation request.
+(deftest compile-now-test
+  (are [elm res] (= res (core/-eval (c/compile {} elm) {:now tu/now} nil nil))
+    {:type "Now"}
+    tu/now))
 
 
 ;; 18.14. SameAs
@@ -574,9 +601,9 @@
       "2019-04-17" "2019-04-17" true
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/same-as #elm/date"2019")
-    (tu/testing-binary-null elm/same-as #elm/date"2019-04")
-    (tu/testing-binary-null elm/same-as #elm/date"2019-04-17")
+    (tu/testing-binary-null elm/same-as #elm/date "2019")
+    (tu/testing-binary-null elm/same-as #elm/date "2019-04")
+    (tu/testing-binary-null elm/same-as #elm/date "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/same-as elm/date x y "year"))
@@ -596,9 +623,9 @@
       "2019-04-17" "2019-04-17" true
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/same-as #elm/date-time"2019")
-    (tu/testing-binary-null elm/same-as #elm/date-time"2019-04")
-    (tu/testing-binary-null elm/same-as #elm/date-time"2019-04-17")
+    (tu/testing-binary-null elm/same-as #elm/date-time "2019")
+    (tu/testing-binary-null elm/same-as #elm/date-time "2019-04")
+    (tu/testing-binary-null elm/same-as #elm/date-time "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/same-as elm/date-time x y "year"))
@@ -607,25 +634,9 @@
         "2019-04" "2019-04" true
         "2019-04" "2019-05" true
         "2019-04-17" "2019-04-17" true
-        "2019-04-17" "2019-04-18" true))))
+        "2019-04-17" "2019-04-18" true)))
 
-
-;; 18.13. Now
-;;
-;; The Now operator returns the date and time of the start timestamp associated
-;; with the evaluation request. Now is defined in this way for two reasons:
-;;
-;; 1) The operation will always return the same value within any given
-;; evaluation, ensuring that the result of an expression containing Now will
-;; always return the same result.
-;;
-;; 2) The operation will return the timestamp associated with the evaluation
-;; request, allowing the evaluation to be performed with the same timezone
-;; offset information as the data delivered with the evaluation request.
-(deftest compile-now-test
-  (are [elm res] (= res (core/-eval (c/compile {} elm) {:now tu/now} nil nil))
-    {:type "Now"}
-    tu/now))
+  (tu/testing-binary-precision-form elm/same-as))
 
 
 ;; 18.15. SameOrBefore
@@ -674,8 +685,8 @@
 (deftest compile-same-or-before-test
   (testing "Interval"
     (are [x y res] (= res (tu/compile-binop elm/same-or-before elm/interval x y))
-      [#elm/integer"1" #elm/integer"2"]
-      [#elm/integer"2" #elm/integer"3"] true))
+      [#elm/integer "1" #elm/integer "2"]
+      [#elm/integer "2" #elm/integer "3"] true))
 
   (testing "Date"
     (are [x y res] (= res (tu/compile-binop elm/same-or-before elm/date x y))
@@ -689,9 +700,9 @@
       "2019-04-17" "2019-04-17" true
       "2019-04-17" "2019-04-16" false)
 
-    (tu/testing-binary-null elm/same-or-before #elm/date"2019")
-    (tu/testing-binary-null elm/same-or-before #elm/date"2019-04")
-    (tu/testing-binary-null elm/same-or-before #elm/date"2019-04-17")
+    (tu/testing-binary-null elm/same-or-before #elm/date "2019")
+    (tu/testing-binary-null elm/same-or-before #elm/date "2019-04")
+    (tu/testing-binary-null elm/same-or-before #elm/date "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/same-or-before elm/date x y "year"))
@@ -714,9 +725,9 @@
       "2019-04-17" "2019-04-17" true
       "2019-04-17" "2019-04-16" false)
 
-    (tu/testing-binary-null elm/same-or-before #elm/date-time"2019")
-    (tu/testing-binary-null elm/same-or-before #elm/date-time"2019-04")
-    (tu/testing-binary-null elm/same-or-before #elm/date-time"2019-04-17")
+    (tu/testing-binary-null elm/same-or-before #elm/date-time "2019")
+    (tu/testing-binary-null elm/same-or-before #elm/date-time "2019-04")
+    (tu/testing-binary-null elm/same-or-before #elm/date-time "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/same-or-before elm/date-time x y "year"))
@@ -725,7 +736,9 @@
         "2019" "2018" false
         "2019-04" "2019-05" true
         "2019-04" "2019-04" true
-        "2019-04" "2019-03" true))))
+        "2019-04" "2019-03" true)))
+
+  (tu/testing-binary-precision-form elm/same-or-before))
 
 
 ;; 18.15. SameOrAfter
@@ -774,8 +787,8 @@
 (deftest compile-same-or-after-test
   (testing "Interval"
     (are [x y res] (= res (tu/compile-binop elm/same-or-after elm/interval x y))
-      [#elm/integer"2" #elm/integer"3"]
-      [#elm/integer"1" #elm/integer"2"] true))
+      [#elm/integer "2" #elm/integer "3"]
+      [#elm/integer "1" #elm/integer "2"] true))
 
   (testing "Date"
     (are [x y res] (= res (tu/compile-binop elm/same-or-after elm/date x y))
@@ -789,9 +802,9 @@
       "2019-04-17" "2019-04-17" true
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/same-or-after #elm/date"2019")
-    (tu/testing-binary-null elm/same-or-after #elm/date"2019-04")
-    (tu/testing-binary-null elm/same-or-after #elm/date"2019-04-17")
+    (tu/testing-binary-null elm/same-or-after #elm/date "2019")
+    (tu/testing-binary-null elm/same-or-after #elm/date "2019-04")
+    (tu/testing-binary-null elm/same-or-after #elm/date "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/same-or-after elm/date x y "year"))
@@ -814,9 +827,9 @@
       "2019-04-17" "2019-04-17" true
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/same-or-after #elm/date-time"2019")
-    (tu/testing-binary-null elm/same-or-after #elm/date-time"2019-04")
-    (tu/testing-binary-null elm/same-or-after #elm/date-time"2019-04-17")
+    (tu/testing-binary-null elm/same-or-after #elm/date-time "2019")
+    (tu/testing-binary-null elm/same-or-after #elm/date-time "2019-04")
+    (tu/testing-binary-null elm/same-or-after #elm/date-time "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/same-or-after elm/date-time x y "year"))
@@ -825,7 +838,9 @@
         "2019" "2020" false
         "2019-04" "2019-03" true
         "2019-04" "2019-04" true
-        "2019-04" "2019-05" true))))
+        "2019-04" "2019-05" true)))
+
+  (tu/testing-binary-precision-form elm/same-or-after))
 
 
 ;; 18.18. Time
@@ -842,54 +857,54 @@
 (deftest compile-time-test
   (testing "Static hour"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/time [#elm/integer"12"]
+      #elm/time [#elm/integer "12"]
       (date-time/local-time 12)))
 
   (testing "Dynamic hour"
     (let [compile-ctx {:library {:parameters {:def [{:name "hour"}]}}}
-          elm #elm/time [#elm/parameter-ref"hour"]
+          elm #elm/time [#elm/parameter-ref "hour"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"hour" 12}}]
       (is (= (date-time/local-time 12) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static hour-minute"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/time [#elm/integer"12" #elm/integer"13"]
+      #elm/time [#elm/integer "12" #elm/integer "13"]
       (date-time/local-time 12 13)))
 
   (testing "Dynamic hour-minute"
     (let [compile-ctx {:library {:parameters {:def [{:name "minute"}]}}}
-          elm #elm/time [#elm/integer"12" #elm/parameter-ref"minute"]
+          elm #elm/time [#elm/integer "12" #elm/parameter-ref "minute"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"minute" 13}}]
       (is (= (date-time/local-time 12 13) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static hour-minute-second"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/time [#elm/integer"12" #elm/integer"13" #elm/integer"14"]
+      #elm/time [#elm/integer "12" #elm/integer "13" #elm/integer "14"]
       (date-time/local-time 12 13 14)))
 
   (testing "Dynamic hour-minute-second"
     (let [compile-ctx {:library {:parameters {:def [{:name "second"}]}}}
-          elm #elm/time [#elm/integer"12"
-                         #elm/integer"13"
-                         #elm/parameter-ref"second"]
+          elm #elm/time [#elm/integer "12"
+                         #elm/integer "13"
+                         #elm/parameter-ref "second"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"second" 14}}]
       (is (= (date-time/local-time 12 13 14) (core/-eval expr eval-ctx nil nil)))))
 
   (testing "Static hour-minute-second-millisecond"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/time [#elm/integer"12" #elm/integer"13" #elm/integer"14"
-                 #elm/integer"15"]
+      #elm/time [#elm/integer "12" #elm/integer "13" #elm/integer "14"
+                 #elm/integer "15"]
       (date-time/local-time 12 13 14 15)))
 
   (testing "Dynamic hour-minute-second-millisecond"
     (let [compile-ctx {:library {:parameters {:def [{:name "millisecond"}]}}}
-          elm #elm/time [#elm/integer"12"
-                         #elm/integer"13"
-                         #elm/integer"14"
-                         #elm/parameter-ref"millisecond"]
+          elm #elm/time [#elm/integer "12"
+                         #elm/integer "13"
+                         #elm/integer "14"
+                         #elm/parameter-ref "millisecond"]
           expr (c/compile compile-ctx elm)
           eval-ctx {:parameters {"millisecond" 15}}]
       (is (= (date-time/local-time 12 13 14 15) (core/-eval expr eval-ctx nil nil)))))

--- a/modules/cql/test/blaze/elm/compiler/interval_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/interval_operators_test.clj
@@ -31,7 +31,7 @@
 (test/use-fixtures :each fixture)
 
 
-(def interval-zero #elm/interval [#elm/integer"0" #elm/integer"0"])
+(def interval-zero #elm/interval [#elm/integer "0" #elm/integer "0"])
 
 ;; 19.1. Interval
 ;;
@@ -90,30 +90,30 @@
 
     (are [elm res] (= res (c/compile {} elm))
       #elm/interval [:< #elm/as ["{urn:hl7-org:elm-types:r1}Integer" {:type "Null"}]
-                     #elm/integer"1"]
+                     #elm/integer "1"]
       (interval nil 1)
 
-      #elm/interval [#elm/integer"1"
+      #elm/interval [#elm/integer "1"
                      #elm/as ["{urn:hl7-org:elm-types:r1}Integer" {:type "Null"}] :>]
       (interval 1 nil)
 
-      #elm/interval [:< #elm/integer"1" #elm/integer"2"] (interval 2 2)
-      #elm/interval [#elm/integer"1" #elm/integer"2" :>] (interval 1 1)
-      #elm/interval [:< #elm/integer"1" #elm/integer"3" :>] (interval 2 2)))
+      #elm/interval [:< #elm/integer "1" #elm/integer "2"] (interval 2 2)
+      #elm/interval [#elm/integer "1" #elm/integer "2" :>] (interval 1 1)
+      #elm/interval [:< #elm/integer "1" #elm/integer "3" :>] (interval 2 2)))
 
   (testing "Dynamic"
     (are [elm res] (= res (tu/dynamic-compile-eval elm))
-      (elm/interval [:< (elm/as ["{urn:hl7-org:elm-types:r1}Integer" #elm/parameter-ref"nil"])
-                     #elm/integer"1"])
+      (elm/interval [:< (elm/as ["{urn:hl7-org:elm-types:r1}Integer" #elm/parameter-ref "nil"])
+                     #elm/integer "1"])
       (interval nil 1)
 
-      (elm/interval [#elm/integer"1"
-                     (elm/as ["{urn:hl7-org:elm-types:r1}Integer" #elm/parameter-ref"nil"]) :>])
+      (elm/interval [#elm/integer "1"
+                     (elm/as ["{urn:hl7-org:elm-types:r1}Integer" #elm/parameter-ref "nil"]) :>])
       (interval 1 nil)))
 
   (testing "Invalid interval"
     (are [elm] (thrown? Exception (core/-eval (c/compile {} elm) {} nil nil))
-      #elm/interval [#elm/integer"5" #elm/integer"3"])))
+      #elm/interval [#elm/integer "5" #elm/integer "3"])))
 
 
 ;; 19.2. After
@@ -160,36 +160,36 @@
   (testing "Interval"
     (testing "if both intervals are closed, the start of the first (3) has to be greater then the end of the second (2)"
       (are [x y res] (= res (tu/compile-binop elm/after elm/interval x y))
-        [#elm/integer"3" #elm/integer"4"]
-        [#elm/integer"1" #elm/integer"2"] true
-        [#elm/integer"2" #elm/integer"3"]
-        [#elm/integer"1" #elm/integer"2"] false))
+        [#elm/integer "3" #elm/integer "4"]
+        [#elm/integer "1" #elm/integer "2"] true
+        [#elm/integer "2" #elm/integer "3"]
+        [#elm/integer "1" #elm/integer "2"] false))
 
     (testing "if one of the intervals is open, start and end can be the same (2)"
       (are [x y res] (= res (tu/compile-binop elm/after elm/interval x y))
-        [#elm/integer"2" #elm/integer"3"]
-        [#elm/integer"1" #elm/integer"2" :>] true
-        [:< #elm/integer"2" #elm/integer"3"]
-        [#elm/integer"1" #elm/integer"2"] true
-        [:< #elm/integer"2" #elm/integer"3"]
-        [#elm/integer"1" #elm/integer"2" :>] true))
+        [#elm/integer "2" #elm/integer "3"]
+        [#elm/integer "1" #elm/integer "2" :>] true
+        [:< #elm/integer "2" #elm/integer "3"]
+        [#elm/integer "1" #elm/integer "2"] true
+        [:< #elm/integer "2" #elm/integer "3"]
+        [#elm/integer "1" #elm/integer "2" :>] true))
 
     (testing "if both intervals are open, start and end can overlap slightly"
       (are [x y res] (= res (tu/compile-binop elm/after elm/interval x y))
-        [:< #elm/integer"2" #elm/integer"4"]
-        [#elm/integer"1" #elm/integer"3" :>] true))
+        [:< #elm/integer "2" #elm/integer "4"]
+        [#elm/integer "1" #elm/integer "3" :>] true))
 
     (testing "if one of the relevant bounds is infinity, the result is false"
       (are [x y res] (= res (tu/compile-binop elm/after elm/interval x y))
-        [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer"3"]
-        [#elm/integer"1" #elm/integer"2"] false
-        [#elm/integer"2" #elm/integer"3"]
-        [#elm/integer"1" {:type "Null"}] false))
+        [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer "3"]
+        [#elm/integer "1" #elm/integer "2"] false
+        [#elm/integer "2" #elm/integer "3"]
+        [#elm/integer "1" {:type "Null"}] false))
 
     (testing "if the second interval has an unknown high bound, the result is null"
       (are [x y res] (= res (tu/compile-binop elm/after elm/interval x y))
-        [#elm/integer"2" #elm/integer"3"]
-        [#elm/integer"1" {:type "Null"} :>] nil))
+        [#elm/integer "2" #elm/integer "3"]
+        [#elm/integer "1" {:type "Null"} :>] nil))
 
     (tu/testing-binary-null elm/after interval-zero))
 
@@ -205,9 +205,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/after #elm/date"2019")
-    (tu/testing-binary-null elm/after #elm/date"2019-04")
-    (tu/testing-binary-null elm/after #elm/date"2019-04-17")
+    (tu/testing-binary-null elm/after #elm/date "2019")
+    (tu/testing-binary-null elm/after #elm/date "2019-04")
+    (tu/testing-binary-null elm/after #elm/date "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/after elm/date x y "year"))
@@ -233,9 +233,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/after #elm/date-time"2019")
-    (tu/testing-binary-null elm/after #elm/date-time"2019-04")
-    (tu/testing-binary-null elm/after #elm/date-time"2019-04-17")
+    (tu/testing-binary-null elm/after #elm/date-time "2019")
+    (tu/testing-binary-null elm/after #elm/date-time "2019-04")
+    (tu/testing-binary-null elm/after #elm/date-time "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/after elm/date-time
@@ -248,7 +248,9 @@
         "2019-04" "2019-05" false
         "2019-04-17" "2019-04-16" false
         "2019-04-17" "2019-04-17" false
-        "2019-04-17" "2019-04-18" false))))
+        "2019-04-17" "2019-04-18" false)))
+
+  (tu/testing-binary-precision-form elm/after))
 
 
 ;; 19.3. Before
@@ -294,36 +296,36 @@
   (testing "Interval"
     (testing "if both intervals are closed, the end of the first (2) has to be less then the start of the second (3)"
       (are [x y res] (= res (tu/compile-binop elm/before elm/interval x y))
-        [#elm/integer"1" #elm/integer"2"]
-        [#elm/integer"3" #elm/integer"4"] true
-        [#elm/integer"1" #elm/integer"2"]
-        [#elm/integer"2" #elm/integer"3"] false))
+        [#elm/integer "1" #elm/integer "2"]
+        [#elm/integer "3" #elm/integer "4"] true
+        [#elm/integer "1" #elm/integer "2"]
+        [#elm/integer "2" #elm/integer "3"] false))
 
     (testing "if one of the intervals is open, start and end can be the same (2)"
       (are [x y res] (= res (tu/compile-binop elm/before elm/interval x y))
-        [#elm/integer"1" #elm/integer"2" :>]
-        [#elm/integer"2" #elm/integer"3"] true
-        [#elm/integer"1" #elm/integer"2"]
-        [:< #elm/integer"2" #elm/integer"3"] true
-        [#elm/integer"1" #elm/integer"2" :>]
-        [:< #elm/integer"2" #elm/integer"3"] true))
+        [#elm/integer "1" #elm/integer "2" :>]
+        [#elm/integer "2" #elm/integer "3"] true
+        [#elm/integer "1" #elm/integer "2"]
+        [:< #elm/integer "2" #elm/integer "3"] true
+        [#elm/integer "1" #elm/integer "2" :>]
+        [:< #elm/integer "2" #elm/integer "3"] true))
 
     (testing "if both intervals are open, start and end can overlap slightly"
       (are [x y res] (= res (tu/compile-binop elm/before elm/interval x y))
-        [#elm/integer"1" #elm/integer"3" :>]
-        [:< #elm/integer"2" #elm/integer"4"] true))
+        [#elm/integer "1" #elm/integer "3" :>]
+        [:< #elm/integer "2" #elm/integer "4"] true))
 
     (testing "if one of the relevant bounds is infinity, the result is false"
       (are [x y res] (= res (tu/compile-binop elm/before elm/interval x y))
-        [#elm/integer"1" {:type "Null"}]
-        [#elm/integer"2" #elm/integer"3"] false
-        [#elm/integer"1" #elm/integer"2"]
-        [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer"3"] false))
+        [#elm/integer "1" {:type "Null"}]
+        [#elm/integer "2" #elm/integer "3"] false
+        [#elm/integer "1" #elm/integer "2"]
+        [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer "3"] false))
 
     (testing "if the second interval has an unknown low bound, the result is null"
       (are [x y res] (= res (tu/compile-binop elm/before elm/interval x y))
-        [#elm/integer"1" #elm/integer"2"]
-        [:< {:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer"3"] nil))
+        [#elm/integer "1" #elm/integer "2"]
+        [:< {:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer "3"] nil))
 
     (tu/testing-binary-null elm/before interval-zero))
 
@@ -339,9 +341,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-16" false)
 
-    (tu/testing-binary-null elm/before #elm/date"2019")
-    (tu/testing-binary-null elm/before #elm/date"2019-04")
-    (tu/testing-binary-null elm/before #elm/date"2019-04-17")
+    (tu/testing-binary-null elm/before #elm/date "2019")
+    (tu/testing-binary-null elm/before #elm/date "2019-04")
+    (tu/testing-binary-null elm/before #elm/date "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/before elm/date x y
@@ -368,9 +370,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-16" false)
 
-    (tu/testing-binary-null elm/before #elm/date-time"2019")
-    (tu/testing-binary-null elm/before #elm/date-time"2019-04")
-    (tu/testing-binary-null elm/before #elm/date-time"2019-04-17")
+    (tu/testing-binary-null elm/before #elm/date-time "2019")
+    (tu/testing-binary-null elm/before #elm/date-time "2019-04")
+    (tu/testing-binary-null elm/before #elm/date-time "2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/before elm/date-time
@@ -383,7 +385,9 @@
         "2019-04" "2019-03" false
         "2019-04-17" "2019-04-18" false
         "2019-04-17" "2019-04-17" false
-        "2019-04-17" "2019-04-16" false))))
+        "2019-04-17" "2019-04-16" false)))
+
+  (tu/testing-binary-precision-form elm/before))
 
 
 ;; 19.4. Collapse
@@ -419,27 +423,29 @@
 (deftest compile-collapse-test
   (testing "Integer"
     (are [source per res] (= res (core/-eval (c/compile {} (elm/collapse [source per])) {} nil nil))
-      #elm/list [#elm/interval [#elm/integer"1" #elm/integer"2"]]
+      #elm/list [#elm/interval [#elm/integer "1" #elm/integer "2"]]
       {:type "Null"}
       [(interval 1 2)]
 
-      #elm/list [#elm/interval [#elm/integer"1" #elm/integer"2"]
-                 #elm/interval [#elm/integer"2" #elm/integer"3"]]
+      #elm/list [#elm/interval [#elm/integer "1" #elm/integer "2"]
+                #elm/interval [#elm/integer "2" #elm/integer "3"]]
       {:type "Null"}
       [(interval 1 3)]
 
       #elm/list [{:type "Null"}] {:type "Null"} []
       #elm/list [{:type "Null"} {:type "Null"}] {:type "Null"} []
-      #elm/list[] {:type "Null"} []
+      #elm/list [] {:type "Null"} []
 
       {:type "Null"} {:type "Null"} nil))
 
   (testing "DateTime"
     (are [source per res] (= res (core/-eval (c/compile {} (elm/collapse [source per])) {} nil nil))
-      #elm/list [#elm/interval [#elm/date-time"2012-01-01" #elm/date-time"2012-01-15"]
-                 #elm/interval [#elm/date-time"2012-01-16" #elm/date-time"2012-05-25"]]
+      #elm/list [#elm/interval [#elm/date-time "2012-01-01" #elm/date-time "2012-01-15"]
+                #elm/interval [#elm/date-time "2012-01-16" #elm/date-time "2012-05-25"]]
       {:type "Null"}
-      [(interval (system/date-time 2012 1 1) (system/date-time 2012 5 25))])))
+      [(interval (system/date-time 2012 1 1) (system/date-time 2012 5 25))]))
+
+  (tu/testing-binary-form elm/collapse))
 
 
 ;; 19.5. Contains
@@ -466,32 +472,26 @@
 (deftest compile-contains-test
   (testing "Interval"
     (testing "Integer"
-      (are [interval x res] (= res (core/-eval (c/compile {} (elm/contains [interval x])) {} nil nil))
-        #elm/interval [#elm/integer"1" #elm/integer"1"] #elm/integer"1" true
-        #elm/interval [#elm/integer"1" #elm/integer"1"] #elm/integer"2" false))
+      (are [interval x res] (= res (c/compile {} (elm/contains [interval x])))
+        #elm/interval [#elm/integer "1" #elm/integer "1"] #elm/integer "1" true
+        #elm/interval [#elm/integer "1" #elm/integer "1"] #elm/integer "2" false)
 
-    (testing "Null"
-      (are [interval x] (nil? (c/compile {} (elm/contains [interval x])))
-        interval-zero {:type "Null"}
-
-        {:type "Null"} {:type "Null"})))
+      (tu/testing-binary-null elm/contains interval-zero #elm/integer "1")))
 
   (testing "List"
     (are [list x res] (= res (core/-eval (c/compile {} (elm/contains [list x])) {} nil nil))
-      #elm/list[] #elm/integer"1" false
+      #elm/list [] #elm/integer "1" false
 
-      #elm/list [#elm/integer"1"] #elm/integer"1" true
-      #elm/list [#elm/integer"1"] #elm/integer"2" false
+      #elm/list [#elm/integer "1"] #elm/integer "1" true
+      #elm/list [#elm/integer "1"] #elm/integer "2" false
 
-      #elm/list [#elm/quantity[1 "m"]] #elm/quantity[100 "cm"] true
+      #elm/list [#elm/quantity [1 "m"]] #elm/quantity [100 "cm"] true
 
-      #elm/list [#elm/date"2019"] #elm/date"2019-01" false)
+      #elm/list [#elm/date "2019"] #elm/date "2019-01" false)
 
-    (testing "Null"
-      (are [list x] (nil? (c/compile {} (elm/contains [list x])))
-        #elm/list[] {:type "Null"}
+    (tu/testing-binary-null elm/contains #elm/list [] #elm/integer "1"))
 
-        {:type "Null"} {:type "Null"}))))
+  (tu/testing-binary-precision-form elm/contains))
 
 
 ;; 19.6. End
@@ -510,17 +510,19 @@
 (deftest compile-end-test
   (testing "Integer"
     (are [x res] (= res (tu/compile-unop elm/end elm/interval x))
-      [#elm/integer"1" #elm/integer"2"] 2
-      [#elm/integer"1" #elm/integer"2" :>] 1
-      [#elm/integer"1" {:type "Null"}] Integer/MAX_VALUE))
+      [#elm/integer "1" #elm/integer "2"] 2
+      [#elm/integer "1" #elm/integer "2" :>] 1
+      [#elm/integer "1" {:type "Null"}] Integer/MAX_VALUE))
 
   (testing "Decimal"
     (are [x res] (= res (tu/compile-unop elm/end elm/interval x))
-      [#elm/decimal"1" #elm/decimal"2.1"] 2.1M
-      [#elm/decimal"1" #elm/decimal"2.1" :>] 2.09999999M
-      [#elm/decimal"1" {:type "Null"}] decimal/max))
+      [#elm/decimal "1" #elm/decimal "2.1"] 2.1M
+      [#elm/decimal "1" #elm/decimal "2.1" :>] 2.09999999M
+      [#elm/decimal "1" {:type "Null"}] decimal/max))
 
-  (tu/testing-unary-null elm/end))
+  (tu/testing-unary-null elm/end)
+
+  (tu/testing-unary-form elm/end))
 
 
 ;; 19.7. Ends
@@ -541,11 +543,13 @@
 (deftest compile-ends-test
   (testing "Integer"
     (are [x y res] (= res (tu/compile-binop elm/ends elm/interval x y))
-      [#elm/integer"1" #elm/integer"3"] [#elm/integer"1" #elm/integer"3"] true
-      [#elm/integer"2" #elm/integer"3"] [#elm/integer"1" #elm/integer"3"] true
-      [#elm/integer"1" #elm/integer"3"] [#elm/integer"2" #elm/integer"3"] false))
+      [#elm/integer "1" #elm/integer "3"] [#elm/integer "1" #elm/integer "3"] true
+      [#elm/integer "2" #elm/integer "3"] [#elm/integer "1" #elm/integer "3"] true
+      [#elm/integer "1" #elm/integer "3"] [#elm/integer "2" #elm/integer "3"] false))
 
-  (tu/testing-binary-null elm/ends interval-zero))
+  (tu/testing-binary-null elm/ends interval-zero)
+
+  (tu/testing-binary-precision-form elm/ends))
 
 
 ;; 19.8. Equal
@@ -580,22 +584,24 @@
   (testing "List"
     (are [x y res] (= res (tu/compile-binop elm/except elm/list x y))
       [] [] []
-      [] [#elm/integer"1"] []
-      [#elm/integer"1"] [#elm/integer"1"] []
-      [#elm/integer"1"] [] [1]
-      [#elm/integer"1"] [#elm/integer"2"] [1]
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"2"] [1]
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"1"] [2])
+      [] [#elm/integer "1"] []
+      [#elm/integer "1"] [#elm/integer "1"] []
+      [#elm/integer "1"] [] [1]
+      [#elm/integer "1"] [#elm/integer "2"] [1]
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "2"] [1]
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "1"] [2])
 
-    (tu/testing-binary-null elm/except #elm/list[]))
+    (tu/testing-binary-null elm/except #elm/list []))
 
   (testing "Interval"
     (testing "Integer"
       (are [x y res] (= res (tu/compile-binop elm/except elm/interval x y))
-        [#elm/integer"1" #elm/integer"3"] [#elm/integer"3" #elm/integer"4"] (interval 1 2)
-        [#elm/integer"3" #elm/integer"5"] [#elm/integer"1" #elm/integer"3"] (interval 4 5)))
+        [#elm/integer "1" #elm/integer "3"] [#elm/integer "3" #elm/integer "4"] (interval 1 2)
+        [#elm/integer "3" #elm/integer "5"] [#elm/integer "1" #elm/integer "3"] (interval 4 5)))
 
-    (tu/testing-binary-null elm/except interval-zero)))
+    (tu/testing-binary-null elm/except interval-zero))
+
+  (tu/testing-binary-form elm/except))
 
 
 ;; 19.11. Expand
@@ -673,21 +679,23 @@
   (testing "List"
     (are [x y res] (= res (tu/compile-binop elm/includes elm/list x y))
       [] [] true
-      [#elm/integer"1"] [#elm/integer"1"] true
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"1"] true
+      [#elm/integer "1"] [#elm/integer "1"] true
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "1"] true
 
       [{:type "Null"}] [{:type "Null"}] false)
 
-    (tu/testing-binary-null elm/includes #elm/list[]))
+    (tu/testing-binary-null elm/includes #elm/list []))
 
 
   (testing "Interval"
     (testing "Integer"
       (are [x y res] (= res (tu/compile-binop elm/includes elm/interval x y))
-        [#elm/integer"1" #elm/integer"2"] [#elm/integer"1" #elm/integer"2"] true
-        [#elm/integer"1" #elm/integer"2"] [#elm/integer"1" #elm/integer"3"] false))
+        [#elm/integer "1" #elm/integer "2"] [#elm/integer "1" #elm/integer "2"] true
+        [#elm/integer "1" #elm/integer "2"] [#elm/integer "1" #elm/integer "3"] false))
 
-    (tu/testing-binary-null elm/includes interval-zero)))
+    (tu/testing-binary-null elm/includes interval-zero))
+
+  (tu/testing-binary-precision-form elm/includes))
 
 
 ;; 19.14. IncludedIn
@@ -719,38 +727,40 @@
 (deftest compile-intersect-test
   (testing "List"
     (are [x y res] (= res (tu/compile-binop elm/intersect elm/list x y))
-      [#elm/integer"1"] [#elm/integer"1"] [1]
-      [#elm/integer"1"] [#elm/integer"2"] []
+      [#elm/integer "1"] [#elm/integer "1"] [1]
+      [#elm/integer "1"] [#elm/integer "2"] []
 
-      [#elm/integer"1"] [#elm/integer"1" #elm/integer"2"] [1]
+      [#elm/integer "1"] [#elm/integer "1" #elm/integer "2"] [1]
 
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"1"] [1])
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "1"] [1])
 
-    (tu/testing-binary-null elm/intersect #elm/list[]))
+    (tu/testing-binary-null elm/intersect #elm/list []))
 
   (testing "Interval"
     (are [x y res] (= res (tu/compile-binop elm/intersect elm/interval x y))
-      [#elm/integer"1" #elm/integer"2"]
-      [#elm/integer"2" #elm/integer"3"]
+      [#elm/integer "1" #elm/integer "2"]
+      [#elm/integer "2" #elm/integer "3"]
       (interval 2 2)
 
-      [#elm/integer"2" #elm/integer"3"]
-      [#elm/integer"1" #elm/integer"2"]
+      [#elm/integer "2" #elm/integer "3"]
+      [#elm/integer "1" #elm/integer "2"]
       (interval 2 2)
 
-      [#elm/integer"1" #elm/integer"10"]
-      [#elm/integer"5" #elm/integer"8"]
+      [#elm/integer "1" #elm/integer "10"]
+      [#elm/integer "5" #elm/integer "8"]
       (interval 5 8)
 
-      [#elm/integer"1" #elm/integer"10"]
-      [#elm/integer"5" {:type "Null"} :>]
+      [#elm/integer "1" #elm/integer "10"]
+      [#elm/integer "5" {:type "Null"} :>]
       nil
 
-      [#elm/integer"1" #elm/integer"2"]
-      [#elm/integer"3" #elm/integer"4"]
+      [#elm/integer "1" #elm/integer "2"]
+      [#elm/integer "3" #elm/integer "4"]
       nil)
 
-    (tu/testing-binary-null elm/intersect interval-zero)))
+    (tu/testing-binary-null elm/intersect interval-zero))
+
+  (tu/testing-binary-form elm/intersect))
 
 
 ;; 19.16. Meets
@@ -778,10 +788,12 @@
 (deftest compile-meets-before-test
   (testing "Integer"
     (are [x y res] (= res (tu/compile-binop elm/meets-before elm/interval x y))
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"3" #elm/integer"4"] true
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"4" #elm/integer"5"] false))
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "3" #elm/integer "4"] true
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "4" #elm/integer "5"] false))
 
-  (tu/testing-binary-null elm/meets-before interval-zero))
+  (tu/testing-binary-null elm/meets-before interval-zero)
+
+  (tu/testing-binary-precision-form elm/meets-before))
 
 
 ;; 19.18. MeetsAfter
@@ -801,10 +813,12 @@
 (deftest compile-meets-after-test
   (testing "Integer"
     (are [x y res] (= res (tu/compile-binop elm/meets-after elm/interval x y))
-      [#elm/integer"3" #elm/integer"4"] [#elm/integer"1" #elm/integer"2"] true
-      [#elm/integer"4" #elm/integer"5"] [#elm/integer"1" #elm/integer"2"] false))
+      [#elm/integer "3" #elm/integer "4"] [#elm/integer "1" #elm/integer "2"] true
+      [#elm/integer "4" #elm/integer "5"] [#elm/integer "1" #elm/integer "2"] false))
 
-  (tu/testing-binary-null elm/meets-after interval-zero))
+  (tu/testing-binary-null elm/meets-after interval-zero)
+
+  (tu/testing-binary-precision-form elm/meets-after))
 
 
 ;; 19.20. Overlaps
@@ -827,37 +841,39 @@
 (deftest compile-overlaps-test
   (testing "Static"
     (are [x y res] (= res (tu/compile-binop elm/overlaps elm/interval x y))
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"3" #elm/integer"4"] false
-      [#elm/integer"3" #elm/integer"4"] [#elm/integer"1" #elm/integer"2"] false
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "3" #elm/integer "4"] false
+      [#elm/integer "3" #elm/integer "4"] [#elm/integer "1" #elm/integer "2"] false
 
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"2" #elm/integer"4"] true
-      [#elm/integer"2" #elm/integer"4"] [#elm/integer"1" #elm/integer"2"] true
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "2" #elm/integer "4"] true
+      [#elm/integer "2" #elm/integer "4"] [#elm/integer "1" #elm/integer "2"] true
 
-      [#elm/integer"1" #elm/integer"3"] [#elm/integer"2" #elm/integer"4"] true
-      [#elm/integer"2" #elm/integer"4"] [#elm/integer"1" #elm/integer"3"] true
+      [#elm/integer "1" #elm/integer "3"] [#elm/integer "2" #elm/integer "4"] true
+      [#elm/integer "2" #elm/integer "4"] [#elm/integer "1" #elm/integer "3"] true
 
-      [#elm/integer"2" #elm/integer"3"] [#elm/integer"1" #elm/integer"4"] true
-      [#elm/integer"1" #elm/integer"4"] [#elm/integer"2" #elm/integer"3"] true
+      [#elm/integer "2" #elm/integer "3"] [#elm/integer "1" #elm/integer "4"] true
+      [#elm/integer "1" #elm/integer "4"] [#elm/integer "2" #elm/integer "3"] true
 
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"1" #elm/integer"2"] true))
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "1" #elm/integer "2"] true))
 
   (testing "Dynamic"
     (are [x y res] (= res (tu/dynamic-compile-eval (elm/overlaps [(elm/interval x) (elm/interval y)])))
-      [#elm/integer"1" #elm/parameter-ref"2"] [#elm/integer"3" #elm/parameter-ref"4"] false
-      [#elm/integer"3" #elm/parameter-ref"4"] [#elm/integer"1" #elm/parameter-ref"2"] false
+      [#elm/integer "1" #elm/parameter-ref "2"] [#elm/integer "3" #elm/parameter-ref "4"] false
+      [#elm/integer "3" #elm/parameter-ref "4"] [#elm/integer "1" #elm/parameter-ref "2"] false
 
-      [#elm/integer"1" #elm/parameter-ref"2"] [#elm/integer"2" #elm/parameter-ref"4"] true
-      [#elm/integer"2" #elm/parameter-ref"4"] [#elm/integer"1" #elm/parameter-ref"2"] true
+      [#elm/integer "1" #elm/parameter-ref "2"] [#elm/integer "2" #elm/parameter-ref "4"] true
+      [#elm/integer "2" #elm/parameter-ref "4"] [#elm/integer "1" #elm/parameter-ref "2"] true
 
-      [#elm/integer"1" #elm/parameter-ref"3"] [#elm/integer"2" #elm/parameter-ref"4"] true
-      [#elm/integer"2" #elm/parameter-ref"4"] [#elm/integer"1" #elm/parameter-ref"3"] true
+      [#elm/integer "1" #elm/parameter-ref "3"] [#elm/integer "2" #elm/parameter-ref "4"] true
+      [#elm/integer "2" #elm/parameter-ref "4"] [#elm/integer "1" #elm/parameter-ref "3"] true
 
-      [#elm/integer"2" #elm/parameter-ref"3"] [#elm/integer"1" #elm/parameter-ref"4"] true
-      [#elm/integer"1" #elm/parameter-ref"4"] [#elm/integer"2" #elm/parameter-ref"3"] true
+      [#elm/integer "2" #elm/parameter-ref "3"] [#elm/integer "1" #elm/parameter-ref "4"] true
+      [#elm/integer "1" #elm/parameter-ref "4"] [#elm/integer "2" #elm/parameter-ref "3"] true
 
-      [#elm/integer"1" #elm/parameter-ref"2"] [#elm/integer"1" #elm/parameter-ref"2"] true))
+      [#elm/integer "1" #elm/parameter-ref "2"] [#elm/integer "1" #elm/parameter-ref "2"] true))
 
-  (tu/testing-binary-null elm/overlaps interval-zero))
+  (tu/testing-binary-null elm/overlaps interval-zero)
+
+  (tu/testing-binary-precision-form elm/overlaps))
 
 
 ;; 19.21. OverlapsBefore
@@ -884,10 +900,12 @@
 (deftest compile-point-from-test
   (testing "Integer"
     (are [x res] (= res (tu/compile-unop elm/point-from elm/interval x))
-      [#elm/integer"1" #elm/integer"1"] 1
-      [#elm/integer"2" #elm/integer"2"] 2))
+      [#elm/integer "1" #elm/integer "1"] 1
+      [#elm/integer "2" #elm/integer "2"] 2))
 
-  (tu/testing-unary-null elm/point-from))
+  (tu/testing-unary-null elm/point-from)
+
+  (tu/testing-unary-form elm/point-from))
 
 
 ;; 19.24. ProperContains
@@ -914,11 +932,13 @@
   (testing "Interval"
     (testing "Integer"
       (are [interval x res] (= res (c/compile {} (elm/proper-contains [interval x])))
-        #elm/interval [#elm/integer"1" #elm/integer"3"] #elm/integer"2" true
-        #elm/interval [#elm/integer"1" #elm/integer"1"] #elm/integer"1" false
-        #elm/interval [#elm/integer"1" #elm/integer"1"] #elm/integer"2" false))
+        #elm/interval [#elm/integer "1" #elm/integer "3"] #elm/integer "2" true
+        #elm/interval [#elm/integer "1" #elm/integer "1"] #elm/integer "1" false
+        #elm/interval [#elm/integer "1" #elm/integer "1"] #elm/integer "2" false))
 
-    (tu/testing-binary-null elm/proper-contains interval-zero)))
+    (tu/testing-binary-null elm/proper-contains interval-zero))
+
+  (tu/testing-binary-precision-form elm/proper-contains))
 
 
 ;; 19.25. ProperIn
@@ -954,10 +974,12 @@
   (testing "Interval"
     (testing "Integer"
       (are [x y res] (= res (tu/compile-binop elm/proper-includes elm/interval x y))
-        [#elm/integer"1" #elm/integer"3"] [#elm/integer"1" #elm/integer"2"] true
-        [#elm/integer"1" #elm/integer"2"] [#elm/integer"1" #elm/integer"2"] false))
+        [#elm/integer "1" #elm/integer "3"] [#elm/integer "1" #elm/integer "2"] true
+        [#elm/integer "1" #elm/integer "2"] [#elm/integer "1" #elm/integer "2"] false))
 
-    (tu/testing-binary-null elm/proper-includes interval-zero)))
+    (tu/testing-binary-null elm/proper-includes interval-zero))
+
+  (tu/testing-binary-precision-form elm/proper-includes))
 
 
 ;; 19.27. ProperIncludedIn
@@ -999,17 +1021,19 @@
 (deftest compile-start-test
   (testing "Integer"
     (are [x res] (= res (tu/compile-unop elm/start elm/interval x))
-      [#elm/integer"1" #elm/integer"2"] 1
-      [:< #elm/integer"1" #elm/integer"2"] 2
-      [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer"2"] Integer/MIN_VALUE))
+      [#elm/integer "1" #elm/integer "2"] 1
+      [:< #elm/integer "1" #elm/integer "2"] 2
+      [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Integer"} #elm/integer "2"] Integer/MIN_VALUE))
 
   (testing "Decimal"
     (are [x res] (= res (tu/compile-unop elm/start elm/interval x))
-      [#elm/decimal"1.1" #elm/decimal"2"] 1.1M
-      [:< #elm/decimal"1.1" #elm/decimal"2"] 1.10000001M
-      [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Decimal"} #elm/decimal"2"] decimal/min))
+      [#elm/decimal "1.1" #elm/decimal "2"] 1.1M
+      [:< #elm/decimal "1.1" #elm/decimal "2"] 1.10000001M
+      [{:type "Null" :resultTypeName "{urn:hl7-org:elm-types:r1}Decimal"} #elm/decimal "2"] decimal/min))
 
-  (tu/testing-unary-null elm/start))
+  (tu/testing-unary-null elm/start)
+
+  (tu/testing-unary-form elm/start))
 
 
 ;; 19.30. Starts
@@ -1030,11 +1054,13 @@
 (deftest compile-starts-test
   (testing "Integer"
     (are [x y res] (= res (tu/compile-binop elm/starts elm/interval x y))
-      [#elm/integer"1" #elm/integer"3"] [#elm/integer"1" #elm/integer"3"] true
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"1" #elm/integer"3"] true
-      [#elm/integer"2" #elm/integer"3"] [#elm/integer"1" #elm/integer"3"] false))
+      [#elm/integer "1" #elm/integer "3"] [#elm/integer "1" #elm/integer "3"] true
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "1" #elm/integer "3"] true
+      [#elm/integer "2" #elm/integer "3"] [#elm/integer "1" #elm/integer "3"] false))
 
-  (tu/testing-binary-null elm/starts interval-zero))
+  (tu/testing-binary-null elm/starts interval-zero)
+
+  (tu/testing-binary-precision-form elm/starts))
 
 
 ;; 19.31. Union
@@ -1058,17 +1084,19 @@
   (testing "List"
     (are [x y res] (= res (tu/compile-binop elm/union elm/list x y))
       [{:type "Null"}] [{:type "Null"}] [nil nil]
-      [#elm/integer"1"] [#elm/integer"1"] [1]
-      [#elm/integer"1"] [#elm/integer"2"] [1 2]
-      [#elm/integer"1"] [#elm/integer"1" #elm/integer"2"] [1 2])
+      [#elm/integer "1"] [#elm/integer "1"] [1]
+      [#elm/integer "1"] [#elm/integer "2"] [1 2]
+      [#elm/integer "1"] [#elm/integer "1" #elm/integer "2"] [1 2])
 
-    (tu/testing-binary-null elm/union #elm/list[]))
+    (tu/testing-binary-null elm/union #elm/list []))
 
   (testing "Interval"
     (are [x y res] (= res (tu/compile-binop elm/union elm/interval x y))
-      [#elm/integer"1" #elm/integer"2"] [#elm/integer"3" #elm/integer"4"] (interval 1 4))
+      [#elm/integer "1" #elm/integer "2"] [#elm/integer "3" #elm/integer "4"] (interval 1 4))
 
-    (tu/testing-binary-null elm/union interval-zero)))
+    (tu/testing-binary-null elm/union interval-zero))
+
+  (tu/testing-binary-form elm/union))
 
 
 ;; 19.32. Width
@@ -1083,6 +1111,8 @@
 (deftest compile-width-test
   (testing "Integer"
     (are [x res] (= res (tu/compile-unop elm/width elm/interval x))
-      [#elm/integer"1" #elm/integer"2"] 1))
+      [#elm/integer "1" #elm/integer "2"] 1))
 
-  (tu/testing-unary-null elm/width))
+  (tu/testing-unary-null elm/width)
+
+  (tu/testing-unary-form elm/width))

--- a/modules/cql/test/blaze/elm/compiler/list_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/list_operators_test.clj
@@ -51,13 +51,13 @@
     #elm/list [{:type "Null"}]
     [nil]
 
-    #elm/list [#elm/integer"1"]
+    #elm/list [#elm/integer "1"]
     [1]
 
-    #elm/list [#elm/integer"1" {:type "Null"}]
+    #elm/list [#elm/integer "1" {:type "Null"}]
     [1 nil]
 
-    #elm/list [#elm/integer"1" #elm/integer"2"]
+    #elm/list [#elm/integer "1" #elm/integer "2"]
     [1 2]))
 
 
@@ -77,15 +77,15 @@
 (deftest compile-current-test
   (testing "default scope"
     (satisfies-prop 100
-    (prop/for-all [x (s/gen int?)]
-      (= x (core/-eval (c/compile {} {:type "Current"}) {} nil x)))))
+      (prop/for-all [x (s/gen int?)]
+        (= x (core/-eval (c/compile {} {:type "Current"}) {} nil x)))))
 
   (testing "named scope"
     (satisfies-prop 100
-    (prop/for-all [scope (s/gen string?)
-                   x (s/gen int?)]
-      (let [expr (c/compile {} {:type "Current" :scope scope})]
-        (= x (core/-eval expr {} nil {scope x})))))))
+      (prop/for-all [scope (s/gen string?)
+                     x (s/gen int?)]
+        (let [expr (c/compile {} {:type "Current" :scope scope})]
+          (= x (core/-eval expr {} nil {scope x})))))))
 
 
 ;; 20.4. Distinct
@@ -101,17 +101,19 @@
 ;;
 ;; If the source argument is null, the result is null.
 (deftest compile-distinct-test
-  (are [list res] (= res (core/-eval (c/compile {} (elm/distinct list)) {} nil nil))
-    #elm/list [#elm/integer"1"] [1]
-    #elm/list [#elm/integer"1" #elm/integer"1"] [1]
-    #elm/list [#elm/integer"1" #elm/integer"1" #elm/integer"2"] [1 2]
+  (are [list res] (= res (c/compile {} (elm/distinct list)))
+    #elm/list [#elm/integer "1"] [1]
+    #elm/list [#elm/integer "1" #elm/integer "1"] [1]
+    #elm/list [#elm/integer "1" #elm/integer "1" #elm/integer "2"] [1 2]
     #elm/list [{:type "Null"}] [nil]
     #elm/list [{:type "Null"} {:type "Null"}] [nil nil]
     #elm/list [{:type "Null"} {:type "Null"} {:type "Null"}] [nil nil nil]
-    #elm/list [#elm/quantity[100 "cm"] #elm/quantity[1 "m"]] [(quantity/quantity 100 "cm")]
-    #elm/list [#elm/quantity[1 "m"] #elm/quantity[100 "cm"]] [(quantity/quantity 1 "m")]
+    #elm/list [#elm/quantity [100 "cm"] #elm/quantity [1 "m"]] [(quantity/quantity 100 "cm")]
+    #elm/list [#elm/quantity [1 "m"] #elm/quantity [100 "cm"]] [(quantity/quantity 1 "m")])
 
-    {:type "Null"} nil))
+  (tu/testing-unary-null elm/distinct)
+
+  (tu/testing-unary-form elm/distinct))
 
 
 ;; 20.5. Equal
@@ -135,12 +137,14 @@
 ;;
 ;; If the argument is null, the result is false.
 (deftest compile-exists-test
-  (are [list res] (= res (core/-eval (c/compile {} (elm/exists list)) {} nil nil))
-    #elm/list [#elm/integer"1"] true
-    #elm/list [#elm/integer"1" #elm/integer"1"] true
+  (are [list res] (= res (c/compile {} (elm/exists list)))
+    #elm/list [#elm/integer "1"] true
+    #elm/list [#elm/integer "1" #elm/integer "1"] true
     #elm/list [] false
 
-    {:type "Null"} false))
+    {:type "Null"} false)
+
+  (tu/testing-unary-form elm/exists))
 
 
 ;; 20.9. Filter
@@ -151,10 +155,10 @@
 ;; If the source argument is null, the result is null.
 (deftest compile-filter-test
   (are [source condition res] (= res (core/-eval (c/compile {} {:type "Filter" :source source :condition condition :scope "A"}) {} nil nil))
-    #elm/list [#elm/integer"1"] #elm/boolean"false" []
-    #elm/list [#elm/integer"1"] #elm/equal [#elm/current "A" #elm/integer"1"] [1]
+    #elm/list [#elm/integer "1"] #elm/boolean "false" []
+    #elm/list [#elm/integer "1"] #elm/equal [#elm/current "A" #elm/integer "1"] [1]
 
-    {:type "Null"} #elm/boolean"true" nil))
+    {:type "Null"} #elm/boolean "true" nil))
 
 
 ;; 20.10. First
@@ -166,8 +170,8 @@
 ;; If the argument is null, the result is null.
 (deftest compile-first-test
   (are [source res] (= res (core/-eval (c/compile {} (elm/first source)) {} nil nil))
-    #elm/list [#elm/integer"1"] 1
-    #elm/list [#elm/integer"1" #elm/integer"2"] 1
+    #elm/list [#elm/integer "1"] 1
+    #elm/list [#elm/integer "1" #elm/integer "2"] 1
 
     {:type "Null"} nil))
 
@@ -178,15 +182,17 @@
 ;;
 ;; If the argument is null, the result is null.
 (deftest compile-flatten-test
-  (are [list res] (= res (core/-eval (c/compile {} (elm/flatten list)) {} nil nil))
+  (are [list res] (= res (c/compile {} (elm/flatten list)))
     #elm/list [] []
-    #elm/list [#elm/integer"1"] [1]
-    #elm/list [#elm/integer"1" #elm/list [#elm/integer"2"]] [1 2]
-    #elm/list [#elm/integer"1" #elm/list [#elm/integer"2"] #elm/integer"3"] [1 2 3]
-    #elm/list [#elm/integer"1" #elm/list [#elm/integer"2" #elm/list [#elm/integer"3"]]] [1 2 3]
-    #elm/list [#elm/list [#elm/integer"1" #elm/list [#elm/integer"2"]] #elm/integer"3"] [1 2 3]
+    #elm/list [#elm/integer "1"] [1]
+    #elm/list [#elm/integer "1" #elm/list [#elm/integer "2"]] [1 2]
+    #elm/list [#elm/integer "1" #elm/list [#elm/integer "2"] #elm/integer "3"] [1 2 3]
+    #elm/list [#elm/integer "1" #elm/list [#elm/integer "2" #elm/list [#elm/integer "3"]]] [1 2 3]
+    #elm/list [#elm/list [#elm/integer "1" #elm/list [#elm/integer "2"]] #elm/integer "3"] [1 2 3])
 
-    {:type "Null"} nil))
+  (tu/testing-unary-null elm/flatten)
+
+  (tu/testing-unary-form elm/flatten))
 
 
 ;; 20.12. ForEach
@@ -203,14 +209,14 @@
 (deftest compile-for-each-test
   (testing "Without scope"
     (are [source element res] (= res (core/-eval (c/compile {} {:type "ForEach" :source source :element element}) {} nil nil))
-      #elm/list [#elm/integer"1"] {:type "Null"} [nil]
+      #elm/list [#elm/integer "1"] {:type "Null"} [nil]
 
       {:type "Null"} {:type "Null"} nil))
 
   (testing "With scope"
     (are [source element res] (= res (core/-eval (c/compile {} {:type "ForEach" :source source :element element :scope "A"}) {} nil nil))
-      #elm/list [#elm/integer"1"] #elm/current "A" [1]
-      #elm/list [#elm/integer"1" #elm/integer"2"] #elm/add [#elm/current "A" #elm/integer"1"] [2 3]
+      #elm/list [#elm/integer "1"] #elm/current "A" [1]
+      #elm/list [#elm/integer "1" #elm/integer "2"] #elm/add [#elm/current "A" #elm/integer "1"] [2 3]
 
       {:type "Null"} {:type "Null"} nil)))
 
@@ -244,13 +250,13 @@
 ;; If either argument is null, the result is null.
 (deftest compile-index-of-test
   (are [source element res] (= res (core/-eval (c/compile {} {:type "IndexOf" :source source :element element}) {} nil nil))
-    #elm/list [] #elm/integer"1" -1
-    #elm/list [#elm/integer"1"] #elm/integer"1" 0
-    #elm/list [#elm/integer"1" #elm/integer"1"] #elm/integer"1" 0
-    #elm/list [#elm/integer"1" #elm/integer"2"] #elm/integer"2" 1
+    #elm/list [] #elm/integer "1" -1
+    #elm/list [#elm/integer "1"] #elm/integer "1" 0
+    #elm/list [#elm/integer "1" #elm/integer "1"] #elm/integer "1" 0
+    #elm/list [#elm/integer "1" #elm/integer "2"] #elm/integer "2" 1
 
     #elm/list [] {:type "Null"} nil
-    {:type "Null"} #elm/integer"1" nil
+    {:type "Null"} #elm/integer "1" nil
     {:type "Null"} {:type "Null"} nil))
 
 
@@ -268,8 +274,8 @@
 ;; If the argument is null, the result is null.
 (deftest compile-last-test
   (are [source res] (= res (core/-eval (c/compile {} {:type "Last" :source source}) {} nil nil))
-    #elm/list [#elm/integer"1"] 1
-    #elm/list [#elm/integer"1" #elm/integer"2"] 2
+    #elm/list [#elm/integer "1"] 1
+    #elm/list [#elm/integer "1" #elm/integer "2"] 2
 
     {:type "Null"} nil))
 
@@ -325,11 +331,13 @@
 (deftest compile-singleton-from-test
   (are [list res] (= res (core/-eval (c/compile {} (elm/singleton-from list)) {} nil nil))
     #elm/list [] nil
-    #elm/list [#elm/integer"1"] 1
+    #elm/list [#elm/integer "1"] 1
     {:type "Null"} nil)
 
   (are [list] (thrown? Exception (core/-eval (c/compile {} (elm/singleton-from list)) {} nil nil))
-    #elm/list [#elm/integer"1" #elm/integer"1"]))
+    #elm/list [#elm/integer "1" #elm/integer "1"])
+
+  (tu/testing-unary-null elm/singleton-from))
 
 
 ;; 20.26. Slice
@@ -347,17 +355,17 @@
 ;; the startIndex, the result is an empty list.
 (deftest compile-slice-test
   (are [source start end res] (= res (core/-eval (c/compile {} {:type "Slice" :source source :startIndex start :endIndex end}) {} nil nil))
-    #elm/list [#elm/integer"1"] #elm/integer"0" #elm/integer"1" [1]
-    #elm/list [#elm/integer"1" #elm/integer"2"] #elm/integer"0" #elm/integer"1" [1]
-    #elm/list [#elm/integer"1" #elm/integer"2"] #elm/integer"1" #elm/integer"2" [2]
-    #elm/list [#elm/integer"1" #elm/integer"2" #elm/integer"3"] #elm/integer"1" #elm/integer"3" [2 3]
-    #elm/list [#elm/integer"1" #elm/integer"2"] {:type "Null"} {:type "Null"} [1 2]
+    #elm/list [#elm/integer "1"] #elm/integer "0" #elm/integer "1" [1]
+    #elm/list [#elm/integer "1" #elm/integer "2"] #elm/integer "0" #elm/integer "1" [1]
+    #elm/list [#elm/integer "1" #elm/integer "2"] #elm/integer "1" #elm/integer "2" [2]
+    #elm/list [#elm/integer "1" #elm/integer "2" #elm/integer "3"] #elm/integer "1" #elm/integer "3" [2 3]
+    #elm/list [#elm/integer "1" #elm/integer "2"] {:type "Null"} {:type "Null"} [1 2]
 
-    #elm/list [#elm/integer"1"] #elm/integer"-1" #elm/integer"0" []
-    #elm/list [#elm/integer"1"] #elm/integer"1" #elm/integer"0" []
+    #elm/list [#elm/integer "1"] #elm/integer "-1" #elm/integer "0" []
+    #elm/list [#elm/integer "1"] #elm/integer "1" #elm/integer "0" []
 
 
-    {:type "Null"} #elm/integer"0" #elm/integer"0" nil
+    {:type "Null"} #elm/integer "0" #elm/integer "0" nil
     {:type "Null"} {:type "Null"} {:type "Null"} nil))
 
 
@@ -373,10 +381,10 @@
 ;; If the argument is null, the result is null.
 (deftest compile-sort-test
   (are [source by res] (= res (core/-eval (c/compile {} {:type "Sort" :source source :by [by]}) {} nil nil))
-    #elm/list [#elm/integer"2" #elm/integer"1"]
+    #elm/list [#elm/integer "2" #elm/integer "1"]
     {:type "ByDirection" :direction "asc"} [1 2]
 
-    #elm/list [#elm/integer"1" #elm/integer"2"]
+    #elm/list [#elm/integer "1" #elm/integer "2"]
     {:type "ByDirection" :direction "desc"} [2 1]
 
     {:type "Null"} {:type "ByDirection" :direction "asc"} nil))

--- a/modules/cql/test/blaze/elm/compiler/logical_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/logical_operators_test.clj
@@ -39,37 +39,60 @@
 (deftest compile-and-test
   (testing "Static"
     (are [x y res] (= res (c/compile {} (elm/and [x y])))
-      #elm/boolean"true" #elm/boolean"true" true
-      #elm/boolean"true" #elm/boolean"false" false
-      #elm/boolean"true" {:type "Null"} nil
+      #elm/boolean "true" #elm/boolean "true" true
+      #elm/boolean "true" #elm/boolean "false" false
+      #elm/boolean "true" {:type "Null"} nil
 
-      #elm/boolean"false" #elm/boolean"true" false
-      #elm/boolean"false" #elm/boolean"false" false
-      #elm/boolean"false" {:type "Null"} false
+      #elm/boolean "false" #elm/boolean "true" false
+      #elm/boolean "false" #elm/boolean "false" false
+      #elm/boolean "false" {:type "Null"} false
 
-      {:type "Null"} #elm/boolean"true" nil
-      {:type "Null"} #elm/boolean"false" false
+      {:type "Null"} #elm/boolean "true" nil
+      {:type "Null"} #elm/boolean "false" false
       {:type "Null"} {:type "Null"} nil))
 
   (testing "Dynamic"
     (are [x y res] (= res (tu/dynamic-compile-eval (elm/and [x y])))
-      #elm/boolean"true" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" #elm/boolean"true" true
-      #elm/parameter-ref"true" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" {:type "Null"} nil
-      {:type "Null"} #elm/parameter-ref"true" nil
+      #elm/boolean "true" #elm/parameter-ref "true" true
+      #elm/parameter-ref "true" #elm/boolean "true" true
+      #elm/parameter-ref "true" #elm/parameter-ref "true" true
+      #elm/parameter-ref "true" {:type "Null"} nil
+      {:type "Null"} #elm/parameter-ref "true" nil
 
-      #elm/boolean"true" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" #elm/boolean"true" false
-      #elm/parameter-ref"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" {:type "Null"} false
-      {:type "Null"} #elm/parameter-ref"false" false
+      #elm/boolean "true" #elm/parameter-ref "false" false
+      #elm/parameter-ref "false" #elm/boolean "true" false
+      #elm/parameter-ref "false" #elm/parameter-ref "false" false
+      #elm/parameter-ref "false" {:type "Null"} false
+      {:type "Null"} #elm/parameter-ref "false" false
 
-      #elm/boolean"false" #elm/parameter-ref"nil" false
-      #elm/parameter-ref"nil" #elm/boolean"false" false
-      #elm/boolean"true" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"true" nil
-      #elm/parameter-ref"nil" #elm/parameter-ref"nil" nil)))
+      #elm/boolean "false" #elm/parameter-ref "nil" false
+      #elm/parameter-ref "nil" #elm/boolean "false" false
+      #elm/boolean "true" #elm/parameter-ref "nil" nil
+      #elm/parameter-ref "nil" #elm/boolean "true" nil
+      #elm/parameter-ref "nil" #elm/parameter-ref "nil" nil))
+
+  (testing "form"
+    (let [compile-ctx# {:library {:parameters {:def [{:name "a"} {:name "b"}]}}}]
+      (are [x y form] (= form (c/form (c/compile compile-ctx# (elm/and [x y]))))
+        #elm/boolean "true" #elm/boolean "true" true
+        #elm/boolean "true" #elm/boolean "false" false
+        #elm/boolean "true" {:type "Null"} nil
+        #elm/boolean "true" #elm/parameter-ref "b" '(param-ref "b")
+
+        #elm/boolean "false" #elm/boolean "true" false
+        #elm/boolean "false" #elm/boolean "false" false
+        #elm/boolean "false" {:type "Null"} false
+        #elm/boolean "false" #elm/parameter-ref "b" false
+
+        {:type "Null"} #elm/boolean "true" nil
+        {:type "Null"} #elm/boolean "false" false
+        {:type "Null"} {:type "Null"} nil
+        {:type "Null"} #elm/parameter-ref "b" '(and nil (param-ref "b"))
+
+        #elm/parameter-ref "a" #elm/boolean "true" '(param-ref "a")
+        #elm/parameter-ref "a" #elm/boolean "false" false
+        #elm/parameter-ref "a" {:type "Null"} '(and nil (param-ref "a"))
+        #elm/parameter-ref "a" #elm/parameter-ref "b" '(and (param-ref "a") (param-ref "b"))))))
 
 
 ;; 13.2. Implies
@@ -86,16 +109,16 @@
 (deftest compile-implies-test
   (testing "Static"
     (are [x y res] (= res (c/compile {} (elm/or [(elm/not x) y])))
-      #elm/boolean"true" #elm/boolean"true" true
-      #elm/boolean"true" #elm/boolean"false" false
-      #elm/boolean"true" {:type "Null"} nil
+      #elm/boolean "true" #elm/boolean "true" true
+      #elm/boolean "true" #elm/boolean "false" false
+      #elm/boolean "true" {:type "Null"} nil
 
-      #elm/boolean"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/boolean"false" true
-      #elm/boolean"false" {:type "Null"} true
+      #elm/boolean "false" #elm/boolean "true" true
+      #elm/boolean "false" #elm/boolean "false" true
+      #elm/boolean "false" {:type "Null"} true
 
-      {:type "Null"} #elm/boolean"true" true
-      {:type "Null"} #elm/boolean"false" nil
+      {:type "Null"} #elm/boolean "true" true
+      {:type "Null"} #elm/boolean "false" nil
       {:type "Null"} {:type "Null"} nil)))
 
 
@@ -107,15 +130,17 @@
 (deftest compile-not-test
   (testing "Static"
     (are [x res] (= res (c/compile {} (elm/not x)))
-      #elm/boolean"true" false
-      #elm/boolean"false" true
+      #elm/boolean "true" false
+      #elm/boolean "false" true
       {:type "Null"} nil))
 
   (testing "Dynamic"
     (are [x res] (= res (tu/dynamic-compile-eval (elm/not x)))
-      #elm/parameter-ref"true" false
-      #elm/parameter-ref"false" true
-      #elm/parameter-ref"nil" nil)))
+      #elm/parameter-ref "true" false
+      #elm/parameter-ref "false" true
+      #elm/parameter-ref "nil" nil))
+
+  (tu/testing-unary-form elm/not))
 
 
 ;; 13.4. Or
@@ -128,37 +153,60 @@
 (deftest compile-or-test
   (testing "Static"
     (are [x y res] (= res (c/compile {} (elm/or [x y])))
-      #elm/boolean"true" #elm/boolean"true" true
-      #elm/boolean"true" #elm/boolean"false" true
-      #elm/boolean"true" {:type "Null"} true
+      #elm/boolean "true" #elm/boolean "true" true
+      #elm/boolean "true" #elm/boolean "false" true
+      #elm/boolean "true" {:type "Null"} true
 
-      #elm/boolean"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/boolean"false" false
-      #elm/boolean"false" {:type "Null"} nil
+      #elm/boolean "false" #elm/boolean "true" true
+      #elm/boolean "false" #elm/boolean "false" false
+      #elm/boolean "false" {:type "Null"} nil
 
-      {:type "Null"} #elm/boolean"true" true
-      {:type "Null"} #elm/boolean"false" nil
+      {:type "Null"} #elm/boolean "true" true
+      {:type "Null"} #elm/boolean "false" nil
       {:type "Null"} {:type "Null"} nil))
 
   (testing "Dynamic"
     (are [x y res] (= res (tu/dynamic-compile-eval (elm/or [x y])))
-      #elm/boolean"false" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" #elm/boolean"false" true
-      #elm/parameter-ref"true" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" {:type "Null"} true
-      {:type "Null"} #elm/parameter-ref"true" true
+      #elm/boolean "false" #elm/parameter-ref "true" true
+      #elm/parameter-ref "true" #elm/boolean "false" true
+      #elm/parameter-ref "true" #elm/parameter-ref "true" true
+      #elm/parameter-ref "true" {:type "Null"} true
+      {:type "Null"} #elm/parameter-ref "true" true
 
-      #elm/boolean"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" #elm/boolean"false" false
-      #elm/parameter-ref"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" {:type "Null"} nil
-      {:type "Null"} #elm/parameter-ref"false" nil
+      #elm/boolean "false" #elm/parameter-ref "false" false
+      #elm/parameter-ref "false" #elm/boolean "false" false
+      #elm/parameter-ref "false" #elm/parameter-ref "false" false
+      #elm/parameter-ref "false" {:type "Null"} nil
+      {:type "Null"} #elm/parameter-ref "false" nil
 
-      #elm/boolean"true" #elm/parameter-ref"nil" true
-      #elm/parameter-ref"nil" #elm/boolean"true" true
-      #elm/boolean"false" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"false" nil
-      #elm/parameter-ref"nil" #elm/parameter-ref"nil" nil)))
+      #elm/boolean "true" #elm/parameter-ref "nil" true
+      #elm/parameter-ref "nil" #elm/boolean "true" true
+      #elm/boolean "false" #elm/parameter-ref "nil" nil
+      #elm/parameter-ref "nil" #elm/boolean "false" nil
+      #elm/parameter-ref "nil" #elm/parameter-ref "nil" nil))
+
+  (testing "form"
+    (let [compile-ctx# {:library {:parameters {:def [{:name "a"} {:name "b"}]}}}]
+      (are [x y form] (= form (c/form (c/compile compile-ctx# (elm/or [x y]))))
+        #elm/boolean "true" #elm/boolean "true" true
+        #elm/boolean "true" #elm/boolean "false" true
+        #elm/boolean "true" {:type "Null"} true
+        #elm/boolean "true" #elm/parameter-ref "b" true
+
+        #elm/boolean "false" #elm/boolean "true" true
+        #elm/boolean "false" #elm/boolean "false" false
+        #elm/boolean "false" {:type "Null"} nil
+        #elm/boolean "false" #elm/parameter-ref "b" '(param-ref "b")
+
+        {:type "Null"} #elm/boolean "true" true
+        {:type "Null"} #elm/boolean "false" nil
+        {:type "Null"} {:type "Null"} nil
+        {:type "Null"} #elm/parameter-ref "b" '(or nil (param-ref "b"))
+
+        #elm/parameter-ref "a" #elm/boolean "true" true
+        #elm/parameter-ref "a" #elm/boolean "false" '(param-ref "a")
+        #elm/parameter-ref "a" {:type "Null"} '(or nil (param-ref "a"))
+        #elm/parameter-ref "a" #elm/parameter-ref "b" '(or (param-ref "a") (param-ref "b"))))))
 
 
 ;; 13.5. Xor
@@ -172,36 +220,59 @@
 (deftest compile-xor-test
   (testing "Static"
     (are [x y res] (= res (c/compile {} (elm/xor [x y])))
-      #elm/boolean"true" #elm/boolean"true" false
-      #elm/boolean"true" #elm/boolean"false" true
-      #elm/boolean"true" {:type "Null"} nil
+      #elm/boolean "true" #elm/boolean "true" false
+      #elm/boolean "true" #elm/boolean "false" true
+      #elm/boolean "true" {:type "Null"} nil
 
-      #elm/boolean"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/boolean"false" false
-      #elm/boolean"false" {:type "Null"} nil
+      #elm/boolean "false" #elm/boolean "true" true
+      #elm/boolean "false" #elm/boolean "false" false
+      #elm/boolean "false" {:type "Null"} nil
 
-      {:type "Null"} #elm/boolean"true" nil
-      {:type "Null"} #elm/boolean"false" nil
+      {:type "Null"} #elm/boolean "true" nil
+      {:type "Null"} #elm/boolean "false" nil
       {:type "Null"} {:type "Null"} nil))
 
   (testing "Dynamic"
     (are [x y res] (= res (tu/dynamic-compile-eval (elm/xor [x y])))
-      #elm/boolean"true" #elm/parameter-ref"true" false
-      #elm/parameter-ref"true" #elm/boolean"true" false
-      #elm/boolean"false" #elm/parameter-ref"true" true
-      #elm/parameter-ref"true" #elm/boolean"false" true
-      #elm/parameter-ref"true" #elm/parameter-ref"true" false
+      #elm/boolean "true" #elm/parameter-ref "true" false
+      #elm/parameter-ref "true" #elm/boolean "true" false
+      #elm/boolean "false" #elm/parameter-ref "true" true
+      #elm/parameter-ref "true" #elm/boolean "false" true
+      #elm/parameter-ref "true" #elm/parameter-ref "true" false
 
-      #elm/boolean"true" #elm/parameter-ref"false" true
-      #elm/parameter-ref"false" #elm/boolean"true" true
-      #elm/boolean"false" #elm/parameter-ref"false" false
-      #elm/parameter-ref"false" #elm/boolean"false" false
-      #elm/parameter-ref"false" #elm/parameter-ref"false" false
+      #elm/boolean "true" #elm/parameter-ref "false" true
+      #elm/parameter-ref "false" #elm/boolean "true" true
+      #elm/boolean "false" #elm/parameter-ref "false" false
+      #elm/parameter-ref "false" #elm/boolean "false" false
+      #elm/parameter-ref "false" #elm/parameter-ref "false" false
 
-      #elm/boolean"true" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"true" nil
-      #elm/boolean"false" #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" #elm/boolean"false" nil
-      {:type "Null"} #elm/parameter-ref"nil" nil
-      #elm/parameter-ref"nil" {:type "Null"} nil
-      #elm/parameter-ref"nil" #elm/parameter-ref"nil" nil)))
+      #elm/boolean "true" #elm/parameter-ref "nil" nil
+      #elm/parameter-ref "nil" #elm/boolean "true" nil
+      #elm/boolean "false" #elm/parameter-ref "nil" nil
+      #elm/parameter-ref "nil" #elm/boolean "false" nil
+      {:type "Null"} #elm/parameter-ref "nil" nil
+      #elm/parameter-ref "nil" {:type "Null"} nil
+      #elm/parameter-ref "nil" #elm/parameter-ref "nil" nil))
+
+  (testing "form"
+    (let [compile-ctx# {:library {:parameters {:def [{:name "a"} {:name "b"}]}}}]
+      (are [x y form] (= form (c/form (c/compile compile-ctx# (elm/xor [x y]))))
+        #elm/boolean "true" #elm/boolean "true" false
+        #elm/boolean "true" #elm/boolean "false" true
+        #elm/boolean "true" {:type "Null"} nil
+        #elm/boolean "true" #elm/parameter-ref "b" '(not (param-ref "b"))
+
+        #elm/boolean "false" #elm/boolean "true" true
+        #elm/boolean "false" #elm/boolean "false" false
+        #elm/boolean "false" {:type "Null"} nil
+        #elm/boolean "false" #elm/parameter-ref "b" '(param-ref "b")
+
+        {:type "Null"} #elm/boolean "true" nil
+        {:type "Null"} #elm/boolean "false" nil
+        {:type "Null"} {:type "Null"} nil
+        {:type "Null"} #elm/parameter-ref "b" nil
+
+        #elm/parameter-ref "a" #elm/boolean "true" '(not (param-ref "a"))
+        #elm/parameter-ref "a" #elm/boolean "false" '(param-ref "a")
+        #elm/parameter-ref "a" {:type "Null"} nil
+        #elm/parameter-ref "a" #elm/parameter-ref "b" '(xor (param-ref "a") (param-ref "b"))))))

--- a/modules/cql/test/blaze/elm/compiler/nullological_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/nullological_operators_test.clj
@@ -45,9 +45,9 @@
   (are [elm res] (= res (core/-eval (c/compile {} (elm/coalesce elm)) {} nil nil))
     [] nil
     [{:type "Null"}] nil
-    [#elm/boolean"false" #elm/boolean"true"] false
-    [{:type "Null"} #elm/integer"1" #elm/integer"2"] 1
-    [#elm/integer"2"] 2
+    [#elm/boolean "false" #elm/boolean "true"] false
+    [{:type "Null"} #elm/integer "1" #elm/integer "2"] 1
+    [#elm/integer "2"] 2
     [#elm/list []] nil
     [{:type "Null"} #elm/list [#elm/string "a"]] ["a"]
     [#elm/list [{:type "Null"} #elm/string "a"]] "a"))
@@ -61,15 +61,17 @@
 (deftest compile-is-false-test
   (testing "Static"
     (are [x res] (= res (c/compile {} (elm/is-false x)))
-      #elm/boolean"true" false
-      #elm/boolean"false" true
+      #elm/boolean "true" false
+      #elm/boolean "false" true
       {:type "Null"} false))
 
   (testing "Dynamic"
     (are [x res] (= res (tu/dynamic-compile-eval (elm/is-false x)))
-      #elm/parameter-ref"true" false
-      #elm/parameter-ref"false" true
-      #elm/parameter-ref"nil" false)))
+      #elm/parameter-ref "true" false
+      #elm/parameter-ref "false" true
+      #elm/parameter-ref "nil" false))
+
+  (tu/testing-unary-form elm/is-false))
 
 
 ;; 14.4. IsNull
@@ -80,15 +82,17 @@
 (deftest compile-is-null-test
   (testing "Static"
     (are [x res] (= res (c/compile {} (elm/is-null x)))
-      #elm/boolean"true" false
-      #elm/boolean"false" false
+      #elm/boolean "true" false
+      #elm/boolean "false" false
       {:type "Null"} true))
 
   (testing "Dynamic"
     (are [x res] (= res (tu/dynamic-compile-eval (elm/is-null x)))
-      #elm/parameter-ref"true" false
-      #elm/parameter-ref"false" false
-      #elm/parameter-ref"nil" true)))
+      #elm/parameter-ref "true" false
+      #elm/parameter-ref "false" false
+      #elm/parameter-ref "nil" true))
+
+  (tu/testing-unary-form elm/is-null))
 
 
 ;; 14.5. IsTrue
@@ -99,12 +103,14 @@
 (deftest compile-is-true-test
   (testing "Static"
     (are [x res] (= res (c/compile {} (elm/is-true x)))
-      #elm/boolean"true" true
-      #elm/boolean"false" false
+      #elm/boolean "true" true
+      #elm/boolean "false" false
       {:type "Null"} false))
 
   (testing "Dynamic"
     (are [x res] (= res (tu/dynamic-compile-eval (elm/is-true x)))
-      #elm/parameter-ref"true" true
-      #elm/parameter-ref"false" false
-      #elm/parameter-ref"nil" false)))
+      #elm/parameter-ref "true" true
+      #elm/parameter-ref "false" false
+      #elm/parameter-ref "nil" false))
+
+  (tu/testing-unary-form elm/is-true))

--- a/modules/cql/test/blaze/elm/compiler/parameters_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/parameters_test.clj
@@ -42,13 +42,16 @@
           {:library
            {:parameters
             {:def
-             [{:name "parameter-def-101820"}]}}}]
-      (is (= (->ParameterRef "parameter-def-101820")
-             (c/compile context #elm/parameter-ref"parameter-def-101820")))))
+             [{:name "parameter-def-101820"}]}}}
+          expr (c/compile context #elm/parameter-ref "parameter-def-101820")]
+      (is (= (->ParameterRef "parameter-def-101820") expr))
+
+      (testing "form"
+        (is (= '(param-ref "parameter-def-101820") (core/-form expr))))))
 
   (testing "definition not found"
     (let [context {:library {}}]
-      (given (ba/try-anomaly (c/compile context #elm/parameter-ref"parameter-def-103701"))
+      (given (ba/try-anomaly (c/compile context #elm/parameter-ref "parameter-def-103701"))
         ::anom/category := ::anom/incorrect
         ::anom/message := "Parameter definition `parameter-def-103701` not found."
         :context := context)))
@@ -59,7 +62,7 @@
            {:parameters
             {:def
              [{:name "parameter-def-111045"}]}}}
-          expr (c/compile context #elm/parameter-ref"parameter-def-111045")]
+          expr (c/compile context #elm/parameter-ref "parameter-def-111045")]
       (given (ba/try-anomaly (core/-eval expr {} nil nil))
         ::anom/category := ::anom/incorrect
         ::anom/message := "Value of parameter `parameter-def-111045` not found."

--- a/modules/cql/test/blaze/elm/compiler/simple_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/simple_values_test.clj
@@ -34,49 +34,49 @@
 (deftest compile-literal-test
   (testing "Boolean Literal"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/boolean"true" true
-      #elm/boolean"false" false))
+      #elm/boolean "true" true
+      #elm/boolean "false" false))
 
   (testing "Decimal Literal"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/decimal"-1" -1M
-      #elm/decimal"0" 0M
-      #elm/decimal"1" 1M
+      #elm/decimal "-1" -1M
+      #elm/decimal "0" 0M
+      #elm/decimal "1" 1M
 
-      #elm/decimal"-0.1" -0.1M
-      #elm/decimal"0.0" 0M
-      #elm/decimal"0.1" 0.1M
+      #elm/decimal "-0.1" -0.1M
+      #elm/decimal "0.0" 0M
+      #elm/decimal "0.1" 0.1M
 
-      #elm/decimal"0.000000001" 0M
-      #elm/decimal"0.000000005" 1E-8M
+      #elm/decimal "0.000000001" 0M
+      #elm/decimal "0.000000005" 1E-8M
 
-      #elm/decimal"-99999999999999999999.99999999" -99999999999999999999.99999999M
-      #elm/decimal"99999999999999999999.99999999" 99999999999999999999.99999999M)
+      #elm/decimal "-99999999999999999999.99999999" -99999999999999999999.99999999M
+      #elm/decimal "99999999999999999999.99999999" 99999999999999999999.99999999M)
 
     (testing "failure"
-      (given (ba/try-anomaly (c/compile {} #elm/decimal"x"))
+      (given (ba/try-anomaly (c/compile {} #elm/decimal "x"))
         ::anom/category := ::anom/incorrect
         ::anom/message := "Incorrect decimal literal `x`.")))
 
   (testing "Long Literal"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/long"-1" -1
-      #elm/long"0" 0
-      #elm/long"1" 1)
+      #elm/long "-1" -1
+      #elm/long "0" 0
+      #elm/long "1" 1)
 
     (testing "failure"
-      (given (ba/try-anomaly (c/compile {} #elm/long"x"))
+      (given (ba/try-anomaly (c/compile {} #elm/long "x"))
         ::anom/category := ::anom/incorrect
         ::anom/message := "Incorrect long literal `x`.")))
 
   (testing "Integer Literal"
     (are [elm res] (= res (c/compile {} elm))
-      #elm/integer"-1" -1
-      #elm/integer"0" 0
-      #elm/integer"1" 1)
+      #elm/integer "-1" -1
+      #elm/integer "0" 0
+      #elm/integer "1" 1)
 
     (testing "failure"
-      (given (ba/try-anomaly (c/compile {} #elm/integer"x"))
+      (given (ba/try-anomaly (c/compile {} #elm/integer "x"))
         ::anom/category := ::anom/incorrect
         ::anom/message := "Incorrect integer literal `x`.")))
 

--- a/modules/cql/test/blaze/elm/compiler/structured_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/structured_values_test.clj
@@ -42,10 +42,10 @@
 ;; expression, including another Tuple.
 (deftest compile-tuple-test
   (are [elm res] (= res (core/-eval (c/compile {} elm) {} nil nil))
-    #elm/tuple{"id" #elm/integer"1"}
+    #elm/tuple{"id" #elm/integer "1"}
     {:id 1}
 
-    #elm/tuple{"id" #elm/integer"1" "name" #elm/string "john"}
+    #elm/tuple{"id" #elm/integer "1" "name" #elm/string "john"}
     {:id 1 :name "john"}))
 
 
@@ -108,7 +108,10 @@
                   {:eval-context "Patient"}
                   elm)
                 result (coll/first (core/-eval expr nil nil {"R" entity}))]
-            (is (= identifier result))))
+            (is (= identifier result))
+
+            (testing "form"
+              (is (= '(:identifier R) (core/-form expr))))))
 
         (testing "without source-type"
           (let [elm
@@ -230,7 +233,10 @@
                    :life/single-query-scope "R"}
                   elm)
                 result (coll/first (core/-eval expr nil nil entity))]
-            (is (= identifier result))))
+            (is (= identifier result))
+
+            (testing "form"
+              (is (= '(:identifier default) (core/-form expr))))))
 
         (testing "without source-type"
           (let [elm
@@ -333,7 +339,10 @@
                :identifier [identifier]}
               expr (c/compile {:library library :eval-context "Patient"} elm)
               result (coll/first (core/-eval expr {:library-context {"Patient" source}} nil nil))]
-          (is (= identifier result))))
+          (is (= identifier result))
+
+          (testing "form"
+            (is (= '(:identifier (expr-ref "Patient")) (core/-form expr))))))
 
       (testing "without source-type"
         (let [library {:statements {:def [{:name "Patient"}]}}
@@ -424,7 +433,7 @@
             {:name "name"
              :type {:name "{urn:hl7-org:elm-types:r1}String" :type "NamedTypeSpecifier"}}]}
           :element
-          [{:name "id" :value #elm/integer"1"}]}}
+          [{:name "id" :value #elm/integer "1"}]}}
         1))
 
     (testing "Quantity"
@@ -434,7 +443,7 @@
           {:resultTypeName "{urn:hl7-org:elm-types:r1}Decimal"
            :path "value"
            :type "Property"
-           :source #elm/quantity[42 "m"]}
+           :source #elm/quantity [42 "m"]}
           42M))
 
       (testing "unit"
@@ -443,7 +452,7 @@
           {:resultTypeName "{urn:hl7-org:elm-types:r1}String"
            :path "unit"
            :type "Property"
-           :source #elm/quantity[42 "m"]}
+           :source #elm/quantity [42 "m"]}
           "m")))
 
     (testing "nil"

--- a/modules/cql/test/blaze/elm/literal.clj
+++ b/modules/cql/test/blaze/elm/literal.clj
@@ -106,6 +106,13 @@
    :name name})
 
 
+;; 9.4. FunctionRef
+(defn function-ref [name & ops]
+  {:type "FunctionRef"
+   :name name
+   :operand ops})
+
+
 
 ;; 11. External Data
 
@@ -318,11 +325,13 @@
     (assoc :precision precision)))
 
 
+;; 16.20. Subtract
 (defn subtract [ops]
   {:type "Subtract"
    :operand ops})
 
 
+;; 16.21. Successor
 (defn successor [op]
   {:type "Successor"
    :operand op})
@@ -334,10 +343,59 @@
    :operand op})
 
 
+;; 16.23. TruncatedDivide
 (defn truncated-divide [ops]
   {:type "TruncatedDivide"
    :operand ops})
 
+
+
+;; 17. String Operators
+
+;; 17.3. EndsWith
+(defn ends-with [ops]
+  {:type "EndsWith"
+   :operand ops})
+
+
+;; 17.6. Indexer
+(defn indexer [ops]
+  {:type "Indexer"
+   :operand ops})
+
+
+;; 17.8. Length
+(defn length [x]
+  {:type "Length"
+   :operand x})
+
+
+;; 17.9. Lower
+(defn lower [x]
+  {:type "Lower"
+   :operand x})
+
+
+;; 17.10. Matches
+(defn matches [ops]
+  {:type "Matches"
+   :operand ops})
+
+
+;; 17.16. StartsWith
+(defn starts-with [ops]
+  {:type "StartsWith"
+   :operand ops})
+
+
+;; 17.18. Upper
+(defn upper [x]
+  {:type "Upper"
+   :operand x})
+
+
+
+;; 18. Date and Time Operators
 
 ;; 18.14. SameAs
 (defn same-as [[x y precision]]
@@ -495,8 +553,12 @@
 
 
 ;; 19.5. Contains
-(defn contains [ops]
-  {:type "Contains" :operand ops})
+(defn contains [[list x precision]]
+  (cond->
+    {:type "Contains"
+     :operand [list x]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.6. End
@@ -505,8 +567,12 @@
 
 
 ;; 19.7. Ends
-(defn ends [ops]
-  {:type "Ends" :operand ops})
+(defn ends [[x y precision]]
+  (cond->
+    {:type "Ends"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.10. Except
@@ -515,8 +581,12 @@
 
 
 ;; 19.13. Includes
-(defn includes [ops]
-  {:type "Includes" :operand ops})
+(defn includes [[x y precision]]
+  (cond->
+    {:type "Includes"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.15. Intersect
@@ -525,18 +595,30 @@
 
 
 ;; 19.17. MeetsBefore
-(defn meets-before [ops]
-  {:type "MeetsBefore" :operand ops})
+(defn meets-before [[x y precision]]
+  (cond->
+    {:type "MeetsBefore"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.18. MeetsAfter
-(defn meets-after [ops]
-  {:type "MeetsAfter" :operand ops})
+(defn meets-after [[x y precision]]
+  (cond->
+    {:type "MeetsAfter"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.20. Overlaps
-(defn overlaps [ops]
-  {:type "Overlaps" :operand ops})
+(defn overlaps [[x y precision]]
+  (cond->
+    {:type "Overlaps"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.23. PointFrom
@@ -545,13 +627,21 @@
 
 
 ;; 19.24. ProperContains
-(defn proper-contains [ops]
-  {:type "ProperContains" :operand ops})
+(defn proper-contains [[x y precision]]
+  (cond->
+    {:type "ProperContains"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.26. ProperIncludes
-(defn proper-includes [ops]
-  {:type "ProperIncludes" :operand ops})
+(defn proper-includes [[x y precision]]
+  (cond->
+    {:type "ProperIncludes"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.29. Start
@@ -560,8 +650,12 @@
 
 
 ;; 19.30. Starts
-(defn starts [ops]
-  {:type "Starts" :operand ops})
+(defn starts [[x y precision]]
+  (cond->
+    {:type "Starts"
+     :operand [x y]}
+    precision
+    (assoc :precision precision)))
 
 
 ;; 19.31. Union

--- a/modules/cql/test/blaze/elm/literal_spec.clj
+++ b/modules/cql/test/blaze/elm/literal_spec.clj
@@ -1,6 +1,6 @@
 (ns blaze.elm.literal-spec
   (:require
-    [blaze.elm.literal :as literal]
+    [blaze.elm.literal :as elm]
     [blaze.elm.spec]
     [clojure.spec.alpha :as s]))
 
@@ -9,22 +9,22 @@
 ;; 1. Simple Values
 
 ;; 1.1. Literal
-(s/fdef literal/boolean
+(s/fdef elm/boolean
   :args (s/cat :s string?)
   :ret :elm/expression)
 
 
-(s/fdef literal/decimal
+(s/fdef elm/decimal
   :args (s/cat :s string?)
   :ret :elm/expression)
 
 
-(s/fdef literal/integer
+(s/fdef elm/integer
   :args (s/cat :s string?)
   :ret :elm/expression)
 
 
-(s/fdef literal/string
+(s/fdef elm/string
   :args (s/cat :s string?)
   :ret :elm/expression)
 
@@ -33,13 +33,13 @@
 ;; 2. Structured Values
 
 ;; 2.1. Tuple
-(s/fdef literal/tuple
+(s/fdef elm/tuple
   :args (s/cat :arg (s/map-of string? :elm/expression))
   :ret :elm/expression)
 
 
 ;; 2.1. Instance
-(s/fdef literal/instance
+(s/fdef elm/instance
   :args (s/cat :arg (s/tuple string? (s/map-of string? :elm/expression)))
   :ret :elm/expression)
 
@@ -48,7 +48,7 @@
 ;; 3. Clinical Values
 
 ;; 3.1 Code
-(s/fdef literal/code
+(s/fdef elm/code
   :args
   (s/cat
     :args
@@ -57,13 +57,13 @@
 
 
 ;; 3.3. CodeRef
-(s/fdef literal/code-ref
+(s/fdef elm/code-ref
   :args (s/cat :name string?)
   :ret :elm/expression)
 
 
 ;; 3.9. Quantity
-(s/fdef literal/quantity
+(s/fdef elm/quantity
   :args (s/cat :args (s/spec (s/cat :value number? :unit (s/? string?))))
   :ret :elm/expression)
 
@@ -72,192 +72,193 @@
 ;; 9. Reusing Logic
 
 ;; 9.2. ExpressionRef
-(s/fdef literal/expression-ref
+(s/fdef elm/expression-ref
   :args (s/cat :name string?)
   :ret :elm/expression)
 
 
-(s/fdef literal/equal
+(s/fdef elm/equal
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/equivalent
+(s/fdef elm/equivalent
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/greater
+(s/fdef elm/greater
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/greater-or-equal
+(s/fdef elm/greater-or-equal
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/less
+(s/fdef elm/less
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/less-or-equal
+(s/fdef elm/less-or-equal
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/and
+(s/fdef elm/and
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/not
+(s/fdef elm/not
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/or
+(s/fdef elm/or
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/xor
+(s/fdef elm/xor
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/is-false
+(s/fdef elm/is-false
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/is-null
+(s/fdef elm/is-null
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/is-true
+(s/fdef elm/is-true
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/list
+(s/fdef elm/list
   :args (s/cat :elements (s/coll-of :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/if-expr
+(s/fdef elm/if-expr
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/abs
+(s/fdef elm/abs
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/add
+(s/fdef elm/add
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/ceiling
+(s/fdef elm/ceiling
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/divide
+(s/fdef elm/divide
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/exp
+(s/fdef elm/exp
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/floor
+(s/fdef elm/floor
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/log
+(s/fdef elm/log
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/ln
+(s/fdef elm/ln
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/modulo
+(s/fdef elm/modulo
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/multiply
+(s/fdef elm/multiply
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/negate
+(s/fdef elm/negate
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/power
+(s/fdef elm/power
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/predecessor
+(s/fdef elm/predecessor
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/round
-  :args (s/cat :arg (s/coll-of :elm/expression))
+(s/fdef elm/round
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression
+                                   :precision (s/? :elm/expression))))
   :ret :elm/expression)
 
 
-(s/fdef literal/subtract
+(s/fdef elm/subtract
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/successor
+(s/fdef elm/successor
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/truncate
+(s/fdef elm/truncate
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/truncated-divide
+(s/fdef elm/truncated-divide
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
-(s/fdef literal/date
+(s/fdef elm/date
   :args (s/cat :arg (s/alt :str string? :exprs (s/coll-of :elm/expression)))
   :ret :elm/expression)
 
 
-(s/fdef literal/date-from
+(s/fdef elm/date-from
   :args (s/cat :op :elm/expression)
   :ret :elm/expression)
 
 
-(s/fdef literal/date-time
+(s/fdef elm/date-time
   :args (s/cat :arg (s/alt :str string? :exprs (s/coll-of :elm/expression)))
   :ret :elm/expression)
 
 
-(s/fdef literal/time
+(s/fdef elm/time
   :args (s/cat :arg (s/alt :str string? :exprs (s/coll-of :elm/expression)))
   :ret :elm/expression)
 
@@ -269,123 +270,156 @@
          :high :elm/expression
          :high-open (s/? #{:>})))
 
-(s/fdef literal/interval
+(s/fdef elm/interval
   :args (s/cat :arg (s/spec ::interval-arg))
   :ret :elm/expression)
 
 
 ;; 19.2. After
-(s/fdef literal/after
+(s/fdef elm/after
   :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
                                    :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.3. Before
-(s/fdef literal/before
+(s/fdef elm/before
   :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
                                    :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.4. Collapse
-(s/fdef literal/collapse
+(s/fdef elm/collapse
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
 ;; 19.5. Contains
-(s/fdef literal/contains
-  :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
+(s/fdef elm/contains
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
+  :ret :elm/expression)
+
+
+;; 19.6. End
+(s/fdef elm/end
+  :args (s/cat :interval :elm/expression)
+  :ret :elm/expression)
+
+
+;; 19.7. Ends
+(s/fdef elm/ends
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.13. Except
-(s/fdef literal/except
+(s/fdef elm/except
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
 ;; 19.13. Includes
-(s/fdef literal/includes
-  :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
+(s/fdef elm/includes
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.15. Intersect
-(s/fdef literal/intersect
+(s/fdef elm/intersect
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
 ;; 19.17. MeetsBefore
-(s/fdef literal/meets-before
-  :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
+(s/fdef elm/meets-before
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.18. MeetsAfter
-(s/fdef literal/meets-after
-  :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
+(s/fdef elm/meets-after
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
+  :ret :elm/expression)
+
+
+;; 19.20. Overlaps
+(s/fdef elm/overlaps
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.24. ProperContains
-(s/fdef literal/proper-contains
-  :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
+(s/fdef elm/proper-contains
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.26. ProperIncludes
-(s/fdef literal/proper-includes
-  :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
+(s/fdef elm/proper-includes
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
+  :ret :elm/expression)
+
+
+;; 19.30. ProperIncludes
+(s/fdef elm/starts
+  :args (s/cat :ops (s/spec (s/cat :x :elm/expression :y :elm/expression
+                                   :precision (s/? string?))))
   :ret :elm/expression)
 
 
 ;; 19.31. Union
-(s/fdef literal/union
+(s/fdef elm/union
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
 ;; 20.3. Current
-(s/fdef literal/current
+(s/fdef elm/current
   :args (s/cat :scope string?)
   :ret :elm/expression)
 
 
 ;; 20.4. Distinct
-(s/fdef literal/distinct
+(s/fdef elm/distinct
   :args (s/cat :list :elm/expression)
   :ret :elm/expression)
 
 
 ;; 20.8. Exists
-(s/fdef literal/exists
+(s/fdef elm/exists
   :args (s/cat :list :elm/expression)
   :ret :elm/expression)
 
 
 ;; 20.10. First
-(s/fdef literal/first
+(s/fdef elm/first
   :args (s/cat :source :elm/expression)
   :ret :elm/expression)
 
 
 ;; 20.11. Flatten
-(s/fdef literal/flatten
+(s/fdef elm/flatten
   :args (s/cat :list :elm/expression)
   :ret :elm/expression)
 
 
 ;; 20.25. SingletonFrom
-(s/fdef literal/singleton-from
+(s/fdef elm/singleton-from
   :args (s/cat :list :elm/expression)
   :ret :elm/expression)
 
 
 ;; 20.28. Times
-(s/fdef literal/times
+(s/fdef elm/times
   :args (s/cat :lists (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
@@ -394,61 +428,67 @@
 ;; 22. Type Operators
 
 ;; 22.1. As
-(s/fdef literal/as
+(s/fdef elm/as
   :args (s/cat :arg (s/tuple string? :elm/expression))
   :ret :elm/expression)
 
 
 ;; 22.6. ConvertQuantity
-(s/fdef literal/convert-quantity
+(s/fdef elm/convert-quantity
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)
 
 
 ;; 22.17. Descendents
-(s/fdef literal/descendents
+(s/fdef elm/descendents
   :args (s/cat :source :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.22. ToDate
-(s/fdef literal/to-date
+(s/fdef elm/to-date
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.23. ToDateTime
-(s/fdef literal/to-date-time
+(s/fdef elm/to-date-time
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.24. ToDecimal
-(s/fdef literal/to-decimal
+(s/fdef elm/to-decimal
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.25. ToInteger
-(s/fdef literal/to-integer
+(s/fdef elm/to-integer
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.26. ToList
-(s/fdef literal/to-list
+(s/fdef elm/to-list
+  :args (s/cat :operand :elm/expression)
+  :ret :elm/expression)
+
+
+;; 22.27. ToLong
+(s/fdef elm/to-long
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.28. ToQuantity
-(s/fdef literal/to-quantity
+(s/fdef elm/to-quantity
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
 
 ;; 22.30. ToString
-(s/fdef literal/to-string
+(s/fdef elm/to-string
   :args (s/cat :operand :elm/expression)
   :ret :elm/expression)
 
@@ -457,6 +497,6 @@
 ;; 23. Clinical Operators
 
 ;; 23.4. CalculateAgeAt
-(s/fdef literal/calculate-age-at
+(s/fdef elm/calculate-age-at
   :args (s/cat :ops (s/tuple :elm/expression :elm/expression))
   :ret :elm/expression)

--- a/modules/cql/test/blaze/elm/normalizer_test.clj
+++ b/modules/cql/test/blaze/elm/normalizer_test.clj
@@ -3,6 +3,7 @@
   https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.literal :as elm]
+    [blaze.elm.literal-spec]
     [blaze.elm.normalizer :refer [normalize]]
     [blaze.elm.normalizer-spec]
     [clojure.spec.test.alpha :as st]

--- a/modules/cql/test/blaze/elm/spec_test.clj
+++ b/modules/cql/test/blaze/elm/spec_test.clj
@@ -24,7 +24,7 @@
 (deftest literal-test
   (testing "valid"
     (are [x] (s/valid? :elm/expression x)
-      #elm/boolean"true"))
+      #elm/boolean "true"))
 
   (testing "invalid"
     (given (s/explain-data :elm/expression {:type "Literal"})
@@ -34,7 +34,7 @@
 (deftest literal-integer-test
   (testing "valid"
     (are [x] (s/valid? :elm/integer x)
-      #elm/integer"0"))
+      #elm/integer "0"))
 
   (testing "invalid"
     (given (s/explain-data :elm/integer nil)
@@ -43,14 +43,14 @@
     (given (s/explain-data :elm/integer {:type "Literal"})
       [::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :valueType)))
 
-    (given (s/explain-data :elm/integer #elm/boolean"true")
+    (given (s/explain-data :elm/integer #elm/boolean "true")
       [::s/problems 0 :path 0] := :valueType)))
 
 
 (deftest literal-decimal-test
   (testing "valid"
     (are [x] (s/valid? :elm/decimal x)
-      #elm/decimal"0"))
+      #elm/decimal "0"))
 
   (testing "invalid"
     (given (s/explain-data :elm/decimal nil)
@@ -59,7 +59,7 @@
     (given (s/explain-data :elm/decimal {:type "Literal"})
       [::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :valueType)))
 
-    (given (s/explain-data :elm/decimal #elm/boolean"true")
+    (given (s/explain-data :elm/decimal #elm/boolean "true")
       [::s/problems 0 :path 0] := :valueType)))
 
 
@@ -67,7 +67,7 @@
   (testing "valid"
     (are [x] (s/valid? :elm/expression x)
       #elm/tuple{}
-      #elm/tuple{"id" #elm/integer"0"}))
+      #elm/tuple{"id" #elm/integer "0"}))
 
   (testing "invalid"
     (given (s/explain-data :elm/expression {:type "Tuple" :element "foo"})
@@ -86,8 +86,8 @@
 (deftest instance-test
   (testing "valid"
     (are [x] (s/valid? :elm/expression x)
-      #elm/instance["{urn:hl7-org:elm-types:r1}Code"
-                    {"system" #elm/string"foo" "code" #elm/string"bar"}]))
+      #elm/instance ["{urn:hl7-org:elm-types:r1}Code"
+                    {"system" #elm/string "foo" "code" #elm/string "bar"}]))
 
   (testing "invalid"
     (given (s/explain-data :elm/expression {:type "Instance"})
@@ -114,7 +114,7 @@
   (testing "valid"
     (are [x] (s/valid? :elm/expression x)
       {:type "Query"
-       :source [{:alias "foo" :expression #elm/integer"0"}]}))
+       :source [{:alias "foo" :expression #elm/integer "0"}]}))
 
   (testing "invalid"
     (given (s/explain-data :elm/expression {:type "Query"})
@@ -131,54 +131,54 @@
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"}]})
+                                            [{:expression #elm/integer "0"}]})
       [::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :alias)))
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort "foo"})
       [::s/problems 0 :pred] := `map?)
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort {}})
       [::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :by)))
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort {:by "foo"}})
       [::s/problems 0 :pred] := `coll?)
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort {:by ["foo"]}})
       [::s/problems 0 :pred] := `blaze.elm.spec/sort-by-item)
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort {:by [{:type "ByDirection"}]}})
       [::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :direction)))
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort {:by [{:type "ByColumn"}]}})
       [::s/problems 0 :pred] := `(fn [~'%] (contains? ~'% :direction)))
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort
                                             {:by
@@ -189,7 +189,7 @@
 
     (given (s/explain-data :elm/expression {:type "Query"
                                             :source
-                                            [{:expression #elm/integer"0"
+                                            [{:expression #elm/integer "0"
                                               :alias "foo"}]
                                             :sort
                                             {:by

--- a/modules/cql/test/data_readers.clj
+++ b/modules/cql/test/data_readers.clj
@@ -27,6 +27,13 @@
  elm/list blaze.elm.literal/list
  elm/if blaze.elm.literal/if-expr
  elm/abs blaze.elm.literal/abs
+ elm/ends-with blaze.elm.literal/ends-with
+ elm/indexer blaze.elm.literal/indexer
+ elm/length blaze.elm.literal/length
+ elm/lower blaze.elm.literal/lower
+ elm/matches blaze.elm.literal/matches
+ elm/starts-with blaze.elm.literal/starts-with
+ elm/upper blaze.elm.literal/upper
  elm/add blaze.elm.literal/add
  elm/ceiling blaze.elm.literal/ceiling
  elm/divide blaze.elm.literal/divide
@@ -48,8 +55,12 @@
  elm/date blaze.elm.literal/date
  elm/date-from blaze.elm.literal/date-from
  elm/date-time blaze.elm.literal/date-time
+ elm/date-time-component-from blaze.elm.literal/date-time-component-from
+ elm/difference-between blaze.elm.literal/difference-between
+ elm/duration-between blaze.elm.literal/duration-between
  elm/time blaze.elm.literal/time
  elm/interval blaze.elm.literal/interval
+ elm/contains blaze.elm.literal/contains
  elm/intersect blaze.elm.literal/intersect
  elm/current blaze.elm.literal/current
  elm/distinct blaze.elm.literal/distinct
@@ -66,6 +77,7 @@
  elm/to-decimal blaze.elm.literal/to-decimal
  elm/to-integer blaze.elm.literal/to-integer
  elm/to-list blaze.elm.literal/to-list
+ elm/to-long blaze.elm.literal/to-long
  elm/to-quantity blaze.elm.literal/to-quantity
  elm/to-string blaze.elm.literal/to-string
  elm/calculate-age-at blaze.elm.literal/calculate-age-at}

--- a/modules/db/test/blaze/db/impl/search_param/date_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/date_test.clj
@@ -13,7 +13,6 @@
     [blaze.fhir-path :as fhir-path]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
-    [blaze.fhir.spec.type :as type]
     [blaze.fhir.structure-definition-repo]
     [blaze.test-util :refer [with-system]]
     [clojure.spec.test.alpha :as st]
@@ -208,7 +207,7 @@
       (testing "issued"
         (let [patient {:fhir/type :fhir/DiagnosticReport
                        :id "id-155607"
-                       :issued (type/->Instant "2019-11-17T00:14:29.917+01:00")}
+                       :issued #fhir/instant"2019-11-17T00:14:29.917+01:00"}
               hash (hash/generate patient)
               [[_ k0]]
               (search-param/index-entries


### PR DESCRIPTION
The ELM compiler compiles ELM data structures into data structures that can be evaluated on a database. That compiled data structures consist mostly of Clojure records. Printing that data structures can be useful in order to see something like a query plan. However, Clojure records don't always print very nice and some used opaque functions do not print at all. So we introduce compiled query forms that can be obtained by calling the -form method for now and a form function later. The forms are modeled in the LISP tradition and can be printed or even pretty-printed.

The implementation is far from complete now.