### PR TITLE
Resolve Issues with Large Methods

### DIFF
--- a/modules/cql/src/blaze/elm/compiler/logical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/logical_operators.clj
@@ -21,9 +21,10 @@
 (defn- nil-and
   "Creates an and-expression where one operand is known to be nil."
   [x]
-  (case x
-    (true nil) nil
+  (condp identical? x
+    true nil
     false false
+    nil nil
     (nil-and-expr x)))
 
 
@@ -31,7 +32,7 @@
   "Creates an and-expression where `a` is known to be dynamic and `b` could be
   static or dynamic."
   [a b]
-  (case b
+  (condp identical? b
     true a
     false false
     nil (nil-and-expr a)
@@ -51,7 +52,7 @@
 (defmethod core/compile* :elm.compiler.type/and
   [context {[a b] :operand}]
   (let [a (core/compile* context a)]
-    (case a
+    (condp identical? a
       true (core/compile* context b)
       false false
       nil (nil-and (core/compile* context b))
@@ -83,9 +84,10 @@
 (defn- nil-or
   "Creates an or-expression where one operand is known to be nil."
   [x]
-  (case x
+  (condp identical? x
     true true
-    (false nil) nil
+    false nil
+    nil nil
     (nil-or-expr x)))
 
 
@@ -93,7 +95,7 @@
   "Creates an or-expression where `a` is known to be dynamic and `b` could be
   static or dynamic."
   [a b]
-  (case b
+  (condp identical? b
     true true
     false a
     nil (nil-or-expr a)
@@ -113,7 +115,7 @@
 (defmethod core/compile* :elm.compiler.type/or
   [context {[a b] :operand}]
   (let [a (core/compile* context a)]
-    (case a
+    (condp identical? a
       true true
       false (core/compile* context b)
       nil (nil-or (core/compile* context b))
@@ -125,7 +127,7 @@
   "Creates an xor-expression where `a` is known to be dynamic and `b` could be
   static or dynamic."
   [a b]
-  (case b
+  (condp identical? b
     true
     (reify core/Expression
       (-eval [_ context resource scope]
@@ -148,7 +150,7 @@
 (defmethod core/compile* :elm.compiler.type/xor
   [context {[a b] :operand}]
   (let [a (core/compile* context a)]
-    (case a
+    (condp identical? a
       true (core/compile* context {:type "Not" :operand b})
       false (core/compile* context b)
       nil nil

--- a/modules/cql/src/blaze/elm/compiler/macros.clj
+++ b/modules/cql/src/blaze/elm/compiler/macros.clj
@@ -3,6 +3,10 @@
     [blaze.elm.compiler.core :as core]))
 
 
+(defn- compile-kw [name]
+  (keyword "elm.compiler.type" (clojure.core/name name)))
+
+
 (defmacro defunop
   {:arglists '([name attr-map? bindings & body])}
   [name & more]
@@ -10,7 +14,7 @@
         more (if (map? (first more)) (next more) more)
         [[operand-binding expr-binding] & body] more]
     (if expr-binding
-      `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+      `(defmethod core/compile* ~(compile-kw name)
          [context# expr#]
          (let [operand# (core/compile* (merge context# ~attr-map) (:operand expr#))]
            (if (core/static? operand#)
@@ -24,7 +28,7 @@
                    ~@body))
                (-form [~'_]
                  (list (quote ~name) (core/-form operand#)))))))
-      `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+      `(defmethod core/compile* ~(compile-kw name)
          [context# expr#]
          (let [operand# (core/compile* (merge context# ~attr-map) (:operand expr#))]
            (if (core/static? operand#)
@@ -44,7 +48,7 @@
   (let [attr-map (when (map? (first more)) (first more))
         more (if (map? (first more)) (next more) more)
         [[op-1-binding op-2-binding] & body] more]
-    `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+    `(defmethod core/compile* ~(compile-kw name)
        [context# {[operand-1# operand-2#] :operand}]
        (let [context# (merge context# ~attr-map)
              operand-1# (core/compile* context# operand-1#)
@@ -65,7 +69,7 @@
 (defmacro defternop
   {:arglists '([name bindings & body])}
   [name [op-1-binding op-2-binding op-3-binding] & body]
-  `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+  `(defmethod core/compile* ~(compile-kw name)
      [context# {[operand-1# operand-2# operand-3#] :operand}]
      (let [operand-1# (core/compile* context# operand-1#)
            operand-2# (core/compile* context# operand-2#)
@@ -81,7 +85,7 @@
 (defmacro defnaryop
   {:arglists '([name bindings & body])}
   [name [operands-binding] & body]
-  `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+  `(defmethod core/compile* ~(compile-kw name)
      [context# {operands# :operand}]
      (let [operands# (mapv #(core/compile* context# %) operands#)]
        (reify core/Expression
@@ -93,7 +97,7 @@
 (defmacro defaggop
   {:arglists '([name bindings & body])}
   [name [source-binding] & body]
-  `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+  `(defmethod core/compile* ~(compile-kw name)
      [context# {source# :source}]
      (let [source# (core/compile* context# source#)]
        (reify core/Expression
@@ -105,7 +109,7 @@
 (defmacro defunopp
   {:arglists '([name bindings & body])}
   [name [operand-binding precision-binding expr-binding] & body]
-  `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+  `(defmethod core/compile* ~(compile-kw name)
      [context# {operand# :operand precision# :precision :as expr#}]
      (let [operand# (core/compile* context# operand#)
            ~precision-binding (some-> precision# core/to-chrono-unit)
@@ -124,7 +128,7 @@
   (let [attr-map (when (map? (first more)) (first more))
         more (if (map? (first more)) (next more) more)
         [[op-1-binding op-2-binding precision-binding] & body] more]
-    `(defmethod core/compile* ~(keyword "elm.compiler.type" (clojure.core/name name))
+    `(defmethod core/compile* ~(compile-kw name)
        [context# {[operand-1# operand-2#] :operand precision# :precision}]
        (let [context# (merge context# ~attr-map)
              operand-1# (core/compile* context# operand-1#)

--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -45,9 +45,6 @@
    {blaze/test-util
     {:local/root "../test-util"}
 
-    com.clojure-goes-fast/clj-java-decompiler
-    {:mvn/version "0.3.1"}
-
     lambdaisland/kaocha
     {:mvn/version "1.63.998"}}
 

--- a/modules/fhir-path/src/blaze/fhir_path.clj
+++ b/modules/fhir-path/src/blaze/fhir_path.clj
@@ -113,13 +113,13 @@
     (throw-anom (ba/incorrect (singleton-evaluation-msg coll)))))
 
 
-(defrecord StartExpression []
+(deftype StartExpression []
   Expression
   (-eval [_ _ coll]
     coll))
 
 
-(defrecord TypedStartExpression [rf]
+(deftype TypedStartExpression [rf]
   Expression
   (-eval [_ _ coll]
     (.reduce ^IReduceInit coll rf [])))
@@ -131,7 +131,7 @@
     (->TypedStartExpression ((filter pred) conj))))
 
 
-(defrecord GetChildrenExpression [f]
+(deftype GetChildrenExpression [f]
   Expression
   (-eval [_ _ coll]
     (.reduce ^IReduceInit coll f [])))
@@ -147,13 +147,13 @@
           :else res)))))
 
 
-(defrecord InvocationExpression [expression invocation]
+(deftype InvocationExpression [expression invocation]
   Expression
   (-eval [_ context coll]
     (-eval invocation context (-eval expression context coll))))
 
 
-(defrecord IndexerExpression [expression index]
+(deftype IndexerExpression [expression index]
   Expression
   (-eval [_ context coll]
     (let [coll (-eval expression context coll)
@@ -161,7 +161,7 @@
       [(nth coll idx [])])))
 
 
-(defrecord PlusExpression [left-expr right-expr]
+(deftype PlusExpression [left-expr right-expr]
   Expression
   (-eval [_ context coll]
     (let [left (singleton :fhir/string (-eval left-expr context coll))
@@ -177,7 +177,7 @@
           (pr-str coll)))
 
 
-(defrecord IsTypeExpression [expression type-specifier]
+(deftype IsTypeExpression [expression type-specifier]
   Expression
   (-eval [_ context coll]
     (let [coll (-eval expression context coll)]
@@ -194,7 +194,7 @@
           (pr-str coll)))
 
 
-(defrecord AsTypeExpression [expression type-specifier]
+(deftype AsTypeExpression [expression type-specifier]
   Expression
   (-eval [_ context coll]
     (let [coll (-eval expression context coll)]
@@ -208,7 +208,7 @@
         (throw-anom (ba/incorrect (as-type-specifier-msg coll)))))))
 
 
-(defrecord UnionExpression [e1 e2]
+(deftype UnionExpression [e1 e2]
   Expression
   (-eval [_ context coll]
     (let [^Counted c1 (-eval e1 context coll)
@@ -224,7 +224,7 @@
         (vec (reduce conj (set c1) c2))))))
 
 
-(defrecord EqualExpression [left-expr right-expr]
+(deftype EqualExpression [left-expr right-expr]
   Expression
   (-eval [_ context coll]
     (let [left (-eval left-expr context coll)
@@ -241,7 +241,7 @@
             [false]))))))
 
 
-(defrecord NotEqualExpression [left-expr right-expr]
+(deftype NotEqualExpression [left-expr right-expr]
   Expression
   (-eval [_ context coll]
     (let [left (-eval left-expr context coll)
@@ -259,7 +259,7 @@
 
 
 ;; See: http://hl7.org/fhirpath/index.html#and
-(defrecord AndExpression [expr-a expr-b]
+(deftype AndExpression [expr-a expr-b]
   Expression
   (-eval [_ context coll]
     (let [a (singleton :fhir/boolean (-eval expr-a context coll))]
@@ -273,7 +273,7 @@
             :else []))))))
 
 
-(defrecord AsFunctionExpression [type-specifier]
+(deftype AsFunctionExpression [type-specifier]
   Expression
   (-eval [_ _ coll]
     (case (.count ^Counted coll)
@@ -286,19 +286,19 @@
       (throw-anom (ba/incorrect (as-type-specifier-msg coll))))))
 
 
-(defrecord OfTypeFunctionExpression [type-specifier]
+(deftype OfTypeFunctionExpression [type-specifier]
   Expression
   (-eval [_ _ coll]
     (filterv #(identical? type-specifier (fhir-spec/fhir-type %)) coll)))
 
 
-(defrecord ExistsFunctionExpression []
+(deftype ExistsFunctionExpression []
   Expression
   (-eval [_ _ coll]
     [(if (empty? coll) false true)]))
 
 
-(defrecord ExistsWithCriteriaFunctionExpression [criteria]
+(deftype ExistsWithCriteriaFunctionExpression [criteria]
   Expression
   (-eval [_ _ _]
     (throw-anom (ba/unsupported "unsupported `exists` function"))))
@@ -327,7 +327,7 @@
   [])
 
 
-(defrecord ResolveFunctionExpression []
+(deftype ResolveFunctionExpression []
   Expression
   (-eval [_ context coll]
     (.reduce ^IReduceInit coll #(.reduce (resolve context %2) conj %1) [])))
@@ -364,7 +364,7 @@
           (pr-str x)))
 
 
-(defrecord WhereFunctionExpression [where-rf]
+(deftype WhereFunctionExpression [where-rf]
   Expression
   (-eval [_ context coll]
     (.reduce ^IReduceInit coll (where-rf context) [])))
@@ -412,7 +412,7 @@
 
 ;; Additional functions (https://www.hl7.org/fhir/fhirpath.html#functions)
 
-(defrecord ExtensionFunctionExpression [rf]
+(deftype ExtensionFunctionExpression [rf]
   Expression
   (-eval [_ _ coll]
     (.reduce ^IReduceInit coll rf [])))


### PR DESCRIPTION
I saw this problem by starting Blaze with the YourKit profiler. The problem was always Clojure case expressions resulting in large Java switch statements.