### PR TITLE
Intern Uri, Canonical, Code, Coding and CodeableConcept

### DIFF
--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -3007,9 +3007,9 @@
             {:fhir/type :fhir/Observation :id id
              :subject #fhir/Reference{:reference "Patient/0"}
              :code
-             (type/map->CodeableConcept
+             (type/codeable-concept
                {:coding
-                [(type/map->Coding
+                [(type/coding
                    {:system #fhir/uri"system"
                     :code code})]})})]
       (with-system [{:blaze.db/keys [node]} system]
@@ -3033,9 +3033,9 @@
             {:fhir/type :fhir/Observation :id id
              :subject #fhir/Reference{:reference "Patient/0"}
              :code
-             (type/map->CodeableConcept
+             (type/codeable-concept
                {:coding
-                [(type/map->Coding
+                [(type/coding
                    {:system #fhir/uri"system"
                     :code code})]})})]
       (with-system [{:blaze.db/keys [node]} system]
@@ -3088,9 +3088,9 @@
             {:fhir/type :fhir/Observation :id id
              :subject #fhir/Reference{:reference "Patient/0"}
              :code
-             (type/map->CodeableConcept
+             (type/codeable-concept
                {:coding
-                [(type/map->Coding
+                [(type/coding
                    {:system #fhir/uri"system"
                     :code code})]})})]
       (with-system [{:blaze.db/keys [node]} system]

--- a/modules/fhir-structure/resources/data_readers.clj
+++ b/modules/fhir-structure/resources/data_readers.clj
@@ -1,8 +1,8 @@
 {fhir/integer clojure.core/int
  fhir/long clojure.core/long
- fhir/uri blaze.fhir.spec.type/->Uri
+ fhir/uri blaze.fhir.spec.type/uri
  fhir/url blaze.fhir.spec.type/->Url
- fhir/canonical blaze.fhir.spec.type/->Canonical
+ fhir/canonical blaze.fhir.spec.type/canonical
  fhir/base64Binary blaze.fhir.spec.type/->Base64Binary
  fhir/instant blaze.fhir.spec.type/->Instant
  fhir/date blaze.fhir.spec.type/->Date
@@ -18,8 +18,8 @@
  fhir/xhtml blaze.fhir.spec.type/->Xhtml
  fhir/Attachment blaze.fhir.spec.type/map->Attachment
  fhir/Extension blaze.fhir.spec.type/map->Extension
- fhir/Coding blaze.fhir.spec.type/map->Coding
- fhir/CodeableConcept blaze.fhir.spec.type/map->CodeableConcept
+ fhir/Coding blaze.fhir.spec.type/coding
+ fhir/CodeableConcept blaze.fhir.spec.type/codeable-concept
  fhir/Quantity blaze.fhir.spec.type/map->Quantity
  fhir/Period blaze.fhir.spec.type/map->Period
  fhir/Identifier blaze.fhir.spec.type/map->Identifier

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -425,9 +425,9 @@
     (group-by :choice-group child-spec-defs)))
 
 
-(defn- json-object-spec-form [class-name child-spec-defs]
+(defn- json-object-spec-form [create-fn child-spec-defs]
   `(specs/json-object
-     ~(symbol "blaze.fhir.spec.type" (str "map->" class-name))
+     ~(symbol "blaze.fhir.spec.type" create-fn)
      ~(into
         {}
         (comp
@@ -448,18 +448,20 @@
      :modifier :json
      :spec-form
      (case key
+       :fhir.json/Coding
+       (json-object-spec-form "coding" child-spec-defs)
+       :fhir.json/CodeableConcept
+       (json-object-spec-form "codeable-concept" child-spec-defs)
        (:fhir.json/Attachment
          :fhir.json/Extension
-         :fhir.json/Coding
-         :fhir.json/CodeableConcept
          :fhir.json/Quantity
          :fhir.json/Period
          :fhir.json/Identifier
          :fhir.json/Reference
          :fhir.json/Meta)
-       (json-object-spec-form path-part child-spec-defs)
+       (json-object-spec-form (str "map->" path-part) child-spec-defs)
        :fhir.json.Bundle.entry/search
-       (json-object-spec-form "BundleEntrySearch" child-spec-defs)
+       (json-object-spec-form "map->BundleEntrySearch" child-spec-defs)
        (conj (seq (remap-choice-conformer-forms child-spec-defs))
              (json-type-conformer-form kind parent-path-parts path-part)
              (schema-spec-form :json child-spec-defs)
@@ -596,9 +598,9 @@
                              child-spec-defs))}))
 
 
-(defn- cbor-object-spec-form [class-name child-spec-defs]
+(defn- cbor-object-spec-form [create-fn child-spec-defs]
   `(specs/json-object
-     ~(symbol "blaze.fhir.spec.type" (str "map->" class-name))
+     ~(symbol "blaze.fhir.spec.type" create-fn)
      ~(into
         {}
         (comp
@@ -620,18 +622,20 @@
      :modifier :cbor
      :spec-form
      (case key
+       :fhir.cbor/Coding
+       (cbor-object-spec-form "coding" child-spec-defs)
+       :fhir.cbor/CodeableConcept
+       (cbor-object-spec-form "codeable-concept" child-spec-defs)
        (:fhir.cbor/Attachment
          :fhir.cbor/Extension
-         :fhir.cbor/Coding
-         :fhir.cbor/CodeableConcept
          :fhir.cbor/Quantity
          :fhir.cbor/Period
          :fhir.cbor/Identifier
          :fhir.cbor/Reference
          :fhir.cbor/Meta)
-       (cbor-object-spec-form path-part child-spec-defs)
+       (cbor-object-spec-form (str "map->" path-part) child-spec-defs)
        :fhir.cbor.Bundle.entry/search
-       (cbor-object-spec-form "BundleEntrySearch" child-spec-defs)
+       (cbor-object-spec-form "map->BundleEntrySearch" child-spec-defs)
        (conj (seq (remap-choice-conformer-forms child-spec-defs))
              (json-type-conformer-form kind parent-path-parts path-part)
              (schema-spec-form :cbor child-spec-defs)
@@ -722,15 +726,15 @@
       "integer" `(s/and int? (s/conformer int identity))
       "string" `(specs/regex ~pattern identity)
       "decimal" `(s/conformer conform-decimal-json identity)
-      "uri" `(specs/regex ~pattern type/->Uri)
+      "uri" `(specs/regex ~pattern type/uri)
       "url" `(specs/regex ~pattern type/->Url)
-      "canonical" `(specs/regex ~pattern type/->Canonical)
+      "canonical" `(specs/regex ~pattern type/canonical)
       "base64Binary" `(specs/regex ~pattern type/->Base64Binary)
       "instant" `(specs/regex ~pattern type/->Instant)
       "date" `(specs/regex ~pattern type/->Date)
       "dateTime" `(specs/regex ~pattern type/->DateTime)
       "time" `(specs/regex ~pattern type/->Time)
-      "code" `(specs/regex ~pattern type/->Code)
+      "code" `(specs/regex ~pattern type/code)
       "oid" `(specs/regex ~pattern type/->Oid)
       "id" `(specs/regex ~pattern type/->Id)
       "markdown" `(specs/regex ~pattern type/->Markdown)
@@ -774,15 +778,15 @@
     "integer" `(s/conformer int identity)
     "string" `any?
     "decimal" `any?
-    "uri" `(s/conformer type/->Uri identity)
+    "uri" `(s/conformer type/uri identity)
     "url" `(s/conformer type/->Url identity)
-    "canonical" `(s/conformer type/->Canonical identity)
+    "canonical" `(s/conformer type/canonical identity)
     "base64Binary" `(s/conformer type/->Base64Binary identity)
     "instant" `(s/conformer type/->Instant identity)
     "date" `(s/conformer type/->Date identity)
     "dateTime" `(s/conformer type/->DateTime identity)
     "time" `(s/conformer type/->Time identity)
-    "code" `(s/conformer type/->Code identity)
+    "code" `(s/conformer type/code identity)
     "oid" `(s/conformer type/->Oid identity)
     "id" `(s/conformer type/->Id identity)
     "markdown" `(s/conformer type/->Markdown identity)

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl/intern.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl/intern.clj
@@ -1,0 +1,40 @@
+(ns blaze.fhir.spec.impl.intern
+  (:import
+    [clojure.lang Util]
+    [java.lang.ref ReferenceQueue WeakReference]
+    [java.util.concurrent ConcurrentHashMap]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn intern-value
+  "Returns a function of arity 1 that creates a value using `create-fn` only if
+  no value exists already in an internal cache using the argument as key.
+
+  Should be used the following way:
+
+  (def intern-foo
+    \"Creates interned instances of foo.\"
+    (intern-value foo))
+
+  Holds weak references to values so that they can be collected under high
+  pressure. The algorithm was taken from Clojure 1.10.3 keyword interning."
+  [create-fn]
+  (let [cache (ConcurrentHashMap.)
+        rq (ReferenceQueue.)]
+    (fn [key]
+      (loop [ref (.get cache key)]
+        (if ref
+          (if-let [existing-value (.get ^WeakReference ref)]
+            existing-value
+            (do (.remove cache key ref)
+                (recur (.get cache key))))
+          (let [new-value (create-fn key)]
+            (Util/clearCache rq cache)
+            (if-let [ref (.putIfAbsent cache key (WeakReference. new-value rq))]
+              (if-let [existing-value (.get ^WeakReference ref)]
+                existing-value
+                (do (.remove cache key ref)
+                    (recur (.get cache key))))
+              new-value)))))))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -1,6 +1,7 @@
 (ns blaze.fhir.spec.type
   (:refer-clojure :exclude [decimal? string? type uri? uuid?])
   (:require
+    [blaze.fhir.spec.impl.intern :as intern]
     [blaze.fhir.spec.type.macros :as macros :refer [defcomplextype]]
     [blaze.fhir.spec.type.protocols :as p]
     [blaze.fhir.spec.type.system :as system]
@@ -201,6 +202,7 @@
 
 ;; ---- uri -------------------------------------------------------------------
 
+
 (deftype Uri [value]
   p/FhirType
   (-type [_] :fhir/uri)
@@ -233,10 +235,14 @@
   (.write w "\""))
 
 
+(def uri
+  (intern/intern-value ->Uri))
+
+
 (defn xml->Uri
   {:arglists '([element])}
   [{{:keys [_id _extension value]} :attrs}]
-  (->Uri value))
+  (uri value))
 
 
 (defn uri? [x]
@@ -323,10 +329,14 @@
   (.write w "\""))
 
 
+(def canonical
+  (intern/intern-value ->Canonical))
+
+
 (defn xml->Canonical
   {:arglists '([element])}
   [{{:keys [_id value]} :attrs _extensions :content}]
-  (->Canonical value))
+  (canonical value))
 
 
 (defn canonical? [x]
@@ -746,8 +756,12 @@
       (.writeString gen ^String (.value extended-code)))))
 
 
+(def code
+  (intern/intern-value ->Code))
+
+
 (defn tagged-literal->Code [x]
-  (if (string? x) (->Code x) (map->ExtendedCode x)))
+  (if (string? x) (code x) (map->ExtendedCode x)))
 
 
 (defn xml->Code
@@ -756,7 +770,7 @@
   [{{:keys [id value]} :attrs extensions :content}]
   (if (or id (seq extensions))
     (->ExtendedCode id extensions value)
-    (->Code value)))
+    (code value)))
 
 
 (defn code? [x]
@@ -1183,6 +1197,10 @@
    display :string})
 
 
+(def coding
+  (intern/intern-value map->Coding))
+
+
 (declare coding-serializer)
 
 
@@ -1193,6 +1211,10 @@
    extension ^{:cardinality :many} extension-serializer
    coding ^{:cardinality :many} coding-serializer
    text :string})
+
+
+(def codeable-concept
+  (intern/intern-value map->CodeableConcept))
 
 
 (declare codeable-concept-serializer)

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl/intern_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl/intern_test.clj
@@ -1,0 +1,54 @@
+(ns blaze.fhir.spec.impl.intern-test
+  (:require
+    [blaze.executors :as ex]
+    [blaze.fhir.spec.impl.intern :as intern]
+    [clojure.spec.test.alpha :as st]
+    [clojure.test :as test :refer [deftest is testing]])
+  (:import
+    [java.util.concurrent TimeUnit CountDownLatch]))
+
+
+(set! *warn-on-reflection* true)
+(st/instrument)
+
+
+(defn- fixture [f]
+  (st/instrument)
+  (f)
+  (st/unstrument))
+
+
+(test/use-fixtures :each fixture)
+
+
+(defrecord TestType [x])
+
+
+(def identity-intern
+  (intern/intern-value ->TestType))
+
+
+(deftest intern-test
+  (testing "both constructions lead to the same instance"
+    (is (identical? (identity-intern "a") (identity-intern "a"))))
+
+  (testing "parallel construction"
+    (dotimes [x 100]
+      (let [n 100
+            pool (ex/io-pool n "constructor-%d")
+            atoms (repeatedly n #(atom nil))
+            latch (CountDownLatch. 1)
+            ready (CountDownLatch. n)]
+        (doseq [atom atoms]
+          (ex/execute!
+            pool
+            #(do (.countDown ready)
+                 (.await latch)
+                 (reset! atom (identity-intern x)))))
+        ;; wait for threads to be created
+        (.await ready)
+        (.countDown latch)
+        (ex/shutdown! pool)
+        (ex/await-termination pool 10 TimeUnit/SECONDS)
+        (let [value (identity-intern x)]
+          (is (every? #(identical? value (deref %)) atoms)))))))

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
@@ -135,7 +135,7 @@
              [{:key :fhir/uri
                :spec-form `type/uri?}
               {:key :fhir.json/uri
-               :spec-form `(specs/regex "\\S*" type/->Uri)}
+               :spec-form `(specs/regex "\\S*" type/uri)}
               {:key :fhir.xml/uri
                :spec-form
                `(s2/and
@@ -145,7 +145,7 @@
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Uri type/to-xml))}
               {:key :fhir.cbor/uri
-               :spec-form `(s2/conformer type/->Uri identity)}])))
+               :spec-form `(s2/conformer type/uri identity)}])))
 
     (testing "canonical"
       (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "canonical"))
@@ -153,7 +153,7 @@
              [{:key :fhir/canonical
                :spec-form `type/canonical?}
               {:key :fhir.json/canonical
-               :spec-form `(specs/regex "\\S*" type/->Canonical)}
+               :spec-form `(specs/regex "\\S*" type/canonical)}
               {:key :fhir.xml/canonical
                :spec-form
                `(s2/and
@@ -163,7 +163,7 @@
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Canonical type/to-xml))}
               {:key :fhir.cbor/canonical
-               :spec-form `(s2/conformer type/->Canonical identity)}])))
+               :spec-form `(s2/conformer type/canonical identity)}])))
 
     (testing "base64Binary"
       (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "base64Binary"))
@@ -189,7 +189,7 @@
              [{:key :fhir/code
                :spec-form `type/code?}
               {:key :fhir.json/code
-               :spec-form `(specs/regex "[^\\s]+(\\s[^\\s]+)*" type/->Code)}
+               :spec-form `(specs/regex "[^\\s]+(\\s[^\\s]+)*" type/code)}
               {:key :fhir.xml/code
                :spec-form
                `(s2/and
@@ -199,7 +199,7 @@
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Code type/to-xml))}
               {:key :fhir.cbor/code
-               :spec-form `(s2/conformer type/->Code identity)}])))
+               :spec-form `(s2/conformer type/code identity)}])))
 
     (testing "unsignedInt"
       (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "unsignedInt"))

--- a/modules/interaction/src/blaze/interaction/history/instance.clj
+++ b/modules/interaction/src/blaze/interaction/history/instance.clj
@@ -23,7 +23,7 @@
 (defn- link [context query-params relation resource-handle]
   {:fhir/type :fhir.Bundle/link
    :relation relation
-   :url (type/->Uri (history-util/nav-url context query-params
+   :url (type/uri (history-util/nav-url context query-params
                                           (:t resource-handle)))})
 
 

--- a/modules/interaction/src/blaze/interaction/history/system.clj
+++ b/modules/interaction/src/blaze/interaction/history/system.clj
@@ -28,7 +28,7 @@
               (:t resource-handle)
               (-> resource-handle fhir-spec/fhir-type name)
               (:id resource-handle))
-            type/->Uri)})
+            type/uri)})
 
 
 (defn- build-response

--- a/modules/interaction/src/blaze/interaction/history/type.clj
+++ b/modules/interaction/src/blaze/interaction/history/type.clj
@@ -22,7 +22,7 @@
 (defn- link [context query-params relation resource-handle]
   {:fhir/type :fhir.Bundle/link
    :relation relation
-   :url (type/->Uri (history-util/nav-url context query-params
+   :url (type/uri (history-util/nav-url context query-params
                                           (:t resource-handle)
                                           (:id resource-handle)))})
 

--- a/modules/interaction/src/blaze/interaction/history/util.clj
+++ b/modules/interaction/src/blaze/interaction/history/util.clj
@@ -80,11 +80,11 @@
 
 (defn build-entry [context {:fhir/keys [type] :keys [id] :as resource}]
   (cond->
-    {:fullUrl (type/->Uri (fhir-util/instance-url context (name type) id))
+    {:fullUrl (type/uri (fhir-util/instance-url context (name type) id))
      :request
      {:fhir/type :fhir.Bundle.entry/request
       :method (method resource)
-      :url (type/->Uri (url (assoc context :blaze/base-url "") (name type) id
+      :url (type/uri (url (assoc context :blaze/base-url "") (name type) id
                             resource))}
      :response
      {:fhir/type :fhir.Bundle.entry/response

--- a/modules/interaction/src/blaze/interaction/search/util.clj
+++ b/modules/interaction/src/blaze/interaction/search/util.clj
@@ -17,6 +17,6 @@
    (entry context resource match))
   ([context {:fhir/keys [type] :keys [id] :as resource} mode]
    {:fhir/type :fhir.Bundle/entry
-    :fullUrl (type/->Uri (fhir-util/instance-url context (name type) id))
+    :fullUrl (type/uri (fhir-util/instance-url context (name type) id))
     :resource resource
     :search mode}))

--- a/modules/interaction/src/blaze/interaction/search_compartment.clj
+++ b/modules/interaction/src/blaze/interaction/search_compartment.clj
@@ -54,7 +54,7 @@
     {:keys [page-offset] :as params} :params} clauses]
   {:fhir/type :fhir.Bundle/link
    :relation "self"
-   :url (type/->Uri (nav/url base-url match params clauses (iu/t db)
+   :url (type/uri (nav/url base-url match params clauses (iu/t db)
                              {"__page-offset" page-offset}))})
 
 
@@ -68,7 +68,7 @@
                                (iu/t db) (next-link-offset params entries))]
     {:fhir/type :fhir.Bundle/link
      :relation "next"
-     :url (type/->Uri url)}))
+     :url (type/uri url)}))
 
 
 (defn- bundle* [context handles clauses]

--- a/modules/interaction/src/blaze/interaction/search_system.clj
+++ b/modules/interaction/src/blaze/interaction/search_system.clj
@@ -44,7 +44,7 @@
 (defn- self-link [{:keys [match params] :blaze/keys [base-url db]} entries]
   {:fhir/type :fhir.Bundle/link
    :relation "self"
-   :url (type/->Uri (nav/url base-url match params [] (iu/t db)
+   :url (type/uri (nav/url base-url match params [] (iu/t db)
                              (self-link-offset entries)))})
 
 
@@ -59,7 +59,7 @@
                                (iu/t db) (next-link-offset entries))]
     {:fhir/type :fhir.Bundle/link
      :relation "next"
-     :url (type/->Uri url)}))
+     :url (type/uri url)}))
 
 
 (defn- normal-bundle

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -122,7 +122,7 @@
   (let [url (self-link-url-fn clauses (self-link-offset first-entry))]
     {:fhir/type :fhir.Bundle/link
      :relation "self"
-     :url (type/->Uri url)}))
+     :url (type/uri url)}))
 
 
 (defn- next-link-offset [next-handle]
@@ -134,7 +134,7 @@
   (do-sync [url (next-link-url-fn clauses (next-link-offset next-handle))]
     {:fhir/type :fhir.Bundle/link
      :relation "next"
-     :url (type/->Uri url)}))
+     :url (type/uri url)}))
 
 
 (defn- total

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -247,7 +247,7 @@
 
 
 (defn- location [context type id vid]
-  (type/->Uri (fhir-util/versioned-instance-url context type id vid)))
+  (type/uri (fhir-util/versioned-instance-url context type id vid)))
 
 
 (defn- created-entry
@@ -367,7 +367,7 @@
         :status (str status)}
 
        location
-       (assoc :location (type/->Uri location))
+       (assoc :location (type/uri location))
 
        etag
        (assoc :etag etag)
@@ -503,7 +503,7 @@
 (defn- response-bundle [context type entries]
   {:fhir/type :fhir/Bundle
    :id (iu/luid context)
-   :type (type/->Code (str (type/value type) "-response"))
+   :type (type/code (str (type/value type) "-response"))
    :entry entries})
 
 

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -239,7 +239,7 @@
                 @(handler
                    {:body
                     {:fhir/type :fhir/Bundle
-                     :type (type/->Code type)}})]
+                     :type (type/code type)}})]
 
             (testing "response status"
               (is (= 200 status)))
@@ -248,7 +248,7 @@
               (given body
                 :fhir/type := :fhir/Bundle
                 :id := "AAAAAAAAAAAAAAAA"
-                :type := (type/->Code (str type "-response"))
+                :type := (type/code (str type "-response"))
                 :entry :? empty?)))))
 
       (testing "and update interaction"
@@ -271,7 +271,7 @@
                       @(handler
                          {:body
                           {:fhir/type :fhir/Bundle
-                           :type (type/->Code type)
+                           :type (type/code type)
                            :entry entries}})]
 
                   (testing "response status"
@@ -281,7 +281,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (is (nil? resource)))
@@ -302,7 +302,7 @@
                          {:headers {"prefer" "return=representation"}
                           :body
                           {:fhir/type :fhir/Bundle
-                           :type (type/->Code type)
+                           :type (type/code type)
                            :entry entries}})]
 
                   (testing "response status"
@@ -312,7 +312,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (given resource
@@ -349,7 +349,7 @@
                       @(handler
                          {:body
                           {:fhir/type :fhir/Bundle
-                           :type (type/->Code type)
+                           :type (type/code type)
                            :entry entries}})]
 
                   (testing "response status"
@@ -359,7 +359,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (is (nil? resource)))
@@ -381,7 +381,7 @@
                          {:headers {"prefer" "return=representation"}
                           :body
                           {:fhir/type :fhir/Bundle
-                           :type (type/->Code type)
+                           :type (type/code type)
                            :entry entries}})]
 
                   (testing "response status"
@@ -391,7 +391,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (given resource
@@ -425,7 +425,7 @@
                     @(handler
                        {:body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry entries}})]
 
                 (testing "response status"
@@ -435,7 +435,7 @@
                   (given body
                     :fhir/type := :fhir/Bundle
                     :id := "AAAAAAAAAAAAAAAA"
-                    :type := (type/->Code (str type "-response"))))
+                    :type := (type/code (str type "-response"))))
 
                 (testing "entry resource"
                   (is (nil? resource)))
@@ -456,7 +456,7 @@
                        {:headers {"prefer" "return=representation"}
                         :body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry entries}})]
 
                 (testing "response status"
@@ -466,7 +466,7 @@
                   (given body
                     :fhir/type := :fhir/Bundle
                     :id := "AAAAAAAAAAAAAAAA"
-                    :type := (type/->Code (str type "-response"))))
+                    :type := (type/code (str type "-response"))))
 
                 (testing "entry resource"
                   (given resource
@@ -495,7 +495,7 @@
                     @(handler
                        {:body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry
                          [{:fhir/type :fhir.Bundle/entry
                            :resource
@@ -514,7 +514,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (is (nil? resource)))
@@ -538,7 +538,7 @@
                        {:headers {"prefer" "return=representation"}
                         :body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry
                          [{:fhir/type :fhir.Bundle/entry
                            :resource
@@ -557,7 +557,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (given resource
@@ -585,7 +585,7 @@
                     @(handler
                        {:body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry
                          [{:fhir/type :fhir.Bundle/entry
                            :resource
@@ -604,7 +604,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (is (nil? resource)))
@@ -628,7 +628,7 @@
                        {:headers {"prefer" "return=representation"}
                         :body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry
                          [{:fhir/type :fhir.Bundle/entry
                            :resource
@@ -647,7 +647,7 @@
                     (given body
                       :fhir/type := :fhir/Bundle
                       :id := "AAAAAAAAAAAAAAAA"
-                      :type := (type/->Code (str type "-response"))))
+                      :type := (type/code (str type "-response"))))
 
                   (testing "entry resource"
                     (given resource
@@ -679,7 +679,7 @@
                     @(handler
                        {:body
                         {:fhir/type :fhir/Bundle
-                         :type (type/->Code type)
+                         :type (type/code type)
                          :entry entries}})]
 
                 (testing "response status"
@@ -689,7 +689,7 @@
                   (given body
                     :fhir/type := :fhir/Bundle
                     :id := "AAAAAAAAAAAAAAAA"
-                    :type := (type/->Code (str type "-response"))))
+                    :type := (type/code (str type "-response"))))
 
                 (testing "entry resource"
                   (is (nil? resource)))
@@ -709,7 +709,7 @@
                   @(handler
                      {:body
                       {:fhir/type :fhir/Bundle
-                       :type (type/->Code type)
+                       :type (type/code type)
                        :entry
                        [{:fhir/type :fhir.Bundle/entry
                          :request
@@ -724,7 +724,7 @@
                 (given body
                   :fhir/type := :fhir/Bundle
                   :id := "AAAAAAAAAAAAAAAA"
-                  :type := (type/->Code (str type "-response"))))
+                  :type := (type/code (str type "-response"))))
 
               (testing "returns error"
                 (testing "with status"
@@ -747,7 +747,7 @@
                   @(handler
                      {:body
                       {:fhir/type :fhir/Bundle
-                       :type (type/->Code type)
+                       :type (type/code type)
                        :entry
                        [{:fhir/type :fhir.Bundle/entry
                          :request
@@ -762,7 +762,7 @@
                 (given body
                   :fhir/type := :fhir/Bundle
                   :id := "AAAAAAAAAAAAAAAA"
-                  :type := (type/->Code (str type "-response"))))
+                  :type := (type/code (str type "-response"))))
 
               (testing "entry resource"
                 (given resource

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -267,7 +267,7 @@
        "population" #fhir/code"summary"
        "subject-list" #fhir/code"subject-list"
        "subject" #fhir/code"individual")
-     :measure (type/->Canonical measure-ref)
+     :measure (type/canonical measure-ref)
      :date now
      :period
      (type/map->Period

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/stratifier.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/stratifier.clj
@@ -7,7 +7,7 @@
 
 
 (defn- value-concept [value]
-  (type/map->CodeableConcept {:text (str (if (nil? value) "null" value))}))
+  (type/codeable-concept {:text (str (if (nil? value) "null" value))}))
 
 
 (defn- stratum* [population value]

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
@@ -56,7 +56,7 @@
 (defn- coerce-report-type [_ value]
   (if-not (s/valid? :blaze.fhir.operation.evaluate-measure/report-type value)
     (ba/incorrect (invalid-report-type-param-msg value) :fhir/issue "value")
-    (type/->Code value)))
+    (type/code value)))
 
 
 (defn- invalid-subject-param-msg [subject]

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -123,11 +123,11 @@
 
 
 (defn- population-concept [code]
-  (type/map->CodeableConcept
+  (type/codeable-concept
     {:coding
-     [(type/map->Coding
+     [(type/coding
         {:system #fhir/uri"http://terminology.hl7.org/CodeSystem/measure-population"
-         :code (type/->Code code)})]}))
+         :code (type/code code)})]}))
 
 
 (defn- cql-expression [expr]

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -44,19 +44,19 @@
 
 
 (defn- scoring-concept [code]
-  (type/map->CodeableConcept
+  (type/codeable-concept
     {:coding
-     [(type/map->Coding
+     [(type/coding
         {:system #fhir/uri"http://terminology.hl7.org/CodeSystem/measure-scoring"
-         :code (type/->Code code)})]}))
+         :code (type/code code)})]}))
 
 
 (defn- population-concept [code]
-  (type/map->CodeableConcept
+  (type/codeable-concept
     {:coding
-     [(type/map->Coding
+     [(type/coding
         {:system #fhir/uri"http://terminology.hl7.org/CodeSystem/measure-population"
-         :code (type/->Code code)})]}))
+         :code (type/code code)})]}))
 
 
 (defn- cql-expression [expr]

--- a/modules/rest-api/src/blaze/rest_api/capabilities.clj
+++ b/modules/rest-api/src/blaze/rest_api/capabilities.clj
@@ -30,7 +30,7 @@
             #(some #{name} (:blaze.rest-api.operation/resource-types %))
             operations)]
       (cond->
-        {:type (type/->Code name)
+        {:type (type/code name)
          :interaction
          (reduce
            (fn [res code]
@@ -39,7 +39,7 @@
                (conj
                  res
                  (cond->
-                   {:code (type/->Code (clojure.core/name code))}
+                   {:code (type/code (clojure.core/name code))}
                    doc
                    (assoc :documentation (type/->Markdown doc))))
                res))
@@ -69,9 +69,9 @@
          (transduce
            (map
              (fn [{:keys [name url type]}]
-               (cond-> {:name name :type (type/->Code type)}
+               (cond-> {:name name :type (type/code type)}
                  url
-                 (assoc :definition (type/->Canonical url))
+                 (assoc :definition (type/canonical url))
                  (= "quantity" type)
                  (assoc :documentation quantity-documentation))))
            conj
@@ -88,7 +88,7 @@
                     [code def-uri type-handler instance-handler]}]
                 (when (or type-handler instance-handler)
                   {:name code
-                   :definition (type/->Canonical def-uri)})))
+                   :definition (type/canonical def-uri)})))
             operations))))))
 
 

--- a/modules/rest-api/src/blaze/rest_api/middleware/auth_guard.clj
+++ b/modules/rest-api/src/blaze/rest_api/middleware/auth_guard.clj
@@ -26,6 +26,6 @@
                  :severity #fhir/code"error"
                  :code #fhir/code"login"
                  :details
-                 (type/map->CodeableConcept
+                 (type/codeable-concept
                    {:coding [msg-auth-required]})}]})
             (ring/status 401))))))

--- a/modules/rest-util/src/blaze/handler/util.clj
+++ b/modules/rest-util/src/blaze/handler/util.clj
@@ -38,9 +38,9 @@
           (cond->
             {:fhir/type :fhir.OperationOutcome/issue
              :severity #fhir/code"error"
-             :code (or (some-> code type/->Code) (issue-code category))}
+             :code (or (some-> code type/code) (issue-code category))}
             severity
-            (assoc :severity (type/->Code severity))
+            (assoc :severity (type/code severity))
             diagnostics
             (assoc :diagnostics diagnostics)
             (coll? expression)
@@ -59,13 +59,13 @@
   (cond->
     {:fhir/type :fhir.OperationOutcome/issue
      :severity #fhir/code"error"
-     :code (or (some-> issue type/->Code) (issue-code category))}
+     :code (or (some-> issue type/code) (issue-code category))}
     operation-outcome
     (assoc
       :details
       {:coding
        [{:system #fhir/uri"http://terminology.hl7.org/CodeSystem/operation-outcome"
-         :code (type/->Code operation-outcome)}]})
+         :code (type/code operation-outcome)}]})
     message
     (assoc :diagnostics message)
     stacktrace


### PR DESCRIPTION
In FHIR, some values repeat in many resources. First uri's are used as system's in Codings and Identifiers. Second canonical values are used to refer to other resources. Third codes are often the same for a large number of resources. Last, Coding and CodeableConcept contain system and code values and are also often the same in it's entirety.

By interning instances of those values, only one instance will resist in memory as opposed to many. Because all values are immutable, there is no risk in sharing instances. The memory savings are about 50 % for Synthea BMI Observations.