### PR TITLE
Use Simple Symbols for Protocol Methods

### DIFF
--- a/modules/cql/src/blaze/elm/compiler/macros.clj
+++ b/modules/cql/src/blaze/elm/compiler/macros.clj
@@ -22,11 +22,11 @@
                    ~expr-binding expr#]
                ~@body)
              (reify core/Expression
-               (-eval [~'_ context# resource# scope#]
+               (~'-eval [~'_ context# resource# scope#]
                  (let [~operand-binding (core/-eval operand# context# resource# scope#)
                        ~expr-binding expr#]
                    ~@body))
-               (-form [~'_]
+               (~'-form [~'_]
                  (list (quote ~name) (core/-form operand#)))))))
       `(defmethod core/compile* ~(compile-kw name)
          [context# expr#]
@@ -35,10 +35,10 @@
              (let [~operand-binding operand#]
                ~@body)
              (reify core/Expression
-               (-eval [~'_ context# resource# scope#]
+               (~'-eval [~'_ context# resource# scope#]
                  (let [~operand-binding (core/-eval operand# context# resource# scope#)]
                    ~@body))
-               (-form [~'_]
+               (~'-form [~'_]
                  (list (quote ~name) (core/-form operand#))))))))))
 
 
@@ -58,11 +58,11 @@
                  ~op-2-binding operand-2#]
              ~@body)
            (reify core/Expression
-             (-eval [~'_ context# resource# scope#]
+             (~'-eval [~'_ context# resource# scope#]
                (let [~op-1-binding (core/-eval operand-1# context# resource# scope#)
                      ~op-2-binding (core/-eval operand-2# context# resource# scope#)]
                  ~@body))
-             (-form [~'_]
+             (~'-form [~'_]
                (list (quote ~name) (core/-form operand-1#) (core/-form operand-2#)))))))))
 
 
@@ -75,7 +75,7 @@
            operand-2# (core/compile* context# operand-2#)
            operand-3# (core/compile* context# operand-3#)]
        (reify core/Expression
-         (-eval [~'_ context# resource# scope#]
+         (~'-eval [~'_ context# resource# scope#]
            (let [~op-1-binding (core/-eval operand-1# context# resource# scope#)
                  ~op-2-binding (core/-eval operand-2# context# resource# scope#)
                  ~op-3-binding (core/-eval operand-3# context# resource# scope#)]
@@ -89,7 +89,7 @@
      [context# {operands# :operand}]
      (let [operands# (mapv #(core/compile* context# %) operands#)]
        (reify core/Expression
-         (-eval [~'_ context# resource# scope#]
+         (~'-eval [~'_ context# resource# scope#]
            (let [~operands-binding (mapv #(core/-eval % context# resource# scope#) operands#)]
              ~@body))))))
 
@@ -101,7 +101,7 @@
      [context# {source# :source}]
      (let [source# (core/compile* context# source#)]
        (reify core/Expression
-         (-eval [~'_ context# resource# scope#]
+         (~'-eval [~'_ context# resource# scope#]
            (let [~source-binding (core/-eval source# context# resource# scope#)]
              ~@body))))))
 
@@ -115,10 +115,10 @@
            ~precision-binding (some-> precision# core/to-chrono-unit)
            ~(or expr-binding '_) expr#]
        (reify core/Expression
-         (-eval [~'_ context# resource# scope#]
+         (~'-eval [~'_ context# resource# scope#]
            (let [~operand-binding (core/-eval operand# context# resource# scope#)]
              ~@body))
-         (-form [~'_]
+         (~'-form [~'_]
            (list (quote ~name) (core/-form operand#) precision#))))))
 
 
@@ -140,11 +140,11 @@
                  ~precision-binding chrono-precision#]
              ~@body)
            (reify core/Expression
-             (-eval [~'_ context# resource# scope#]
+             (~'-eval [~'_ context# resource# scope#]
                (let [~op-1-binding (core/-eval operand-1# context# resource# scope#)
                      ~op-2-binding (core/-eval operand-2# context# resource# scope#)
                      ~precision-binding chrono-precision#]
                  ~@body))
-             (-form [~'_]
+             (~'-form [~'_]
                (list (quote ~name) (core/-form operand-1#) (core/-form operand-2#)
                      precision#))))))))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/macros.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/macros.clj
@@ -38,8 +38,6 @@
   `(.serialize ~(with-meta serializer {:tag `JsonSerializer}) ~x ~gen ~provider))
 
 
-(comment (serialize 's 1 'g 'p))
-
 (defmacro defcomplextype
   [name [& fields] & {:keys [fhir-type hash-num references field-serializers]}]
   (let [sink-sym (gensym "sink")
@@ -49,8 +47,8 @@
     `(do
        (defrecord ~name [~@fields]
          p/FhirType
-         (-type [~'_] ~(or fhir-type (keyword "fhir" (str name))))
-         (-hash-into [~'_ ~sink-sym]
+         (~'-type [~'_] ~(or fhir-type (keyword "fhir" (str name))))
+         (~'-hash-into [~'_ ~sink-sym]
            (.putByte ~sink-sym-tag (byte ~hash-num))
            ~@(map-indexed
                (fn [idx field]
@@ -60,7 +58,7 @@
                       ~field ~sink-sym)))
                fields))
          ~(or references
-              `(-references [~'_]
+              `(~'-references [~'_]
                             (-> (transient [])
                                 ~@(keep
                                     (fn [field]


### PR DESCRIPTION
Generating code using syntax quote appends the current namespace to simple symbols. However protocol methods should not contain any namespace in reify or defrecord. So we have to use syntax unquote and quote here.