### PR TITLE
Move ByteBuffer Namespace into its Own Module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         module:
         - anomaly
         - async
+        - byte-buffer
         - cassandra
         - coll
         - cql

--- a/modules/byte-buffer/Makefile
+++ b/modules/byte-buffer/Makefile
@@ -1,0 +1,13 @@
+lint:
+	clj-kondo --lint src test deps.edn
+
+test:
+	clojure -M:test --profile :ci
+
+test-coverage:
+	true
+
+clean:
+	rm -rf .clj-kondo/.cache .cpcache target
+
+.PHONY: lint test test-coverage clean

--- a/modules/byte-buffer/deps.edn
+++ b/modules/byte-buffer/deps.edn
@@ -1,0 +1,16 @@
+{:deps
+ {com.google.protobuf/protobuf-java
+  {:mvn/version "3.19.4"}}
+
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+
+   :extra-deps
+   {blaze/test-util
+    {:local/root "../test-util"}
+
+    lambdaisland/kaocha
+    {:mvn/version "1.64.1010"}}
+
+   :main-opts ["-m" "kaocha.runner"]}}}

--- a/modules/byte-buffer/test/blaze/byte_buffer_test.clj
+++ b/modules/byte-buffer/test/blaze/byte_buffer_test.clj
@@ -1,6 +1,6 @@
-(ns blaze.db.impl.byte-buffer-test
+(ns blaze.byte-buffer-test
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]))
 

--- a/modules/byte-buffer/tests.edn
+++ b/modules/byte-buffer/tests.edn
@@ -1,0 +1,5 @@
+#kaocha/v1
+    #merge
+        [{}
+         #profile {:ci {:reporter kaocha.report/documentation
+                        :color? false}}]

--- a/modules/cassandra/test/blaze/cassandra_test.clj
+++ b/modules/cassandra/test/blaze/cassandra_test.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :as ba]
     [blaze.async.comp :as ac]
+    [blaze.byte-buffer :as bb]
     [blaze.cassandra :as cass]
     [blaze.cassandra-spec]
     [blaze.test-util :refer [satisfies-prop]]
@@ -92,7 +93,7 @@
   (reify Row
     (^ByteBuffer getByteBuffer [_ ^int i]
       (assert (= idx i))
-      (ByteBuffer/wrap (byte-array bytes)))))
+      (bb/wrap (byte-array bytes)))))
 
 
 (defn resultset-with [row]

--- a/modules/db-resource-store-cassandra/deps.edn
+++ b/modules/db-resource-store-cassandra/deps.edn
@@ -2,6 +2,9 @@
  {blaze/async
   {:local/root "../async"}
 
+  blaze/byte-buffer
+  {:local/root "../byte-buffer"}
+
   blaze/cassandra
   {:local/root "../cassandra"}
 

--- a/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
+++ b/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :as ba :refer [when-ok]]
     [blaze.async.comp :as ac :refer [do-sync]]
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.cassandra :as cass]
     [blaze.cassandra.spec]
@@ -15,8 +16,7 @@
     [prometheus.alpha :as prom :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.lang AutoCloseable]
-    [java.nio ByteBuffer]))
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -98,7 +98,7 @@
 
 
 (defn- bind-put [statement hash resource]
-  (let [content (ByteBuffer/wrap (fhir-spec/unform-cbor resource))]
+  (let [content (bb/wrap (fhir-spec/unform-cbor resource))]
     (prom/observe! resource-bytes (.capacity content))
     (cass/bind statement (bs/hex hash) content)))
 

--- a/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
+++ b/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [hash])
   (:require
     [blaze.async.comp :as ac]
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.cassandra :as cass]
     [blaze.cassandra-spec]
@@ -60,7 +61,7 @@
   (reify Row
     (^ByteBuffer getByteBuffer [_ ^int i]
       (assert (= idx i))
-      (ByteBuffer/wrap bytes))))
+      (bb/wrap bytes))))
 
 
 (defn resultset-with [row]
@@ -335,7 +336,7 @@
   (testing "execute error"
     (let [resource {:fhir/type :fhir/Patient :id "0"}
           hash (hash/generate resource)
-          encoded-resource (ByteBuffer/wrap (fhir-spec/unform-cbor resource))
+          encoded-resource (bb/wrap (fhir-spec/unform-cbor resource))
           session
           (reify CqlSession
             (^PreparedStatement prepare [_ ^SimpleStatement statement]
@@ -360,7 +361,7 @@
   (testing "DriverTimeoutException"
     (let [resource {:fhir/type :fhir/Patient :id "0"}
           hash (hash/generate resource)
-          encoded-resource (ByteBuffer/wrap (fhir-spec/unform-cbor resource))
+          encoded-resource (bb/wrap (fhir-spec/unform-cbor resource))
           session
           (reify CqlSession
             (^PreparedStatement prepare [_ ^SimpleStatement statement]
@@ -389,7 +390,7 @@
   (testing "WriteTimeoutException"
     (let [resource {:fhir/type :fhir/Patient :id "0"}
           hash (hash/generate resource)
-          encoded-resource (ByteBuffer/wrap (fhir-spec/unform-cbor resource))
+          encoded-resource (bb/wrap (fhir-spec/unform-cbor resource))
           session
           (reify CqlSession
             (^PreparedStatement prepare [_ ^SimpleStatement statement]
@@ -418,7 +419,7 @@
   (testing "success"
     (let [resource {:fhir/type :fhir/Patient :id "0"}
           hash (hash/generate resource)
-          encoded-resource (ByteBuffer/wrap (fhir-spec/unform-cbor resource))
+          encoded-resource (bb/wrap (fhir-spec/unform-cbor resource))
           session
           (reify CqlSession
             (^PreparedStatement prepare [_ ^SimpleStatement statement]

--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -4,6 +4,9 @@
  {blaze/async
   {:local/root "../async"}
 
+  blaze/byte-buffer
+  {:local/root "../byte-buffer"}
+
   blaze/byte-string
   {:local/root "../byte-string"}
 

--- a/modules/db/src/blaze/db/impl/codec.clj
+++ b/modules/db/src/blaze/db/impl/codec.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.codec
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.fhir.spec.type.system])
   (:import
     [blaze.fhir.spec.type.system DateTimeYear DateTimeYearMonth

--- a/modules/db/src/blaze/db/impl/index/compartment/resource.clj
+++ b/modules/db/src/blaze/db/impl/index/compartment/resource.clj
@@ -1,9 +1,9 @@
 (ns blaze.db.impl.index.compartment.resource
   "Functions for accessing the CompartmentResource index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.bytes :as bytes]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.iterators :as i]))

--- a/modules/db/src/blaze/db/impl/index/compartment/search_param_value_resource.clj
+++ b/modules/db/src/blaze/db/impl/index/compartment/search_param_value_resource.clj
@@ -1,8 +1,8 @@
 (ns blaze.db.impl.index.compartment.search-param-value-resource
   "Functions for accessing the CompartmentSearchParamValueResource index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.bytes :as bytes]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.search-param-value-resource :as sp-vr]

--- a/modules/db/src/blaze/db/impl/index/resource_as_of.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_as_of.clj
@@ -1,9 +1,9 @@
 (ns blaze.db.impl.index.resource-as-of
   "Functions for accessing the ResourceAsOf index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-handle :as rh]
     [blaze.db.impl.iterators :as i]

--- a/modules/db/src/blaze/db/impl/index/resource_handle.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_handle.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.resource-handle
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.fhir.spec.type.protocols :as p]))
 

--- a/modules/db/src/blaze/db/impl/index/resource_search_param_value.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_search_param_value.clj
@@ -1,9 +1,9 @@
 (ns blaze.db.impl.index.resource-search-param-value
   "Functions for accessing the ResourceSearchParamValue index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.bytes :as bytes]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.iterators :as i]))

--- a/modules/db/src/blaze/db/impl/index/rts_as_of.clj
+++ b/modules/db/src/blaze/db/impl/index/rts_as_of.clj
@@ -5,7 +5,7 @@
    * TypeAsOf
    * SystemAsOf"
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-as-of :as rao]
     [blaze.db.impl.index.system-as-of :as sao]

--- a/modules/db/src/blaze/db/impl/index/search_param_value_resource.clj
+++ b/modules/db/src/blaze/db/impl/index/search_param_value_resource.clj
@@ -1,8 +1,8 @@
 (ns blaze.db.impl.index.search-param-value-resource
   "Functions for accessing the SearchParamValueResource index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.bytes :as bytes]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.iterators :as i]))

--- a/modules/db/src/blaze/db/impl/index/system_as_of.clj
+++ b/modules/db/src/blaze/db/impl/index/system_as_of.clj
@@ -1,9 +1,9 @@
 (ns blaze.db.impl.index.system-as-of
   "Functions for accessing the SystemAsOf index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-handle :as rh]
     [blaze.db.impl.iterators :as i])

--- a/modules/db/src/blaze/db/impl/index/system_stats.clj
+++ b/modules/db/src/blaze/db/impl/index/system_stats.clj
@@ -14,7 +14,7 @@
   Each transaction which touches any resources, puts an entry with the new
   totals at its t."
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.kv :as kv])
   (:import

--- a/modules/db/src/blaze/db/impl/index/t_by_instant.clj
+++ b/modules/db/src/blaze/db/impl/index/t_by_instant.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.t-by-instant
   "Functions for accessing the TByInstant index."
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.kv :as kv])
   (:import
     [com.google.common.primitives Longs]))

--- a/modules/db/src/blaze/db/impl/index/tx_success.clj
+++ b/modules/db/src/blaze/db/impl/index/tx_success.clj
@@ -5,7 +5,7 @@
   successful transactions happened. In other words, this index maps each t which
   is just a monotonically increasing number to a real point in time."
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.index.cbor :as cbor]
     [blaze.db.kv :as kv])
   (:import

--- a/modules/db/src/blaze/db/impl/index/type_as_of.clj
+++ b/modules/db/src/blaze/db/impl/index/type_as_of.clj
@@ -1,9 +1,9 @@
 (ns blaze.db.impl.index.type-as-of
   "Functions for accessing the TypeAsOf index."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-handle :as rh]
     [blaze.db.impl.iterators :as i])

--- a/modules/db/src/blaze/db/impl/index/type_stats.clj
+++ b/modules/db/src/blaze/db/impl/index/type_stats.clj
@@ -15,7 +15,7 @@
   Each transaction which touches resources of a particular type, puts an entry
   with the new totals for this type at its t."
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.kv :as kv])
   (:import

--- a/modules/db/src/blaze/db/impl/iterators.clj
+++ b/modules/db/src/blaze/db/impl/iterators.clj
@@ -17,10 +17,10 @@
   free of side effects by creating an exclusive key-value store iterator before
   calling one of the functions and closing it after the collection is consumed."
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.coll.core :as coll]
     [blaze.db.impl.arrays-support :as arrays-support]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.kv :as kv])
   (:import
     [clojure.lang IReduceInit]))

--- a/modules/db/src/blaze/db/impl/search_param/util.clj
+++ b/modules/db/src/blaze/db/impl/search_param/util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.search-param.util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.fhir.spec :as fhir-spec]
     [clojure.string :as str])

--- a/modules/db/src/blaze/db/tx_log/local.clj
+++ b/modules/db/src/blaze/db/tx_log/local.clj
@@ -11,8 +11,8 @@
   (:require
     [blaze.anomaly :as ba]
     [blaze.async.comp :as ac]
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.iterators :as i]
     [blaze.db.kv :as kv]
     [blaze.db.tx-log :as tx-log]

--- a/modules/db/src/blaze/db/tx_log/local/codec.clj
+++ b/modules/db/src/blaze/db/tx_log/local/codec.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.tx-log.local.codec
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [jsonista.core :as j]
     [taoensso.timbre :as log])

--- a/modules/db/test-perf/blaze/db/impl/index/resource_handle_test.clj
+++ b/modules/db/test-perf/blaze/db/impl/index/resource_handle_test.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.impl.index.resource-handle-test
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.index.resource-handle :as rh]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest testing]]

--- a/modules/db/test/blaze/db/impl/index/compartment/resource_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/compartment/resource_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.compartment.resource-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.compartment.test-util :as tu]
     [blaze.db.impl.iterators :as i]

--- a/modules/db/test/blaze/db/impl/index/compartment/search_param_value_resource_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/compartment/search_param_value_resource_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.compartment.search-param-value-resource-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.compartment.test-util :as tu]
     [blaze.db.impl.iterators :as i]

--- a/modules/db/test/blaze/db/impl/index/resource_as_of_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_as_of_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.resource-as-of-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-handle :as rh]))
 

--- a/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.impl.index.resource-handle-spec
   (:require
-    [blaze.db.impl.byte-buffer :refer [byte-buffer?]]
+    [blaze.byte-buffer :refer [byte-buffer?]]
     [blaze.db.impl.codec-spec]
     [blaze.db.impl.index.resource-handle :as rh]
     [blaze.db.kv-spec]

--- a/modules/db/test/blaze/db/impl/index/resource_search_param_value_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_search_param_value_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.resource-search-param-value-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.iterators :as i]
     [blaze.db.kv :as kv]))

--- a/modules/db/test/blaze/db/impl/index/search_param_value_resource_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/search_param_value_resource_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.search-param-value-resource-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.iterators :as i]
     [blaze.db.kv :as kv]))

--- a/modules/db/test/blaze/db/impl/index/system_as_of_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/system_as_of_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.system-as-of-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-handle :as rh]))
 

--- a/modules/db/test/blaze/db/impl/index/system_stats_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/system_stats_test_util.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.impl.index.system-stats-test-util
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]))
 
 

--- a/modules/db/test/blaze/db/impl/index/type_as_of_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/type_as_of_test_util.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.index.type-as-of-test-util
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-handle :as rh]))
 

--- a/modules/db/test/blaze/db/impl/index/type_stats_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/type_stats_test_util.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.impl.index.type-stats-test-util
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]))
 
 

--- a/modules/db/test/blaze/db/impl/iterators_test.clj
+++ b/modules/db/test/blaze/db/impl/iterators_test.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.iterators-test
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.bytes :as bytes]
     [blaze.db.impl.iterators :as i]
     [blaze.db.kv :as kv]

--- a/modules/db/test/blaze/db/impl/search_param/composite_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite_test.clj
@@ -1,8 +1,8 @@
 (ns blaze.db.impl.search-param.composite-test
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.byte-string-spec]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-search-param-value-test-util :as r-sp-v-tu]
     [blaze.db.impl.index.search-param-value-resource-test-util :as sp-vr-tu]

--- a/modules/db/test/blaze/db/impl/search_param/date_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/date_test.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.search-param.date-test
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string-spec]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.search-param-value-resource-spec]
     [blaze.db.impl.index.search-param-value-resource-test-util :as sp-vr-tu]

--- a/modules/db/test/blaze/db/impl/search_param/number_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/number_test.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.search-param.number-test
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string-spec]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-search-param-value-test-util :as r-sp-v-tu]
     [blaze.db.impl.index.search-param-value-resource-test-util :as sp-vr-tu]

--- a/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.search-param.quantity-test
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string-spec]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-search-param-value-test-util :as r-sp-v-tu]
     [blaze.db.impl.index.search-param-value-resource-test-util :as sp-vr-tu]

--- a/modules/db/test/blaze/db/impl/search_param/string_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/string_test.clj
@@ -1,7 +1,7 @@
 (ns blaze.db.impl.search-param.string-test
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.byte-string-spec]
-    [blaze.db.impl.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-search-param-value-test-util :as r-sp-v-tu]
     [blaze.db.impl.index.search-param-value-resource-test-util :as sp-vr-tu]

--- a/modules/db/test/blaze/db/impl/search_param/token_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/token_test.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.impl.search-param.token-test
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-search-param-value-test-util :as r-sp-v-tu]
     [blaze.db.impl.index.search-param-value-resource-spec]

--- a/modules/db/test/blaze/db/impl/search_param_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param_test.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.impl.search-param-test
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.impl.codec :as codec]
     [blaze.db.impl.index.resource-search-param-value-test-util :as r-sp-v-tu]
     [blaze.db.impl.index.search-param-value-resource-spec]

--- a/modules/db/test/blaze/db/tx_log/local/codec_spec.clj
+++ b/modules/db/test/blaze/db/tx_log/local/codec_spec.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.tx-log.local.codec-spec
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.tx-log.local.codec :as codec]
     [blaze.db.tx-log.spec]
     [clojure.spec.alpha :as s]))

--- a/modules/db/test/blaze/db/tx_log/local/codec_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local/codec_test.clj
@@ -1,6 +1,6 @@
 (ns blaze.db.tx-log.local.codec-test
   (:require
-    [blaze.db.impl.byte-buffer :as bb]
+    [blaze.byte-buffer :as bb]
     [blaze.db.tx-log.local.codec :as codec]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest testing]]

--- a/modules/fhir-client/deps.edn
+++ b/modules/fhir-client/deps.edn
@@ -2,6 +2,9 @@
  {blaze/async
   {:local/root "../async"}
 
+  blaze/byte-buffer
+  {:local/root "../byte-buffer"}
+
   blaze/http-client
   {:local/root "../http-client"}
 

--- a/modules/fhir-client/src/blaze/fhir_client/impl.clj
+++ b/modules/fhir-client/src/blaze/fhir_client/impl.clj
@@ -4,6 +4,7 @@
     [blaze.anomaly :as ba :refer [when-ok]]
     [blaze.async.comp :as ac]
     [blaze.async.flow :as flow]
+    [blaze.byte-buffer :as bb]
     [blaze.fhir.spec :as fhir-spec]
     [blaze.fhir.spec.type :as type]
     [clojure.java.io :as io]
@@ -12,7 +13,6 @@
     [hato.middleware :as hm]
     [taoensso.timbre :as log])
   (:import
-    [java.nio ByteBuffer]
     [java.nio.channels SeekableByteChannel]
     [java.nio.file Path Files StandardOpenOption]
     [java.util.concurrent Flow$Subscriber Flow$Subscription]))
@@ -167,7 +167,7 @@
     (let [file (.resolve ^Path dir ^String (filename-fn x))]
       (swap! filenames conj (.toAbsolutePath file))
       (with-open [bc (new-file-byte-channel file)]
-        (.write bc (ByteBuffer/wrap (fhir-spec/unform-json x))))))
+        (.write bc (bb/wrap (fhir-spec/unform-json x))))))
   (onError [_ e]
     (flow/cancel! subscription)
     (ac/complete-exceptionally! future e))

--- a/modules/kv/deps.edn
+++ b/modules/kv/deps.edn
@@ -1,5 +1,8 @@
 {:deps
- {blaze/module-base
+ {blaze/byte-buffer
+  {:local/root "../byte-buffer"}
+
+  blaze/module-base
   {:local/root "../module-base"}
 
   com.google.guava/guava

--- a/modules/kv/src/blaze/db/kv_spec.clj
+++ b/modules/kv/src/blaze/db/kv_spec.clj
@@ -1,14 +1,13 @@
 (ns blaze.db.kv-spec
   (:require
+    [blaze.byte-buffer :as bb]
     [blaze.db.kv :as kv]
     [blaze.db.kv.spec]
-    [clojure.spec.alpha :as s])
-  (:import
-    [java.nio ByteBuffer]))
+    [clojure.spec.alpha :as s]))
 
 
 (defn- direct-buffer? [x]
-  (and (instance? ByteBuffer x) (.isDirect ^ByteBuffer x)))
+  (and (bb/byte-buffer? x) (bb/direct? x)))
 
 
 (s/fdef kv/valid?

--- a/modules/page-store-cassandra/deps.edn
+++ b/modules/page-store-cassandra/deps.edn
@@ -2,6 +2,9 @@
  {blaze/async
   {:local/root "../async"}
 
+  blaze/byte-buffer
+  {:local/root "../byte-buffer"}
+
   blaze/cassandra
   {:local/root "../cassandra"}
 

--- a/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
+++ b/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :as ba :refer [when-ok]]
     [blaze.async.comp :as ac :refer [do-sync]]
+    [blaze.byte-buffer :as bb]
     [blaze.cassandra :as cass]
     [blaze.cassandra.spec]
     [blaze.module :refer [reg-collector]]
@@ -16,8 +17,7 @@
     [prometheus.alpha :as prom :refer [defhistogram]]
     [taoensso.timbre :as log])
   (:import
-    [java.lang AutoCloseable]
-    [java.nio ByteBuffer]))
+    [java.lang AutoCloseable]))
 
 
 (set! *warn-on-reflection* true)
@@ -68,7 +68,7 @@
 
 (defn- bind-put [statement token clauses]
   (let [content (codec/encode clauses)]
-    (prom/observe! clauses-bytes (.capacity ^ByteBuffer content))
+    (prom/observe! clauses-bytes (bb/capacity content))
     (cass/bind statement token content)))
 
 

--- a/modules/page-store-cassandra/src/blaze/page_store/cassandra/codec.clj
+++ b/modules/page-store-cassandra/src/blaze/page_store/cassandra/codec.clj
@@ -1,11 +1,11 @@
 (ns blaze.page-store.cassandra.codec
   (:require
     [blaze.anomaly :as ba]
+    [blaze.byte-buffer :as bb]
     [cognitect.anomalies :as anom]
     [jsonista.core :as j])
   (:import
-    [com.fasterxml.jackson.dataformat.cbor CBORFactory]
-    [java.nio ByteBuffer]))
+    [com.fasterxml.jackson.dataformat.cbor CBORFactory]))
 
 
 (def ^:private cbor-object-mapper
@@ -26,4 +26,4 @@
 
 
 (defn encode [clauses]
-  (ByteBuffer/wrap (j/write-value-as-bytes clauses cbor-object-mapper)))
+  (bb/wrap (j/write-value-as-bytes clauses cbor-object-mapper)))

--- a/modules/page-store-cassandra/test/blaze/page_store/cassandra/codec_spec.clj
+++ b/modules/page-store-cassandra/test/blaze/page_store/cassandra/codec_spec.clj
@@ -1,14 +1,13 @@
 (ns blaze.page-store.cassandra.codec-spec
   (:require
     [blaze.anomaly-spec]
+    [blaze.byte-buffer :as bb]
     [blaze.page-store :as page-store]
     [blaze.page-store.cassandra.codec :as codec]
     [blaze.page-store.spec]
     [blaze.spec]
     [clojure.spec.alpha :as s]
-    [cognitect.anomalies :as anom])
-  (:import
-    [java.nio ByteBuffer]))
+    [cognitect.anomalies :as anom]))
 
 
 (s/fdef codec/decode
@@ -18,4 +17,4 @@
 
 (s/fdef codec/encode
   :args (s/cat :clauses :blaze.db.query/clauses)
-  :ret #(instance? ByteBuffer %))
+  :ret bb/byte-buffer?)

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
@@ -1,6 +1,7 @@
 (ns blaze.db.kv.rocksdb-test
   (:require
     [blaze.anomaly :as ba]
+    [blaze.byte-buffer :as bb]
     [blaze.db.kv :as kv]
     [blaze.db.kv-spec]
     [blaze.db.kv.rocksdb :as rocksdb]
@@ -13,8 +14,7 @@
     [integrant.core :as ig])
   (:import
     [java.nio.file Files]
-    [java.nio.file.attribute FileAttribute]
-    [java.nio ByteBuffer]))
+    [java.nio.file.attribute FileAttribute]))
 
 
 (set! *warn-on-reflection* true)
@@ -35,9 +35,9 @@
 
 
 (defn- bb [& bytes]
-  (doto (ByteBuffer/allocateDirect (count bytes))
-    (.put (byte-array bytes))
-    (.flip)))
+  (-> (bb/allocate-direct (count bytes))
+      (bb/put-byte-array! (byte-array bytes))
+      bb/flip!))
 
 
 (deftest init-test
@@ -390,26 +390,26 @@
 
       (testing "puts the first byte into the buffer without overflowing"
         (kv/seek-to-first! iter)
-        (let [buf (ByteBuffer/allocateDirect 1)]
+        (let [buf (bb/allocate-direct 1)]
           (is (= 2 (kv/key! iter buf)))
-          (is (= 0x01 (.get buf)))))
+          (is (= 0x01 (bb/get-byte! buf)))))
 
       (testing "sets the limit of a bigger buffer to two"
         (kv/seek-to-first! iter)
-        (let [buf (ByteBuffer/allocateDirect 3)]
+        (let [buf (bb/allocate-direct 3)]
           (is (= 2 (kv/key! iter buf)))
-          (is (= 2 (.limit buf)))))
+          (is (= 2 (bb/limit buf)))))
 
       (testing "writes the key at position"
         (kv/seek-to-first! iter)
-        (let [buf (ByteBuffer/allocateDirect 3)]
-          (.position buf 1)
+        (let [buf (bb/allocate-direct 3)]
+          (bb/set-position! buf 1)
           (is (= 2 (kv/key! iter buf)))
-          (is (= 1 (.position buf)))
-          (is (= 3 (.limit buf)))
-          (is (= 0x00 (.get buf 0)))
-          (is (= 0x01 (.get buf)))
-          (is (= 0x02 (.get buf))))))))
+          (is (= 1 (bb/position buf)))
+          (is (= 3 (bb/limit buf)))
+          (is (= 0x00 (bb/get-byte! buf 0)))
+          (is (= 0x01 (bb/get-byte! buf)))
+          (is (= 0x02 (bb/get-byte! buf))))))))
 
 
 (deftest value-test
@@ -421,26 +421,26 @@
 
       (testing "puts the first byte into the buffer without overflowing"
         (kv/seek-to-first! iter)
-        (let [buf (ByteBuffer/allocateDirect 1)]
+        (let [buf (bb/allocate-direct 1)]
           (is (= 2 (kv/value! iter buf)))
-          (is (= 0x01 (.get buf)))))
+          (is (= 0x01 (bb/get-byte! buf)))))
 
       (testing "sets the limit of a bigger buffer to two"
         (kv/seek-to-first! iter)
-        (let [buf (ByteBuffer/allocateDirect 3)]
+        (let [buf (bb/allocate-direct 3)]
           (is (= 2 (kv/value! iter buf)))
-          (is (= 2 (.limit buf)))))
+          (is (= 2 (bb/limit buf)))))
 
       (testing "writes the value at position"
         (kv/seek-to-first! iter)
-        (let [buf (ByteBuffer/allocateDirect 3)]
-          (.position buf 1)
+        (let [buf (bb/allocate-direct 3)]
+          (bb/set-position! buf 1)
           (is (= 2 (kv/value! iter buf)))
-          (is (= 1 (.position buf)))
-          (is (= 3 (.limit buf)))
-          (is (= 0x00 (.get buf 0)))
-          (is (= 0x01 (.get buf)))
-          (is (= 0x02 (.get buf))))))))
+          (is (= 1 (bb/position buf)))
+          (is (= 3 (bb/limit buf)))
+          (is (= 0x00 (bb/get-byte! buf 0)))
+          (is (= 0x01 (bb/get-byte! buf)))
+          (is (= 0x02 (bb/get-byte! buf))))))))
 
 
 (defn- a-b-system [dir]

--- a/modules/test-util/deps.edn
+++ b/modules/test-util/deps.edn
@@ -2,6 +2,9 @@
  {blaze/anomaly
   {:local/root "../anomaly"}
 
+  blaze/byte-buffer
+  {:local/root "../byte-buffer"}
+
   blaze/executor
   {:local/root "../executor"}
 

--- a/modules/test-util/src/blaze/test_util.clj
+++ b/modules/test-util/src/blaze/test_util.clj
@@ -1,6 +1,7 @@
 (ns blaze.test-util
   (:require
     [blaze.anomaly :as ba]
+    [blaze.byte-buffer :as bb]
     [blaze.executors :as ex]
     [blaze.fhir.structure-definition-repo]
     [clojure.test :refer [is]]
@@ -8,7 +9,6 @@
     [integrant.core :as ig]
     [juxt.iota :refer [given]])
   (:import
-    [java.nio ByteBuffer]
     [java.time Clock Instant ZoneId]
     [java.util Arrays Random]
     [java.util.concurrent Executors TimeUnit]))
@@ -53,9 +53,9 @@
     (proxy [Random] []
       (nextBytes [byte-array]
         (assert (= 20 (count byte-array)))
-        (let [bb (ByteBuffer/wrap byte-array)]
-          (.position bb 12)
-          (.putLong bb (swap! state inc)))))))
+        (let [bb (bb/wrap byte-array)]
+          (bb/set-position! bb 12)
+          (bb/put-long! bb (swap! state inc)))))))
 
 
 (defmethod ig/init-key :blaze.test/executor


### PR DESCRIPTION
First, we need the ByteBuffer functions in various other modules. Second excluding the ByteBuffer tests from coverage for now because of extensive inlining has advantages.