### PR TITLE
Separate Deps Test Aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint-root:
 lint: $(MODULES) lint-root
 
 test-root:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test: $(MODULES) test-root
 

--- a/modules/anomaly/Makefile
+++ b/modules/anomaly/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/anomaly/deps.edn
+++ b/modules/anomaly/deps.edn
@@ -11,21 +11,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/async/Makefile
+++ b/modules/async/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/async/deps.edn
+++ b/modules/async/deps.edn
@@ -14,21 +14,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/byte-buffer/Makefile
+++ b/modules/byte-buffer/Makefile
@@ -2,7 +2,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
 	true

--- a/modules/byte-buffer/deps.edn
+++ b/modules/byte-buffer/deps.edn
@@ -8,9 +8,11 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}}}

--- a/modules/cassandra/Makefile
+++ b/modules/cassandra/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -21,26 +21,20 @@
    {blaze/test-util
     {:local/root "../test-util"}
 
-    lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
-
     org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+    {:mvn/version "0.1"}}}
+
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
                "-e" ".+spec"]}}}

--- a/modules/coll/Makefile
+++ b/modules/coll/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/coll/deps.edn
+++ b/modules/coll/deps.edn
@@ -3,18 +3,17 @@
 
  :aliases
  {:test
-  {:extra-paths ["test"]
+  {:extra-paths ["test"]}
 
-   :extra-deps
+  :kaocha
+  {:extra-deps
    {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
+  :coverage
+  {:extra-deps
    {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 

--- a/modules/cql/Makefile
+++ b/modules/cql/Makefile
@@ -9,10 +9,10 @@ cql-test:
 	sed -i.bak '277d' cql-test/CqlArithmeticFunctionsTest.xml
 
 test: cql-test
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage: cql-test
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache cql-test target

--- a/modules/cql/deps.edn
+++ b/modules/cql/deps.edn
@@ -36,26 +36,20 @@
    {blaze/db-stub
     {:local/root "../db-stub"}
 
-    lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
-
     org.clojure/data.xml
-    {:mvn/version "0.2.0-alpha6"}}
+    {:mvn/version "0.2.0-alpha6"}}}
+
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/db-stub
-    {:local/root "../db-stub"}
-
-    cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    org.clojure/data.xml
-    {:mvn/version "0.2.0-alpha6"}}
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
                "-e" ".*spec$"]}}}

--- a/modules/db-resource-store-cassandra/Makefile
+++ b/modules/db-resource-store-cassandra/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/db-resource-store-cassandra/deps.edn
+++ b/modules/db-resource-store-cassandra/deps.edn
@@ -20,21 +20,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/db-resource-store/Makefile
+++ b/modules/db-resource-store/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/db-resource-store/deps.edn
+++ b/modules/db-resource-store/deps.edn
@@ -28,26 +28,20 @@
     criterium/criterium
     {:mvn/version "0.4.6"}
 
-    lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
-
     mvxcvi/clj-cbor
-    {:mvn/version "1.1.0"}}
+    {:mvn/version "1.1.0"}}}
+
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    mvxcvi/clj-cbor
-    {:mvn/version "1.1.0"}}
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
                "-e" ".*-spec$"]}}}

--- a/modules/db-tx-log-kafka/Makefile
+++ b/modules/db-tx-log-kafka/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/db-tx-log-kafka/deps.edn
+++ b/modules/db-tx-log-kafka/deps.edn
@@ -23,21 +23,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/db-tx-log/Makefile
+++ b/modules/db-tx-log/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/db-tx-log/deps.edn
+++ b/modules/db-tx-log/deps.edn
@@ -17,21 +17,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test test-perf deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -46,9 +46,11 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
@@ -66,14 +68,9 @@
     org.openjdk.jol/jol-core
     {:mvn/version "0.16"}}}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"

--- a/modules/executor/Makefile
+++ b/modules/executor/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/executor/deps.edn
+++ b/modules/executor/deps.edn
@@ -3,22 +3,19 @@
   {:extra-paths ["test"]
 
    :extra-deps
-   {lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
+   {org.clojars.akiel/iota
+    {:mvn/version "0.1"}}}
 
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
+  :coverage
+  {:extra-deps
    {cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/extern-terminology-service/Makefile
+++ b/modules/extern-terminology-service/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/extern-terminology-service/deps.edn
+++ b/modules/extern-terminology-service/deps.edn
@@ -17,24 +17,18 @@
     {:local/root "../test-util"}
 
     com.pgs-soft/HttpClientMock
-    {:mvn/version "1.0.0"}
+    {:mvn/version "1.0.0"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    com.pgs-soft/HttpClientMock
-    {:mvn/version "1.0.0"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/fhir-client/Makefile
+++ b/modules/fhir-client/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/fhir-client/deps.edn
+++ b/modules/fhir-client/deps.edn
@@ -26,24 +26,18 @@
     {:local/root "../test-util"}
 
     com.pgs-soft/HttpClientMock
-    {:mvn/version "1.0.0"}
+    {:mvn/version "1.0.0"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    com.pgs-soft/HttpClientMock
-    {:mvn/version "1.0.0"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/fhir-path/Makefile
+++ b/modules/fhir-path/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/fhir-path/deps.edn
+++ b/modules/fhir-path/deps.edn
@@ -13,25 +13,19 @@
    {blaze/test-util
     {:local/root "../test-util"}
 
-    lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
-
     org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+    {:mvn/version "0.1"}}}
+
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/fhir-structure/Makefile
+++ b/modules/fhir-structure/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -49,14 +49,15 @@
     criterium/criterium
     {:mvn/version "0.4.6"}
 
-    lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
-
     org.openjdk.jol/jol-core
-    {:mvn/version "0.16"}}
+    {:mvn/version "0.16"}}}
 
-   :main-opts
-   ["-m" "kaocha.runner"]}
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
+
+   :main-opts ["-m" "kaocha.runner"]}
 
   :test-perf
   {:extra-paths ["test-perf"]
@@ -71,17 +72,9 @@
     org.openjdk.jol/jol-core
     {:mvn/version "0.16"}}}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    org.openjdk.jol/jol-core
-    {:mvn/version "0.16"}}
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/http-client/Makefile
+++ b/modules/http-client/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/http-client/deps.edn
+++ b/modules/http-client/deps.edn
@@ -11,21 +11,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/interaction/Makefile
+++ b/modules/interaction/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/interaction/deps.edn
+++ b/modules/interaction/deps.edn
@@ -23,21 +23,18 @@
 
    :extra-deps
    {blaze/db-stub
-    {:local/root "../db-stub"}
+    {:local/root "../db-stub"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/db-stub
-    {:local/root "../db-stub"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/jepsen/Makefile
+++ b/modules/jepsen/Makefile
@@ -2,7 +2,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
 	true

--- a/modules/jepsen/deps.edn
+++ b/modules/jepsen/deps.edn
@@ -7,9 +7,10 @@
 
  :aliases
  {:test
-  {:extra-paths ["test"]
+  {:extra-paths ["test"]}
 
-   :extra-deps
+  :kaocha
+  {:extra-deps
    {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 

--- a/modules/kv/Makefile
+++ b/modules/kv/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/kv/deps.edn
+++ b/modules/kv/deps.edn
@@ -14,21 +14,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"

--- a/modules/luid/Makefile
+++ b/modules/luid/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/luid/deps.edn
+++ b/modules/luid/deps.edn
@@ -10,11 +10,13 @@
   {:extra-paths ["test"]
 
    :extra-deps
-   {lambdaisland/kaocha
-    {:mvn/version "1.65.1029"}
+   {org.clojars.akiel/iota
+    {:mvn/version "0.1"}}}
 
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
+    {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
@@ -25,14 +27,9 @@
    {criterium/criterium
     {:mvn/version "0.4.6"}}}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
+  :coverage
+  {:extra-deps
    {cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    org.clojars.akiel/iota
-    {:mvn/version "0.1"}}
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/metrics/Makefile
+++ b/modules/metrics/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/metrics/deps.edn
+++ b/modules/metrics/deps.edn
@@ -11,21 +11,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"

--- a/modules/openid-auth/Makefile
+++ b/modules/openid-auth/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/openid-auth/deps.edn
+++ b/modules/openid-auth/deps.edn
@@ -20,24 +20,18 @@
     {:local/root "../test-util"}
 
     com.pgs-soft/HttpClientMock
-    {:mvn/version "1.0.0"}
+    {:mvn/version "1.0.0"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    com.pgs-soft/HttpClientMock
-    {:mvn/version "1.0.0"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/operation-measure-evaluate-measure/Makefile
+++ b/modules/operation-measure-evaluate-measure/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/operation-measure-evaluate-measure/deps.edn
+++ b/modules/operation-measure-evaluate-measure/deps.edn
@@ -29,21 +29,18 @@
 
    :extra-deps
    {blaze/db-stub
-    {:local/root "../db-stub"}
+    {:local/root "../db-stub"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/db-stub
-    {:local/root "../db-stub"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/page-store-cassandra/Makefile
+++ b/modules/page-store-cassandra/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/page-store-cassandra/deps.edn
+++ b/modules/page-store-cassandra/deps.edn
@@ -20,21 +20,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/page-store/Makefile
+++ b/modules/page-store/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/page-store/deps.edn
+++ b/modules/page-store/deps.edn
@@ -22,21 +22,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "dev" "-s" "test"]}}}

--- a/modules/rest-api/Makefile
+++ b/modules/rest-api/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/rest-api/deps.edn
+++ b/modules/rest-api/deps.edn
@@ -23,21 +23,18 @@
 
    :extra-deps
    {blaze/db-stub
-    {:local/root "../db-stub"}
+    {:local/root "../db-stub"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/db-stub
-    {:local/root "../db-stub"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"

--- a/modules/rest-util/Makefile
+++ b/modules/rest-util/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/rest-util/deps.edn
+++ b/modules/rest-util/deps.edn
@@ -27,21 +27,18 @@
 
    :extra-deps
    {blaze/db-stub
-    {:local/root "../db-stub"}
+    {:local/root "../db-stub"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/db-stub
-    {:local/root "../db-stub"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"

--- a/modules/rocksdb/Makefile
+++ b/modules/rocksdb/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/rocksdb/deps.edn
+++ b/modules/rocksdb/deps.edn
@@ -17,21 +17,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"

--- a/modules/scheduler/Makefile
+++ b/modules/scheduler/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/scheduler/deps.edn
+++ b/modules/scheduler/deps.edn
@@ -8,21 +8,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}

--- a/modules/server/Makefile
+++ b/modules/server/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/server/deps.edn
+++ b/modules/server/deps.edn
@@ -25,25 +25,19 @@
     {:local/root "../test-util"}
 
     hato/hato
-    {:mvn/version "0.8.2"}
+    {:mvn/version "0.8.2"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
-    {:mvn/version "1.2.3"}
-
-    hato/hato
-    {:mvn/version "0.8.2"}}
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
+    {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
                "-e" ".*spec$"]}}}

--- a/modules/thread-pool-executor-collector/Makefile
+++ b/modules/thread-pool-executor-collector/Makefile
@@ -2,10 +2,10 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 test:
-	clojure -M:test --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
-	clojure -M:test-coverage
+	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target

--- a/modules/thread-pool-executor-collector/deps.edn
+++ b/modules/thread-pool-executor-collector/deps.edn
@@ -11,21 +11,18 @@
 
    :extra-deps
    {blaze/test-util
-    {:local/root "../test-util"}
+    {:local/root "../test-util"}}}
 
-    lambdaisland/kaocha
+  :kaocha
+  {:extra-deps
+   {lambdaisland/kaocha
     {:mvn/version "1.65.1029"}}
 
    :main-opts ["-m" "kaocha.runner"]}
 
-  :test-coverage
-  {:extra-paths ["test"]
-
-   :extra-deps
-   {blaze/test-util
-    {:local/root "../test-util"}
-
-    cloverage/cloverage
+  :coverage
+  {:extra-deps
+   {cloverage/cloverage
     {:mvn/version "1.2.3"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}


### PR DESCRIPTION
Starting with version 1.12.3 Cursive does start the REPL in a way that is incompatible with the main-opts from Kaocha. So separating the aliases for :test and :kaocha was necessary. Furthermore I also removed the :test parts of :test-coverage which removed duplication.

See also: https://github.com/cursive-ide/cursive/issues/2322