### PR TITLE
Change Version of CodeQL Upload Sarif to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
         severity: 'CRITICAL,HIGH'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@codeql-bundle-20220401
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: trivy-results.sarif
 


### PR DESCRIPTION
The version 2 is more common as the special codeql-bundle-20220401.