### PR TITLE
Fix Server Errors Because of Unencoded Error Outputs

### DIFF
--- a/modules/rest-api/src/blaze/rest_api.clj
+++ b/modules/rest-api/src/blaze/rest_api.clj
@@ -80,7 +80,9 @@
   [{:keys [auth-backends] :as context}]
   (-> (reitit.ring/ring-handler
         (router context (capabilities/capabilities-handler context))
-        handler-util/default-handler
+        (reitit.ring/routes
+          (reitit.ring/redirect-trailing-slash-handler {:method :strip})
+          (output/wrap-output handler-util/default-handler {:accept-all? true}))
         {:middleware
          (cond-> [wrap-cors]
            (seq auth-backends)

--- a/modules/rest-api/src/blaze/rest_api/middleware/output.clj
+++ b/modules/rest-api/src/blaze/rest_api/middleware/output.clj
@@ -70,19 +70,21 @@
         :json)))
 
 
-(defn- encode-response [request response]
+(defn- encode-response [opts request response]
   (case (request-format request)
     :json (encode-response-json response)
     :xml (encode-response-xml response)
-    nil))
+    (when (:accept-all? opts) (dissoc response :body))))
 
 
-(defn- handle-response [request {:keys [body] :as response}]
-  (cond->> response body (encode-response request)))
+(defn- handle-response [opts request {:keys [body] :as response}]
+  (cond->> response body (encode-response opts request)))
 
 
 (defn wrap-output
   "Middleware to output resources in JSON or XML."
-  [handler]
-  (fn [request respond raise]
-    (handler request #(respond (handle-response request %)) raise)))
+  ([handler]
+   (wrap-output handler {}))
+  ([handler opts]
+   (fn [request respond raise]
+     (handler request #(respond (handle-response opts request %)) raise))))

--- a/modules/rest-api/test/blaze/rest_api_test.clj
+++ b/modules/rest-api/test/blaze/rest_api_test.clj
@@ -341,6 +341,34 @@
       [:headers "Access-Control-Allow-Methods"] := "GET,OPTIONS")))
 
 
+(deftest not-found-test
+  (with-system [{:blaze/keys [rest-api]} system]
+    (given (call rest-api {:request-method :get :uri "/foo"})
+      :status := 404
+      [:body fhir-spec/parse-json :resourceType] := "OperationOutcome"))
+
+  (testing "with text/html accept header"
+    (with-system [{:blaze/keys [rest-api]} system]
+      (given (call rest-api {:request-method :get :uri "/foo"
+                             :headers {"accept" "text/html"}})
+        :status := 404
+        :body := nil))))
+
+
+(deftest method-not-allowed-test
+  (with-system [{:blaze/keys [rest-api]} system]
+    (given (call rest-api {:request-method :put :uri "/metadata"})
+      :status := 405
+      [:body fhir-spec/parse-json :resourceType] := "OperationOutcome"))
+
+  (testing "with text/html accept header"
+    (with-system [{:blaze/keys [rest-api]} system]
+      (given (call rest-api {:request-method :put :uri "/metadata"
+                             :headers {"accept" "text/html"}})
+        :status := 405
+        :body := nil))))
+
+
 (deftest not-acceptable-test
   (with-system [{:blaze/keys [rest-api]} system]
     (given (call rest-api {:request-method :get :uri "/metadata"

--- a/modules/rest-util/src/blaze/handler/util.clj
+++ b/modules/rest-util/src/blaze/handler/util.clj
@@ -216,15 +216,10 @@
       (ring/status 405)))
 
 
-(defn not-acceptable-handler [_]
-  (ring/status 406))
-
-
 (def default-handler
   (reitit.ring/create-default-handler
     {:not-found not-found-handler
-     :method-not-allowed method-not-allowed-handler
-     :not-acceptable not-acceptable-handler}))
+     :method-not-allowed method-not-allowed-handler}))
 
 
 (defn method-not-allowed-batch-handler [request]

--- a/modules/rest-util/test/blaze/handler/util_test.clj
+++ b/modules/rest-util/test/blaze/handler/util_test.clj
@@ -90,12 +90,6 @@
     [:body :issue 0 :diagnostics] := "Method PUT not allowed on `/Patient` endpoint."))
 
 
-(deftest not-acceptable-handler-test
-  (given (handler-util/not-acceptable-handler {})
-    :status := 406
-    :body := nil))
-
-
 (deftest method-not-allowed-batch-handler-test
   (given-failed-future (handler-util/method-not-allowed-batch-handler
                          {:uri "/Patient/0" :request-method :post})


### PR DESCRIPTION
This problem was introduced in v0.17.1. Versions of Blaze before v0.17.1 are not effected.

HTTP Error Outputs with status codes 404 and 405 were not encoded to either JSON or XML, leading to an error in Jersey, leading to a 500.

This commit also introduces redirecting requests including a leading slash to ones without one.