### PR TITLE
Reorder XML Conformer Steps

### DIFF
--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -403,7 +403,7 @@
 
 (defn- remap-choice-conformer-form
   "Creates a conformer form which removes the type suffix of keys on conforming
-  and adds it back on unforming."
+  and adds it back on uniforming."
   [[internal-key child-spec-defs]]
   `(s/conformer
      (fn [~'m]
@@ -499,8 +499,8 @@
 (defn conform-xml
   "First step in conforming an XML `element` into the internal form.
 
-  Builds a map from child tags to either vector of childs or single-valued
-  childs."
+  Builds a map from child tags to either vector of children or single-valued
+  children."
   {:arglists '([element])}
   [{:keys [attrs content]}]
   (transduce
@@ -583,8 +583,8 @@
 (defn- special-xml-schema-spec-form [kind type-name child-spec-defs]
   (let [constructor-sym (symbol "blaze.fhir.spec.type" (str "map->" type-name))
         constructor (resolve constructor-sym)]
-    (conj (seq (remap-choice-conformer-forms child-spec-defs))
-          `(s/conformer ~constructor identity)
+    (conj (seq (conj (remap-choice-conformer-forms child-spec-defs)
+                     `(s/conformer ~constructor identity)))
           (schema-spec-form :xml child-spec-defs)
           `(s/conformer conform-xml
                         ~(xml-unformer kind (keyword type-name) child-spec-defs))

--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -1196,22 +1196,33 @@
         {:url "foo" :valueCode "bar"}
         #fhir/Extension{:url "foo" :value #fhir/code"bar"}
 
-        {:url "foo" :valueReference {}}
-        #fhir/Extension{:url "foo" :value #fhir/Reference{}}
+        {:url "foo" :valueReference {:reference "bar"}}
+        #fhir/Extension{:url "foo" :value #fhir/Reference{:reference "bar"}}
 
-        {:url "foo" :valueCodeableConcept {}}
-        #fhir/Extension{:url "foo" :value #fhir/CodeableConcept{}}))
+        {:url "foo" :valueCodeableConcept {:text "bar"}}
+        #fhir/Extension{:url "foo" :value #fhir/CodeableConcept{:text "bar"}}))
+
+    (testing "XML"
+      (are [xml fhir] (= fhir (s2/conform :fhir.xml/Extension xml))
+        (sexp [nil {:url "foo"} [::f/valueCode {:value "bar"}]])
+        #fhir/Extension{:url "foo" :value #fhir/code"bar"}
+
+        (sexp [nil {:url "foo"} [::f/valueReference {} [::f/reference {:value "bar"}]]])
+        #fhir/Extension{:url "foo" :value #fhir/Reference{:reference "bar"}}
+
+        (sexp [nil {:url "foo"} [::f/valueCodeableConcept {} [::f/text {:value "bar"}]]])
+        #fhir/Extension{:url "foo" :value #fhir/CodeableConcept{:text "bar"}}))
 
     (testing "CBOR"
       (are [json fhir] (= fhir (s2/conform :fhir.cbor/Extension json))
         {:url "foo" :valueCode "bar"}
         #fhir/Extension{:url "foo" :value #fhir/code"bar"}
 
-        {:url "foo" :valueReference {}}
-        #fhir/Extension{:url "foo" :value #fhir/Reference{}}
+        {:url "foo" :valueReference {:reference "bar"}}
+        #fhir/Extension{:url "foo" :value #fhir/Reference{:reference "bar"}}
 
-        {:url "foo" :valueCodeableConcept {}}
-        #fhir/Extension{:url "foo" :value #fhir/CodeableConcept{}})))
+        {:url "foo" :valueCodeableConcept {:text "bar"}}
+        #fhir/Extension{:url "foo" :value #fhir/CodeableConcept{:text "bar"}})))
 
   (testing "conformed instance size"
     (testing "JSON"


### PR DESCRIPTION
I like to have the constructor conformer last, because otherwise the record will be updated, which might be slower than updating a map.

Also added some tests regarding conforming extensions.