### PR TITLE
Improve Interning of Complex Types

### DIFF
--- a/docs/performance/fhir-search.md
+++ b/docs/performance/fhir-search.md
@@ -29,9 +29,9 @@ time curl -s "http://localhost:8080/fhir/Observation?code=http://loinc.org|$CODE
 | EPYC 7543P  |      128 |             4 |                1 |        29 M |           28 M | 17861-6 |  171 k |    0.152 |
 | EPYC 7543P  |      128 |             4 |                1 |        29 M |           28 M | 39156-5 |  967 k |    0.804 |
 | EPYC 7543P  |      128 |             4 |                1 |        29 M |           28 M | 29463-7 |  1.3 M |    1.088 |
-| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 17861-6 |  1.7 M |    1.472 |
-| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 39156-5 |  9.7 M |    8.690 |
-| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 29463-7 |   13 M |   11.410 |
+| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 17861-6 |  1.7 M |    1.304 |
+| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 39156-5 |  9.7 M |    7.768 |
+| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 29463-7 |   13 M |    9.954 |
 
 According to the measurements the time needed by Blaze to count resources only depends on the number of hits and equals roughly in **1 second per 1 million hits**.
 
@@ -56,9 +56,9 @@ blazectl download --server http://localhost:8080/fhir Observation -q "code=http:
 | EPYC 7543P  |      128 |             4 |                1 |        29 M |           28 M | 17861-6 |  171 k |    4.178 |
 | EPYC 7543P  |      128 |             4 |                1 |        29 M |           28 M | 39156-5 |  967 k |   24.492 |
 | EPYC 7543P  |      128 |             4 |                1 |        29 M |           28 M | 29463-7 |  1.3 M |   32.126 |
-| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 17861-6 |  1.7 M |   42.364 |
-| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 39156-5 |  9.7 M |  239.338 |
-| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 29463-7 |   13 M |  322.330 |
+| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 17861-6 |  1.7 M |   44.994 |
+| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 39156-5 |  9.7 M |  252.942 |
+| EPYC 7543P  |      128 |            30 |               10 |       292 M |          278 M | 29463-7 |   13 M |  343.950 |
 
 According to the measurements the time needed by Blaze to deliver resources only depends on the number of hits and equals roughly in **30 seconds per 1 million hits**.
 

--- a/modules/db-resource-store/test/blaze/db/resource_store/cbor_test.clj
+++ b/modules/db-resource-store/test/blaze/db/resource_store/cbor_test.clj
@@ -141,7 +141,7 @@
      #fhir/Quantity
          {:code #fhir/code"kg/m2"
           :system #fhir/uri"http://unitsofmeasure.org"
-          :unit "kg/m2"
+          :unit #fhir/string"kg/m2"
           :value 36.6M}
      :status #fhir/code"final"
      :effective #fhir/dateTime"2005-06-17"

--- a/modules/db-stub/src/blaze/db/api_stub.clj
+++ b/modules/db-stub/src/blaze/db/api_stub.clj
@@ -16,7 +16,8 @@
     [blaze.db.tx-log.local]
     [blaze.fhir.structure-definition-repo]
     [blaze.test-util :refer [with-system]]
-    [integrant.core :as ig]))
+    [integrant.core :as ig]
+    [java-time :as time]))
 
 
 (defn create-mem-node-system [node-config]
@@ -29,7 +30,8 @@
       :resource-store (ig/ref ::rs/kv)
       :kv-store (ig/ref :blaze.db/index-kv-store)
       :resource-indexer (ig/ref :blaze.db.node/resource-indexer)
-      :search-param-registry (ig/ref :blaze.db/search-param-registry)}
+      :search-param-registry (ig/ref :blaze.db/search-param-registry)
+      :poll-timeout (time/millis 10)}
      node-config)
 
    ::tx-log/local

--- a/modules/db/test-perf/blaze/db/api_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/api_test_perf.clj
@@ -107,7 +107,7 @@
   ([version id]
    [:put {:fhir/type :fhir/Observation :id (str id)
           :subject #fhir/Reference{:reference "Patient/0"}
-          :method (type/map->CodeableConcept {:text (str version)})
+          :method (type/codeable-concept {:text (type/string (str version))})
           :code
           #fhir/CodeableConcept
               {:coding

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -1765,7 +1765,7 @@
                :value
                #fhir/Quantity
                        {:value 0M
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :code #fhir/code"kg/m2"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
         [:put {:fhir/type :fhir/Observation
@@ -1775,7 +1775,7 @@
                :value
                #fhir/Quantity
                        {:value 1M
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :code #fhir/code"kg/m2"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
         [:put {:fhir/type :fhir/Observation
@@ -1784,7 +1784,7 @@
                :value
                #fhir/Quantity
                        {:value 2.11M
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :code #fhir/code"kg/m2"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
         [:put {:fhir/type :fhir/Observation
@@ -1793,7 +1793,7 @@
                :value
                #fhir/Quantity
                        {:value 3M
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :code #fhir/code"kg/m2"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]]]
 
@@ -2132,7 +2132,7 @@
                :value
                #fhir/Quantity
                        {:value 23.42M
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :code #fhir/code"kg/m2"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
         [:put {:fhir/type :fhir/Observation
@@ -2141,7 +2141,7 @@
                :value
                #fhir/Quantity
                        {:value 23.42M
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :code #fhir/code"kg/m2"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]]]
 
@@ -2165,7 +2165,7 @@
                :value
                #fhir/Quantity
                        {:value 0M
-                        :unit "m"
+                        :unit #fhir/string"m"
                         :code #fhir/code"m"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
         [:put {:fhir/type :fhir/TestScript
@@ -2175,7 +2175,7 @@
                  :value
                  #fhir/Quantity
                          {:value 0M
-                          :unit "m"
+                          :unit #fhir/string"m"
                           :code #fhir/code"m"
                           :system #fhir/uri"http://unitsofmeasure.org"}}]}]]]
 
@@ -3425,7 +3425,7 @@
                :value
                #fhir/Quantity
                        {:code #fhir/code"kg/m2"
-                        :unit "kg/m²"
+                        :unit #fhir/string"kg/m²"
                         :system #fhir/uri"http://unitsofmeasure.org"
                         :value 42M}}]]]
 

--- a/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
@@ -213,7 +213,7 @@
                :value
                #fhir/Quantity
                        {:value 140M
-                        :unit "mmHg"}}
+                        :unit #fhir/string"mmHg"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3]]
               (search-param/index-entries
@@ -260,7 +260,7 @@
                :value
                #fhir/Quantity
                        {:value 120M
-                        :unit "mm[Hg]"
+                        :unit #fhir/string"mm[Hg]"
                         :code #fhir/code"mm[Hg]"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3]]
@@ -308,7 +308,7 @@
                :value
                #fhir/Quantity
                        {:value 120M
-                        :unit "mmHg"
+                        :unit #fhir/string"mmHg"
                         :code #fhir/code"mm[Hg]"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]

--- a/modules/fhir-structure/resources/data_readers.clj
+++ b/modules/fhir-structure/resources/data_readers.clj
@@ -1,5 +1,6 @@
 {blaze/hash blaze.fhir.hash/from-hex
  blaze/hash-prefix blaze.fhir.hash/prefix-from-hex
+ blaze/field-name blaze.fhir.spec.type.json/field-name
  fhir/boolean blaze.fhir.spec.type/boolean
  fhir/integer blaze.fhir.spec.type/integer
  fhir/long blaze.fhir.spec.type/long
@@ -21,17 +22,17 @@
  fhir/positiveInt blaze.fhir.spec.type/positiveInt
  fhir/uuid blaze.fhir.spec.type/uuid
  fhir/xhtml blaze.fhir.spec.type/->Xhtml
- fhir/Attachment blaze.fhir.spec.type/map->Attachment
+ fhir/Attachment blaze.fhir.spec.type/attachment
  fhir/Extension blaze.fhir.spec.type/extension
  fhir/Coding blaze.fhir.spec.type/coding
  fhir/CodeableConcept blaze.fhir.spec.type/codeable-concept
- fhir/Quantity blaze.fhir.spec.type/map->Quantity
- fhir/Period blaze.fhir.spec.type/map->Period
- fhir/Identifier blaze.fhir.spec.type/map->Identifier
- fhir/HumanName blaze.fhir.spec.type/map->HumanName
- fhir/Address blaze.fhir.spec.type/map->Address
- fhir/Reference blaze.fhir.spec.type/map->Reference
- fhir/Meta blaze.fhir.spec.type/mk-meta
- fhir/BundleEntrySearch blaze.fhir.spec.type/map->BundleEntrySearch
+ fhir/Quantity blaze.fhir.spec.type/quantity
+ fhir/Period blaze.fhir.spec.type/period
+ fhir/Identifier blaze.fhir.spec.type/identifier
+ fhir/HumanName blaze.fhir.spec.type/human-name
+ fhir/Address blaze.fhir.spec.type/address
+ fhir/Reference blaze.fhir.spec.type/reference
+ fhir/Meta blaze.fhir.spec.type/meta
+ fhir/BundleEntrySearch blaze.fhir.spec.type/bundle-entry-search
  system/date blaze.fhir.spec.type.system/parse-date
  system/date-time blaze.fhir.spec.type.system/parse-date-time}

--- a/modules/fhir-structure/src/blaze/fhir/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec.clj
@@ -82,11 +82,11 @@
 
 
 (defn unform-json
-  "Returns the JSON representation of `resource`."
-  [resource]
-  (let [key (transform-type-key (type/type resource) "json")]
+  "Returns the JSON representation of `x` as byte array."
+  [x]
+  (let [key (transform-type-key (type/type x) "json")]
     (if-let [spec (s2/get-spec key)]
-      (j/write-value-as-bytes (s2/unform spec resource) json-object-mapper)
+      (j/write-value-as-bytes (s2/unform spec x) json-object-mapper)
       (throw (ex-info (format "Missing spec: %s" key) {:key key})))))
 
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl/specs.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl/specs.clj
@@ -22,7 +22,7 @@
     (reify
       sp/Spec
       (conform* [_ x _ _]
-        (if (and (string? x) (re-matches pattern x))
+        (if (and (string? x) (.matches (re-matcher pattern x)))
           (f x)
           ::s/invalid))
       (unform* [_ x] x)
@@ -66,7 +66,7 @@
       sp/Spec
       (conform* [_ x _ _]
         (cond
-          (and (string? x) (re-matches pattern x)) (f x)
+          (and (string? x) (.matches (re-matcher pattern x))) (f x)
 
           (map? x)
           (let [conformed (s/conform @extended-spec x)]
@@ -261,7 +261,7 @@
         (if (map? x)
           (let [res (reduce-kv
                       (fn [ret k v]
-                        (if-let [conformed (when-let [sp (@specs k)] (sp/conform* sp v k settings))]
+                        (if-some [conformed (when-let [sp (@specs k)] (sp/conform* sp v k settings))]
                           (if (s/invalid? conformed)
                             (reduced ::s/invalid)
                             (assoc ret (internal-key k) conformed))

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl/util.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl/util.clj
@@ -4,14 +4,38 @@
     [clojure.string :as str]))
 
 
+(defn- assoc-value [v m]
+  (if (nil? v) m (if m (assoc m :value v) v)))
+
+
+(defn- assoc-values [vs ms]
+  (loop [[v & vs] vs
+         [m & ms] ms
+         ret []]
+    (if (or v m)
+      (recur vs ms (conj ret (assoc-value v m)))
+      ret)))
+
+
+(defn- trim-underscore [k]
+  (keyword (subs (name k) 1)))
+
+
 (defn update-extended-primitives [x]
   (if (map? x)
     (reduce-kv
       (fn [ret k v]
         (if (str/starts-with? (name k) "_")
-          (if (map? v)
-            (-> (update ret (keyword (subs (name k) 1)) (partial assoc v :value))
+          (cond
+            (map? v)
+            (-> (update ret (trim-underscore k) assoc-value v)
                 (dissoc k))
+
+            (vector? v)
+            (-> (update ret (trim-underscore k) assoc-values v)
+                (dissoc k))
+
+            :else
             (dissoc ret k))
           ret))
       x

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl/xml.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl/xml.clj
@@ -1,0 +1,38 @@
+(ns blaze.fhir.spec.impl.xml
+  (:require
+    [blaze.fhir.spec.type :as type]
+    [clojure.alpha.spec :as s]
+    [clojure.data.xml.name :as xml-name])
+  (:import
+    [clojure.data.xml.node Element]))
+
+
+(xml-name/alias-uri 'f "http://hl7.org/fhir")
+
+
+(defn element? [x]
+  (instance? Element x))
+
+
+(defn value-matches?
+  {:arglists '([regex element])}
+  [regex {{:keys [value] :as attrs} :attrs content :content}]
+  (or (and (string? value) (.matches (re-matcher regex value)))
+      (or (some? (:id attrs)) (seq content))))
+
+
+(defn set-extension-tag [element]
+  (some-> element (update :content (partial map #(assoc % :tag ::f/extension)))))
+
+
+(defn remove-character-content [element]
+  (update element :content (partial filter element?)))
+
+
+(defn primitive-xml-form [regex constructor]
+  `(s/and
+     element?
+     (fn [~'e] (value-matches? ~regex ~'e))
+     (s/conformer remove-character-content set-extension-tag)
+     (s/schema {:content (s/coll-of :fhir.xml/Extension)})
+     (s/conformer ~constructor type/to-xml)))

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl_spec.clj
@@ -1,14 +1,7 @@
 (ns blaze.fhir.spec.impl-spec
   (:require
     [blaze.fhir.spec.impl :as impl]
-    [clojure.spec.alpha :as s])
-  (:import
-    [java.util.regex Pattern]))
-
-
-(s/fdef impl/xml-value-matches?
-  :args (s/cat :regex #(instance? Pattern %) :element impl/element?)
-  :ret boolean?)
+    [clojure.spec.alpha :as s]))
 
 
 (s/fdef impl/primitive-type->spec-defs

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -1,9 +1,10 @@
 (ns blaze.fhir.spec.type
   (:refer-clojure
     :exclude
-    [boolean boolean? decimal? integer? long string? time type uri? uuid?])
+    [boolean boolean? decimal? integer? long meta string? time type uri? uuid?])
   (:require
     [blaze.fhir.spec.impl.intern :as intern]
+    [blaze.fhir.spec.type.json :as json]
     [blaze.fhir.spec.type.macros :as macros
      :refer [def-complex-type def-primitive-type defextended]]
     [blaze.fhir.spec.type.protocols :as p]
@@ -16,7 +17,7 @@
   (:import
     [blaze.fhir.spec.type.system
      DateTimeYear DateTimeYearMonth DateTimeYearMonthDay]
-    [clojure.lang IPersistentMap Keyword]
+    [clojure.lang IPersistentMap Keyword PersistentVector]
     [com.fasterxml.jackson.core JsonGenerator]
     [com.fasterxml.jackson.databind.module SimpleModule]
     [com.fasterxml.jackson.databind.ser.std StdSerializer]
@@ -44,7 +45,8 @@
 
 
 (defn value
-  "Returns the possible value of the primitive value `x` as FHIRPath system type."
+  "Returns the possible value of the primitive value `x` as FHIRPath system
+  type."
   [x]
   (p/-value x))
 
@@ -93,8 +95,10 @@
   (-type [_])
   (-interned [_] true)
   (-value [_])
+  (-has-primary-content [_] false)
   (-serialize-json [_ _ _])
-  (-serialize-json-as-field [_ _ _ _])
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ _ _])
   (-to-xml [_])
   (-hash-into [_ _])
   (-references [_]))
@@ -119,10 +123,12 @@
   (-type [_] :fhir/boolean)
   (-interned [_] true)
   (-value [b] b)
-  (-serialize-json [b generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [b generator]
     (.writeBoolean ^JsonGenerator generator b))
-  (-serialize-json-as-field [b field-name generator _]
-    (.writeBooleanField ^JsonGenerator generator field-name b))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [b]
     (xml-node/element nil {:value (str b)}))
   (-hash-into [b sink]
@@ -165,7 +171,7 @@
 
 
 (defn boolean? [x]
-  (identical? :fhir/boolean (p/-type x)))
+  (identical? :fhir/boolean (type x)))
 
 
 
@@ -176,10 +182,12 @@
   (-type [_] :fhir/integer)
   (-interned [_] false)
   (-value [i] i)
-  (-serialize-json [i generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [i generator]
     (.writeNumber ^JsonGenerator generator i))
-  (-serialize-json-as-field [i field-name generator _]
-    (.writeNumberField ^JsonGenerator generator ^String field-name i))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [i]
     (xml-node/element nil {:value (str i)}))
   (-hash-into [i sink]
@@ -210,7 +218,7 @@
 
 
 (defn integer? [x]
-  (identical? :fhir/integer (p/-type x)))
+  (identical? :fhir/integer (type x)))
 
 
 
@@ -221,10 +229,12 @@
   (-type [_] :fhir/long)
   (-interned [_] false)
   (-value [l] l)
-  (-serialize-json [l generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [l generator]
     (.writeNumber ^JsonGenerator generator (clojure.core/long l)))
-  (-serialize-json-as-field [l field-name generator _]
-    (.writeNumberField ^JsonGenerator generator ^String field-name (clojure.core/long l)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [l]
     (xml-node/element nil {:value (str l)}))
   (-hash-into [l sink]
@@ -255,7 +265,7 @@
 
 
 (defn long? [x]
-  (identical? :fhir/long (p/-type x)))
+  (identical? :fhir/long (type x)))
 
 
 
@@ -266,10 +276,12 @@
   (-type [_] :fhir/string)
   (-interned [_] false)
   (-value [s] s)
-  (-serialize-json [s generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [s generator]
     (.writeString ^JsonGenerator generator s))
-  (-serialize-json-as-field [s field-name generator _]
-    (.writeStringField ^JsonGenerator generator field-name s))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [s]
     (xml-node/element nil {:value (str s)}))
   (-hash-into [s sink]
@@ -298,8 +310,29 @@
       (string value))))
 
 
+(def ^{:arglists '([x])} intern-string
+  (let [intern (intern/intern-value identity)
+        intern-extended (intern/intern-value map->ExtendedString)]
+    (fn [x]
+      (if (map? x)
+        (let [{:keys [id extension value]} x]
+          (if (and (p/-interned extension) (nil? id))
+            (intern-extended {:extension extension :value value})
+            (->ExtendedString id extension value)))
+        (intern x)))))
+
+
+(defn xml->InternedString
+  {:arglists '([element])}
+  [{{:keys [id value]} :attrs content :content}]
+  (let [extension (seq content)]
+    (if (or id extension)
+      (intern-string {:id id :extension extension :value value})
+      (intern-string value))))
+
+
 (defn string? [x]
-  (identical? :fhir/string (p/-type x)))
+  (identical? :fhir/string (type x)))
 
 
 
@@ -310,10 +343,12 @@
   (-type [_] :fhir/decimal)
   (-interned [_] false)
   (-value [d] d)
-  (-serialize-json [d generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [d generator]
     (.writeNumber ^JsonGenerator generator d))
-  (-serialize-json-as-field [d field-name generator _]
-    (.writeNumberField ^JsonGenerator generator ^String field-name d))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [d]
     (xml-node/element nil {:value (str d)}))
   (-hash-into [d sink]
@@ -344,7 +379,7 @@
 
 
 (defn decimal? [x]
-  (identical? :fhir/decimal (p/-type x)))
+  (identical? :fhir/decimal (type x)))
 
 
 
@@ -355,7 +390,7 @@
 (declare xml->Uri)
 
 
-(def-primitive-type Uri [value] :hash-num 5 :interned true)
+(def-primitive-type Uri [^String value] :hash-num 5 :interned true)
 
 
 
@@ -379,7 +414,7 @@
 (declare xml->Canonical)
 
 
-(def-primitive-type Canonical [value] :hash-num 7 :interned true)
+(def-primitive-type Canonical [^String value] :hash-num 7 :interned true)
 
 
 
@@ -410,11 +445,12 @@
   (-type [_] :fhir/instant)
   (-interned [_] false)
   (-value [_] value)
-  (-serialize-json-as-field [_ field-name generator _]
-    (.writeStringField ^JsonGenerator generator ^String field-name
-                       (system/-to-string value)))
-  (-serialize-json [_ generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [_ generator]
     (.writeString ^JsonGenerator generator ^String (system/-to-string value)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [_]
     (system-to-xml value))
   (-hash-into [_ sink]
@@ -451,23 +487,24 @@
   (-type [_] :fhir/instant)
   (-interned [_] false)
   (-value [instant] (.atOffset instant ZoneOffset/UTC))
-  (-serialize-json-as-field [instant field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [instant generator]
     (.writeString ^JsonGenerator generator (str instant)))
-  (-serialize-json [instant generator _]
-    (.writeString ^JsonGenerator generator (str instant)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [instant]
     (xml-node/element nil {:value (str instant)}))
   (-hash-into [instant sink]
     (doto ^PrimitiveSink sink
       (.putByte (byte 9))                                   ; :fhir/instant
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into (p/-value instant) sink))
+    (system/-hash-into (value instant) sink))
   (-references [_]))
 
 
-(defextended ExtendedInstant [id extension value]
-  :fhir-type :fhir/instant :hash-num 9)
+(defextended ExtendedInstant [id extension ^Instant value]
+  :fhir-type :fhir/instant :hash-num 9 :value-form (.atOffset value ZoneOffset/UTC))
 
 
 (defn- parse-instant-value [value]
@@ -512,7 +549,7 @@
 
 
 (defn instant? [x]
-  (identical? :fhir/instant (p/-type x)))
+  (identical? :fhir/instant (type x)))
 
 
 
@@ -523,11 +560,12 @@
   (-type [_] :fhir/date)
   (-interned [_] false)
   (-value [date] date)
-  (-serialize-json-as-field [date field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [date generator]
     (.writeString ^JsonGenerator generator (str date)))
-  (-serialize-json [date generator _]
-    (.writeString ^JsonGenerator generator (str date)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [date]
     (xml-node/element nil {:value (str date)}))
   (-hash-into [date sink]
@@ -541,11 +579,12 @@
   (-type [_] :fhir/date)
   (-interned [_] false)
   (-value [date] date)
-  (-serialize-json-as-field [date field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [date generator]
     (.writeString ^JsonGenerator generator (str date)))
-  (-serialize-json [date generator _]
-    (.writeString ^JsonGenerator generator (str date)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [date]
     (xml-node/element nil {:value (str date)}))
   (-hash-into [date sink]
@@ -559,11 +598,12 @@
   (-type [_] :fhir/date)
   (-interned [_] false)
   (-value [date] date)
-  (-serialize-json-as-field [date field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [date generator]
     (.writeString ^JsonGenerator generator (str date)))
-  (-serialize-json [date generator _]
-    (.writeString ^JsonGenerator generator (str date)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [date]
     (xml-node/element nil {:value (str date)}))
   (-hash-into [date sink]
@@ -618,7 +658,7 @@
 
 
 (defn date? [x]
-  (identical? :fhir/date (p/-type x)))
+  (identical? :fhir/date (type x)))
 
 
 (defprotocol ConvertToDateTime
@@ -639,11 +679,12 @@
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
   (-value [year] year)
-  (-serialize-json-as-field [year field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [year generator]
     (.writeString ^JsonGenerator generator (str year)))
-  (-serialize-json [year generator _]
-    (.writeString ^JsonGenerator generator (str year)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [year]
     (xml-node/element nil {:value (str year)}))
   (-hash-into [year sink]
@@ -657,11 +698,12 @@
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
   (-value [year-month] year-month)
-  (-serialize-json-as-field [year-month field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [year-month generator]
     (.writeString ^JsonGenerator generator (str year-month)))
-  (-serialize-json [year-month generator _]
-    (.writeString ^JsonGenerator generator (str year-month)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [year-month]
     (xml-node/element nil {:value (str year-month)}))
   (-hash-into [year-month sink]
@@ -675,11 +717,12 @@
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
   (-value [year-month-day] year-month-day)
-  (-serialize-json-as-field [year-month-day field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [year-month-day generator]
     (.writeString ^JsonGenerator generator (str year-month-day)))
-  (-serialize-json [year-month-day generator _]
-    (.writeString ^JsonGenerator generator (str year-month-day)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [year-month-day]
     (xml-node/element nil {:value (str year-month-day)}))
   (-hash-into [year-month-day sink]
@@ -695,11 +738,12 @@
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
   (-value [date-time] date-time)
-  (-serialize-json-as-field [date-time field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [date-time generator]
     (.writeString ^JsonGenerator generator ^String (system/-to-string date-time)))
-  (-serialize-json [date-time generator _]
-    (.writeString ^JsonGenerator generator ^String (system/-to-string date-time)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [date-time]
     (system-to-xml date-time))
   (-hash-into [date-time sink]
@@ -713,11 +757,12 @@
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
   (-value [date-time] date-time)
-  (-serialize-json-as-field [date-time field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [date-time generator]
     (.writeString ^JsonGenerator generator ^String (system/-to-string date-time)))
-  (-serialize-json [date-time generator _]
-    (.writeString ^JsonGenerator generator ^String (system/-to-string date-time)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [date-time]
     (system-to-xml date-time))
   (-hash-into [date-time sink]
@@ -772,7 +817,7 @@
 
 
 (defn dateTime? [x]
-  (identical? :fhir/dateTime (p/-type x)))
+  (identical? :fhir/dateTime (type x)))
 
 
 
@@ -783,11 +828,12 @@
   (-type [_] :fhir/time)
   (-interned [_] false)
   (-value [time] time)
-  (-serialize-json-as-field [time field-name generator _]
-    (.writeStringField ^JsonGenerator generator ^String field-name
-                       (system/-to-string time)))
-  (-serialize-json [time generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [time generator]
     (.writeString ^JsonGenerator generator ^String (system/-to-string time)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [time]
     (system-to-xml time))
   (-hash-into [time sink]
@@ -834,7 +880,7 @@
 
 
 (defn time? [x]
-  (identical? :fhir/time (p/-type x)))
+  (identical? :fhir/time (type x)))
 
 
 
@@ -844,7 +890,8 @@
 (declare code)
 (declare xml->Code)
 
-(def-primitive-type Code [value] :hash-num 13 :interned true)
+
+(def-primitive-type Code [^String value] :hash-num 13 :interned true)
 
 
 
@@ -909,11 +956,12 @@
   (-type [_] :fhir/uuid)
   (-interned [_] false)
   (-value [uuid] (str "urn:uuid:" uuid))
-  (-serialize-json-as-field [uuid field-name generator _]
-    (.writeStringField ^JsonGenerator generator ^String field-name
-                       (str "urn:uuid:" uuid)))
-  (-serialize-json [uuid generator _]
+  (-has-primary-content [_] true)
+  (-serialize-json [uuid generator]
     (.writeString ^JsonGenerator generator (str "urn:uuid:" uuid)))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [uuid]
     (xml-node/element nil {:value (str "urn:uuid:" uuid)}))
   (-hash-into [uuid sink]
@@ -926,7 +974,7 @@
 
 
 (defextended ExtendedUuid [id extension ^UUID value]
-  :fhir-type :fhir/uuid :hash-num 19)
+  :fhir-type :fhir/uuid :hash-num 19 :value-form (str "urn:uuid:" value))
 
 
 (def ^{:arglists '([x])} uuid
@@ -944,7 +992,7 @@
 
 
 (defn uuid? [x]
-  (identical? :fhir/uuid (p/-type x)))
+  (identical? :fhir/uuid (type x)))
 
 
 
@@ -955,11 +1003,12 @@
   (-type [_] :fhir/xhtml)
   (-interned [_] false)
   (-value [_] value)
-  (-serialize-json-as-field [_ field-name generator _]
-    (.writeFieldName ^JsonGenerator generator ^String field-name)
+  (-has-primary-content [_] true)
+  (-serialize-json [_ generator]
     (.writeString ^JsonGenerator generator ^String value))
-  (-serialize-json [_ generator _]
-    (.writeString ^JsonGenerator generator ^String value))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [_ generator]
+    (.writeNull ^JsonGenerator generator))
   (-to-xml [_] (update (xml/parse-str value) :attrs assoc :xmlns "http://www.w3.org/1999/xhtml"))
   (-hash-into [_ sink]
     (doto ^PrimitiveSink sink
@@ -978,7 +1027,7 @@
 
 (defmethod print-method Xhtml [xhtml ^Writer w]
   (.write w "#fhir/xhtml\"")
-  (.write w ^String (p/-value xhtml))
+  (.write w ^String (value xhtml))
   (.write w "\""))
 
 
@@ -1000,21 +1049,28 @@
 ;; ---- Complex Types --------------------------------------------------------
 
 (extend-protocol p/FhirType
-  List
+  PersistentVector
   (-type [_])
   (-interned [xs]
-    (every? p/-interned xs))
+    (.reduce xs #(if (p/-interned %2) %1 (reduced false)) true))
   (-value [_])
-  (-serialize-json-as-field [xs field-name generator provider]
-    (.writeArrayFieldStart ^JsonGenerator generator field-name)
-    (dotimes [i (.size xs)]
-      (p/-serialize-json (.get xs i) generator provider))
+  (-has-primary-content [xs]
+    (.reduce xs #(when (p/-has-primary-content %2) (reduced true)) nil))
+  (-serialize-json [xs generator]
+    (.writeStartArray ^JsonGenerator generator)
+    (.reduce xs #(p/-serialize-json %2 generator) nil)
+    (.writeEndArray ^JsonGenerator generator))
+  (-has-secondary-content [xs]
+    (.reduce xs #(when (p/-has-secondary-content %2) (reduced true)) nil))
+  (-serialize-json-secondary [xs generator]
+    (.writeStartArray ^JsonGenerator generator)
+    (.reduce xs #(p/-serialize-json-secondary %2 generator) nil)
     (.writeEndArray ^JsonGenerator generator))
   (-hash-into [xs sink]
     (.putByte ^PrimitiveSink sink (byte 36))
-    (run! #(p/-hash-into % sink) xs))
+    (.reduce xs #(p/-hash-into %2 sink) nil))
   (-references [xs]
-    (transduce (mapcat p/-references) conj [] xs))
+    (.reduce xs #(into %1 (p/-references %2)) []))
   Keyword
   (-type [_])
   (-value [_])
@@ -1026,22 +1082,19 @@
     (.valAt m :fhir/type))
   (-interned [_] false)
   (-value [_])
-  (-serialize-json [m generator provider]
+  (-has-primary-content [_] true)
+  (-serialize-json [m generator]
     (.writeStartObject ^JsonGenerator generator)
     (run!
       #(let [key (key %)]
          (when-not (identical? :fhir/type key)
-           (p/-serialize-json-as-field (val %) (name key) generator provider)))
+           (when-some [v (val %)]
+             (json/write-field generator (json/field-name (name key)) v))))
       m)
     (.writeEndObject ^JsonGenerator generator))
-  (-serialize-json-as-field [m field-name generator provider]
-    (.writeObjectFieldStart ^JsonGenerator generator field-name)
-    (run!
-      #(let [key (key %)]
-         (when-not (identical? :fhir/type key)
-           (p/-serialize-json-as-field (val %) (name key) generator provider)))
-      m)
-    (.writeEndObject ^JsonGenerator generator))
+  (-has-secondary-content [_] false)
+  (-serialize-json-secondary [m _]
+    (throw (ex-info "A complex type/resource has no secondary content." m)))
   (-hash-into [m sink]
     (.putByte ^PrimitiveSink sink (byte 37))
     (run!
@@ -1053,70 +1106,87 @@
     (transduce (mapcat p/-references) conj [] (vals m))))
 
 
+(declare attachment)
+
+
 (def-complex-type Attachment
-  [id extension contentType language data url size hash title creation]
+  [^String id extension ^:primitive contentType ^:primitive language
+   ^:primitive ^:primitive data ^:primitive url ^:primitive size
+   ^:primitive hash ^:primitive title ^:primitive creation]
   :hash-num 46)
 
 
-(def-complex-type Extension [id extension url ^:polymorph value]
+(declare extension)
+
+
+(def-complex-type Extension [^String id extension ^String url ^:polymorph value]
   :hash-num 39
   :interned (and (nil? id) (p/-interned extension) (p/-interned value)))
 
 
-(def ^{:arglists '([m])} extension
-  "Creates an Extension from a map of :id, :extension, :url or :value."
-  (let [intern-extension (intern/intern-value map->Extension)]
-    (fn [{:keys [id extension value] :as m}]
-      (if (and (nil? id) (p/-interned extension) (p/-interned value))
-        (intern-extension m)
-        (map->Extension m)))))
+(declare coding)
 
 
-(def-complex-type Coding [id extension system version code display]
+(def-complex-type Coding
+  [^String id extension ^:primitive system ^:primitive-string version
+   ^:primitive code ^:primitive-string display ^:primitive userSelected]
   :hash-num 38
   :interned (and (nil? id) (p/-interned extension)))
 
 
-(def coding
-  (let [intern-coding (intern/intern-value map->Coding)]
-    (fn [{:keys [id extension] :as m}]
-      (if (and (nil? id) (p/-interned extension))
-        (intern-coding m)
-        (map->Coding m)))))
+(declare codeable-concept)
 
 
-(def-complex-type CodeableConcept [id extension coding text]
+(def-complex-type CodeableConcept
+  [^String id extension coding ^:primitive-string text]
   :hash-num 39
   :interned (and (nil? id) (p/-interned extension)))
 
 
-(def codeable-concept
-  (let [intern-codeable-concept (intern/intern-value map->CodeableConcept)]
-    (fn [{:keys [id extension] :as m}]
-      (if (and (nil? id) (p/-interned extension))
-        (intern-codeable-concept m)
-        (map->CodeableConcept m)))))
+(declare quantity)
 
 
-(def-complex-type Quantity [id extension value comparator unit system code]
-  :hash-num 40)
+(def-complex-type Quantity
+  [^String id extension ^:primitive value ^:primitive comparator
+   ^:primitive-string unit ^:primitive system ^:primitive code]
+  :hash-num 40
+  :interned (and (nil? id) (p/-interned extension) (nil? value)))
 
 
-(def-complex-type Period [id extension start end]
+(declare period)
+
+
+(def-complex-type Period [^String id extension ^:primitive start ^:primitive end]
   :hash-num 41)
 
 
-(def-complex-type Identifier [id extension use type system value period assigner]
+(declare identifier)
+
+
+(def-complex-type Identifier
+  [^String id extension ^:primitive use type ^:primitive system
+   ^:primitive-string value period assigner]
   :hash-num 42)
 
 
+(declare human-name)
+
+
 (def-complex-type HumanName
-  [id extension use text family given prefix suffix period]
+  [^String id extension ^:primitive use ^:primitive-string text
+   ^:primitive-string family ^:primitive-list given ^:primitive-list prefix
+   ^:primitive-list suffix period]
   :hash-num 46)
 
 
+(declare address)
+
+
 (def-complex-type Address
-  [id extension use type text line city district state postalCode country period]
+  [^String id extension ^:primitive use ^:primitive type ^:primitive-string text
+   ^:primitive-list line ^:primitive-string city ^:primitive-string district
+   ^:primitive-string state ^:primitive-string postalCode
+   ^:primitive-string country period]
   :hash-num 47)
 
 
@@ -1131,7 +1201,12 @@
       [ref])))
 
 
-(def-complex-type Reference [id extension reference type identifier display]
+(declare reference)
+
+
+(def-complex-type Reference
+  [^String id extension ^:primitive-string reference ^:primitive type identifier
+   ^:primitive-string display]
   :hash-num 43
   :references
   (-> (transient (or (some-> reference reference-reference) []))
@@ -1142,18 +1217,23 @@
     (persistent!)))
 
 
+(declare meta)
+
+
 (def-complex-type Meta
-  [id extension versionId lastUpdated source profile security tag]
+  [^String id extension ^:primitive versionId ^:primitive lastUpdated
+   ^:primitive source ^:primitive-list profile security tag]
   :hash-num 44)
 
 
-(def mk-meta
-  (intern/intern-value map->Meta))
+(declare bundle-entry-search)
 
 
-(def-complex-type BundleEntrySearch [id extension mode score]
+(def-complex-type BundleEntrySearch
+  [^String id extension ^:primitive mode ^:primitive score]
   :fhir-type :fhir.Bundle.entry/search
-  :hash-num 45)
+  :hash-num 45
+  :interned (and (nil? id) (p/-interned extension) (nil? score)))
 
 
 
@@ -1161,8 +1241,8 @@
 
 (def ^:private object-serializer
   (proxy [StdSerializer] [Object]
-    (serialize [obj generator provider]
-      (p/-serialize-json obj generator provider))))
+    (serialize [obj generator _]
+      (p/-serialize-json obj generator))))
 
 
 (def fhir-module
@@ -1175,12 +1255,6 @@
 
 
 ;; ---- print -----------------------------------------------------------------
-
-(defmethod print-dup (Class/forName "[B") [^bytes year ^Writer w]
-  (.write w "#=(byte-array [")
-  (.write w ^String (str/join " " (map int (vec year))))
-  (.write w "])"))
-
 
 (defmethod print-dup Year [^Year year ^Writer w]
   (.write w "#=(java.time.Year/of ")

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/json.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/json.clj
@@ -1,0 +1,89 @@
+(ns blaze.fhir.spec.type.json
+  (:require
+    [blaze.fhir.spec.type.protocols :as p]
+    [clojure.string :as str])
+  (:import
+    [java.util Arrays]
+    [clojure.lang PersistentVector]
+    [com.fasterxml.jackson.core JsonGenerator SerializableString]
+    [java.nio.charset StandardCharsets]
+    [java.io Writer]))
+
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+
+(deftype FieldName [^String s ^bytes utf-8-bytes]
+  SerializableString
+  (getValue [_]
+    s)
+  (charLength [_]
+    (.length s))
+  (appendQuotedUTF8 [_ buffer offset]
+    (let [num-bytes (alength utf-8-bytes)]
+      (if (> (unchecked-add-int offset num-bytes) (alength buffer))
+        (int -1)
+        (do (System/arraycopy utf-8-bytes 0 buffer offset num-bytes)
+            num-bytes))))
+  (asUnquotedUTF8 [_]
+    (Arrays/copyOf ^bytes utf-8-bytes (alength utf-8-bytes)))
+  (asQuotedUTF8 [this]
+    (.asUnquotedUTF8 this)))
+
+
+(defmethod print-dup (Class/forName "[B") [^bytes year ^Writer w]
+  (.write w "#=(byte-array [")
+  (.write w ^String (str/join " " (map int (vec year))))
+  (.write w "])"))
+
+
+(defmethod print-method FieldName [^FieldName fieldName ^Writer w]
+  (.write w "#blaze/field-name")
+  (print-dup (.-s fieldName) w))
+
+
+(defn field-name ^SerializableString [s]
+  (->FieldName s (.getBytes ^String s StandardCharsets/UTF_8)))
+
+
+(defn write-field [^JsonGenerator generator ^SerializableString field-name value]
+  (when (p/-has-primary-content value)
+    (.writeFieldName generator field-name)
+    (p/-serialize-json value generator))
+  (when (p/-has-secondary-content value)
+    (.writeFieldName generator (str "_" (.getValue field-name)))
+    (p/-serialize-json-secondary value generator)))
+
+
+(defn- has-primary-content-rf [_ x]
+  (when (p/-has-primary-content x) (reduced true)))
+
+
+(defn- has-secondary-content-rf [_ x]
+  (when (p/-has-secondary-content x) (reduced true)))
+
+
+(defn write-primitive-list-field [^JsonGenerator generator ^SerializableString field-name ^PersistentVector list]
+  (when (.reduce list has-primary-content-rf nil)
+    (.writeFieldName generator field-name)
+    (.writeStartArray generator)
+    (.reduce list #(p/-serialize-json %2 generator) nil)
+    (.writeEndArray generator))
+  (when (.reduce list has-secondary-content-rf nil)
+    (.writeFieldName generator (str "_" (.getValue field-name)))
+    (.writeStartArray generator)
+    (.reduce list #(p/-serialize-json-secondary %2 generator) nil)
+    (.writeEndArray generator)))
+
+
+(defn write-primitive-string-field [^JsonGenerator generator ^SerializableString field-name value]
+  (if (string? value)
+    (do (.writeFieldName generator field-name)
+        (.writeString generator ^String value))
+    (write-field generator field-name value)))
+
+
+(defn write-non-primitive-field [^JsonGenerator generator ^SerializableString field-name value]
+  (.writeFieldName generator field-name)
+  (p/-serialize-json value generator))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/protocols.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/protocols.clj
@@ -5,8 +5,28 @@
   (-type [_])
   (-interned [_])
   (-value [_])
-  (-serialize-json-as-field [_ field-name generator provider])
-  (-serialize-json [_ generator provider])
+  (-has-primary-content [value]
+    "Returns true if there is primary JSON content available.")
+  (-serialize-json [value generator]
+    "Serializes the primary content of `value`.
+
+    For primitive types, the primary content is the (inner) :value which can be
+    represented as a primary JSON value or the JSON `null` value because that is
+    needed to fill up JSON arrays in case `value` has secondary content. For all
+    other types, it's the whole content.
+
+    See also: https://www.hl7.org/fhir/datatypes.html#representations")
+  (-has-secondary-content [value]
+    "Returns true if there is secondary JSON content available.")
+  (-serialize-json-secondary [value generator]
+    "Serializes the secondary content of `value`.
+
+    For primitive types, the secondary content is it's :id and :extension that
+    has to be serialized under a field starting with an underscore. For all
+    other types, it's a JSON `null` value because that is needed to fill up
+    JSON arrays in case `value` has primary content.
+
+    See also: https://www.hl7.org/fhir/datatypes.html#representations")
   (-to-xml [_])
   (-hash-into [_ sink])
   (-references [_]))

--- a/modules/fhir-structure/test-perf/blaze/fhir/spec/type_test_mem.clj
+++ b/modules/fhir-structure/test-perf/blaze/fhir/spec/type_test_mem.clj
@@ -94,6 +94,7 @@
     #fhir/HumanName{} 64
 
     #fhir/Address{} 80
+    #fhir/Address{:extension [#fhir/Extension{:url "url-120620" :value #fhir/code"code-120656"}]} 320
     #fhir/Address{:text "text-212402"} 136
     #fhir/Address{:line ["line-212441"]} 200
 
@@ -103,6 +104,17 @@
     #fhir/Meta{:profile [#fhir/canonical"foo"]} 192
 
     #fhir/BundleEntrySearch{} 48)
+
+  (testing "interning"
+    (are [x y] (= (mem/total-size x) (mem/total-size x y))
+      #fhir/Address{:extension [#fhir/Extension{:url "foo" :value #fhir/code"bar"}]}
+      #fhir/Address{:extension [#fhir/Extension{:url "foo" :value #fhir/code"bar"}]}
+
+      #fhir/Meta{:profile [#fhir/canonical"foo"]}
+      #fhir/Meta{:profile [#fhir/canonical"foo"]}
+
+      #fhir/Coding{:system #fhir/uri"foo" :code #fhir/code"bar"}
+      #fhir/Coding{:system #fhir/uri"foo" :code #fhir/code"bar"}))
 
   (testing "instant"
     (testing "backed by OffsetDateTime, taking into account shared offsets"

--- a/modules/fhir-structure/test-perf/blaze/fhir/spec_test_perf.clj
+++ b/modules/fhir-structure/test-perf/blaze/fhir/spec_test_perf.clj
@@ -2,24 +2,111 @@
   (:require
     [blaze.fhir.spec :as fhir-spec]
     [blaze.test-util :as tu]
-    [clojure.test :refer [are deftest]]
+    [clojure.alpha.spec :as s2]
     [criterium.core :as criterium]))
 
 
 (tu/init-fhir-specs)
 
 
-(deftest unform-json-test
-  (are [x mean] (< (:mean (criterium/quick-benchmark (fhir-spec/unform-json x) {}) mean))
-    #fhir/HumanName{:family "Doe" :given ["John"]} 0.3
+(defn- bench-unform-json [x]
+  (apply format "%.3f µs <> %.3f µs" (map #(* % 1e6) (second (:mean (criterium/benchmark (fhir-spec/unform-json x) {}))))))
+
+
+(comment
+  ;; 0,333 µs <> 0,334 µs
+  (bench-unform-json #fhir/HumanName{:family "Doe" :given ["John"]})
+
+  ;; 0,330 µs <> 0,332 µs
+  (bench-unform-json
     #fhir/CodeableConcept
             {:coding
              [#fhir/Coding
                      {:system #fhir/uri"http://loinc.org"
-                      :code #fhir/code"17861-6"}]} 0.4))
+                      :code #fhir/code"17861-6"}]})
 
+  ;; 3,264 µs <> 3,269 µs
+  (bench-unform-json
+    {:fhir/type :fhir/Observation
+     :id "DACG22233TWT7CK4"
+     :meta #fhir/Meta
+            {:versionId #fhir/id"481283"
+             :lastUpdated #fhir/instant"2022-04-20T11:58:38.070Z"
+             :profile [#fhir/canonical"http://hl7.org/fhir/StructureDefinition/bmi"
+                       #fhir/canonical"http://hl7.org/fhir/StructureDefinition/vitalsigns"]}
+     :status #fhir/code"final"
+     :category
+     [#fhir/CodeableConcept
+             {:coding
+              [#fhir/Coding
+                      {:system #fhir/uri"http://terminology.hl7.org/CodeSystem/observation-category"
+                       :code #fhir/code"vital-signs"
+                       :display "vital-signs"}]}]
+     :code #fhir/CodeableConcept
+            {:coding [#fhir/Coding{:system #fhir/uri"http://loinc.org"
+                                   :code #fhir/code"39156-5"
+                                   :display "Body Mass Index"}]
+             :text "Body Mass Index"}
+     :subject #fhir/Reference{:reference "Patient/DACG22233TWT7CKL"}
+     :effective #fhir/dateTime"2013-01-04T23:45:50Z"
+     :issued #fhir/instant"2013-01-04T23:45:50.072Z"
+     :value #fhir/Quantity
+            {:value 14.97M
+             :unit "kg/m2"
+             :system #fhir/uri"http://unitsofmeasure.org"
+             :code #fhir/code"kg/m2"}})
+
+  ;; 4,169 µs <> 4,178 µs
+  (bench-unform-json
+    {:fhir/type :fhir.Bundle/entry
+     :fullUrl "http://localhost:8080/fhir/Observation/DACG22233TWT7CK4"
+     :resource
+     {:fhir/type :fhir/Observation
+      :id "DACG22233TWT7CK4"
+      :meta #fhir/Meta
+             {:versionId #fhir/id"481283"
+              :lastUpdated #fhir/instant"2022-04-20T11:58:38.070Z"
+              :profile [#fhir/canonical"http://hl7.org/fhir/StructureDefinition/bmi"
+                        #fhir/canonical"http://hl7.org/fhir/StructureDefinition/vitalsigns"]}
+      :status #fhir/code"final"
+      :category
+      [#fhir/CodeableConcept
+              {:coding
+               [#fhir/Coding
+                       {:system #fhir/uri"http://terminology.hl7.org/CodeSystem/observation-category"
+                        :code #fhir/code"vital-signs"
+                        :display "vital-signs"}]}]
+      :code #fhir/CodeableConcept
+             {:coding [#fhir/Coding{:system #fhir/uri"http://loinc.org"
+                                    :code #fhir/code"39156-5"
+                                    :display "Body Mass Index"}]
+              :text "Body Mass Index"}
+      :subject #fhir/Reference{:reference "Patient/DACG22233TWT7CKL"}
+      :effective #fhir/dateTime"2013-01-04T23:45:50Z"
+      :issued #fhir/instant"2013-01-04T23:45:50.072Z"
+      :value #fhir/Quantity
+             {:value 14.97M
+              :unit "kg/m2"
+              :system #fhir/uri"http://unitsofmeasure.org"
+              :code #fhir/code"kg/m2"}}
+     :search #fhir/BundleEntrySearch{:mode #fhir/code"match"}})
+
+  )
 
 (comment
   (criterium/quick-bench (fhir-spec/unform-json #fhir/HumanName{:family "Doe" :given ["John"]}))
   (criterium/quick-bench (fhir-spec/unform-json #fhir/CodeableConcept{:coding [#fhir/Coding{:system #fhir/uri"http://loinc.org" :code #fhir/code"17861-6"}]}))
+
+  (criterium/bench (s2/conform :fhir.json/Coding {:system "http://loinc.org" :code "39156-5"}))
+  (criterium/bench (s2/conform :fhir.cbor/Coding {:system "http://loinc.org" :code "39156-5"}))
+
+  (dotimes [_ 50000000]
+    (s2/conform :fhir.json/Coding {:system "http://loinc.org" :code "39156-5"}))
+
+  (dotimes [_ 50000000]
+    (s2/conform :fhir.cbor/Coding {:system "http://loinc.org" :code "39156-5"}))
+
+  (fhir-spec/conform-json (fhir-spec/parse-json
+                            "{\n  \"category\": [\n    {\n      \"coding\": [\n        {\n          \"system\": \"http://terminology.hl7.org/CodeSystem/observation-category\",\n          \"code\": \"vital-signs\",\n          \"display\": \"vital-signs\"\n        }\n      ]\n    }\n  ],\n  \"meta\": {\n    \"versionId\": \"481283\",\n    \"lastUpdated\": \"2022-04-20T11:58:38.070Z\",\n    \"profile\": [\n      \"http://hl7.org/fhir/StructureDefinition/bmi\",\n      \"http://hl7.org/fhir/StructureDefinition/vitalsigns\"\n    ]\n  },\n  \"valueQuantity\": {\n    \"value\": 14.97,\n    \"unit\": \"kg/m2\",\n    \"system\": \"http://unitsofmeasure.org\",\n    \"code\": \"kg/m2\"\n  },\n  \"resourceType\": \"Observation\",\n  \"effectiveDateTime\": \"2013-01-04T23:45:50Z\",\n  \"status\": \"final\",\n  \"id\": \"DACG22233TWT7CK4\",\n  \"code\": {\n    \"coding\": [\n      {\n        \"system\": \"http://loinc.org\",\n        \"code\": \"39156-5\",\n        \"display\": \"Body Mass Index\"\n      }\n    ],\n    \"text\": \"Body Mass Index\"\n  },\n  \"issued\": \"2013-01-04T23:45:50.072Z\",\n  \"subject\": {\n    \"reference\": \"Patient/DACG22233TWT7CKL\"\n  }\n}"))
+
   )

--- a/modules/fhir-structure/test/blaze/fhir/spec/generators.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/generators.clj
@@ -1,0 +1,481 @@
+(ns blaze.fhir.spec.generators
+  (:refer-clojure :exclude [boolean meta time])
+  (:require
+    [blaze.fhir.spec.type :as type]
+    [clojure.string :as str]
+    [clojure.test.check.generators :as gen]))
+
+
+(defn nilable [gen]
+  (gen/one-of [gen (gen/return nil)]))
+
+
+(defn rare-nil [gen]
+  (gen/frequency [[9 gen] [1 (gen/return nil)]]))
+
+
+(defn often-nil [gen]
+  (gen/frequency [[9 (gen/return nil)] [1 gen]]))
+
+
+(def boolean-value
+  gen/boolean)
+
+
+(def integer-value
+  gen/small-integer)
+
+
+(def long-value
+  gen/large-integer)
+
+
+(def string-value
+  (gen/such-that (partial re-matches #"[ \r\n\t\S]+") gen/string 100))
+
+
+(def decimal-value
+  (gen/fmap #(BigDecimal/valueOf ^double %) (gen/double* {:infinite? false :NaN? false})))
+
+
+(def uri-value
+  (gen/such-that (partial re-matches #"\S*") gen/string 100))
+
+
+(def url-value
+  (gen/such-that (partial re-matches #"\S*") gen/string 100))
+
+
+(def canonical-value
+  (gen/such-that (partial re-matches #"\S*") gen/string 100))
+
+
+(def base64Binary-value
+  (->> (gen/vector gen/char-alphanumeric 4)
+       (gen/fmap str/join)
+       (gen/vector)
+       (gen/fmap str/join)
+       (gen/such-that (partial re-matches #"([0-9a-zA-Z\\+/=]{4})+"))))
+
+
+(def year
+  (gen/choose 1900 2100))
+
+
+(def month
+  (gen/choose 1 12))
+
+
+(def day
+  (gen/choose 1 28))
+
+
+(def hour
+  (gen/choose 0 23))
+
+
+(def minute
+  (gen/choose 0 59))
+
+
+(def time-second
+  (gen/choose 0 59))
+
+
+(def zone-offset
+  (gen/fmap (partial apply format "%s%02d:00")
+            (gen/tuple (gen/elements ["+" "-"]) (gen/choose 1 14))))
+
+
+(def zone
+  (gen/one-of [(gen/return "Z") zone-offset]))
+
+
+(def instant-value
+  (gen/fmap (partial apply format "%04d-%02d-%02dT%02d:%02d:%02d%s")
+            (gen/tuple year month day hour minute time-second zone)))
+
+
+(def date-value
+  (gen/one-of
+    [(gen/fmap (partial format "%04d") year)
+     (gen/fmap (partial apply format "%04d-%02d")
+               (gen/tuple year month))
+     (gen/fmap (partial apply format "%04d-%02d-%02d")
+               (gen/tuple year month day))]))
+
+
+(def dateTime-value
+  (gen/one-of
+    [(gen/fmap (partial format "%04d") year)
+     (gen/fmap (partial apply format "%04d-%02d")
+               (gen/tuple year month))
+     (gen/fmap (partial apply format "%04d-%02d-%02d")
+               (gen/tuple year month day))
+     (gen/fmap (partial apply format "%04d-%02d-%02dT%02d:%02d:%02d%s")
+               (gen/tuple year month day hour minute time-second zone))]))
+
+
+(def time-value
+  (gen/fmap (partial apply format "%02d:%02d:%02d")
+            (gen/tuple hour minute time-second)))
+
+
+(def code-value
+  (gen/such-that (partial re-matches #"[^\s]+(\s[^\s]+)*") gen/string 100))
+
+
+(def char-digit
+  (gen/fmap char (gen/choose 48 57)))
+
+
+(def oid-value
+  (gen/such-that (partial re-matches #"urn:oid:[0-2](\.(0|[1-9][0-9]*))+")
+                 (gen/fmap (partial str "urn:oid:0.")
+                           (gen/fmap str/join (gen/vector char-digit)))))
+
+
+(def id-value
+  (gen/such-that (partial re-matches #"[A-Za-z0-9\-\.]{1,64}")
+                 (gen/fmap str/join (gen/vector gen/char-alphanumeric 1 64))))
+
+
+(def markdown-value
+  (gen/such-that (partial re-matches #"[ \r\n\t\S]+") gen/string 100))
+
+
+(def unsignedInt-value
+  gen/nat)
+
+
+(def positiveInt-value
+  (gen/fmap inc gen/nat))
+
+
+(def uuid-value
+  (gen/fmap (partial str "urn:uuid:") gen/uuid))
+
+
+(defn- keep-vals [m]
+  (reduce-kv
+    (fn [ret k v]
+      (if (or (nil? v) (and (vector? v) (empty? v)))
+        (dissoc ret k)
+        ret))
+    m
+    m))
+
+
+(defn- to-map [keys vals]
+  (gen/such-that seq (gen/fmap #(keep-vals (zipmap keys %)) vals) 100))
+
+
+(declare extension)
+
+
+(defn extensions [& {:as gens}]
+  (gen/scale #(/ % 10) (gen/vector (extension gens))))
+
+
+(defn- primitive-gen [constructor value-gen]
+  (fn
+    [& {:keys [id extension value]
+        :or {id (gen/return nil)
+             extension (extensions)
+             value (nilable value-gen)}}]
+    (->> (gen/tuple id extension value)
+         (to-map [:id :extension :value])
+         (gen/fmap constructor))))
+
+
+(def boolean
+  (primitive-gen type/boolean boolean-value))
+
+
+(def integer
+  (primitive-gen type/integer integer-value))
+
+
+(def string
+  (primitive-gen type/string string-value))
+
+
+(def decimal
+  (primitive-gen type/decimal decimal-value))
+
+
+(def uri
+  (primitive-gen type/uri uri-value))
+
+
+(def url
+  (primitive-gen type/url url-value))
+
+
+(def canonical
+  (primitive-gen type/canonical canonical-value))
+
+
+(def base64Binary
+  (primitive-gen type/base64Binary base64Binary-value))
+
+
+(def instant
+  (primitive-gen type/instant instant-value))
+
+
+(def date
+  (primitive-gen type/date date-value))
+
+
+(def dateTime
+  (primitive-gen type/dateTime dateTime-value))
+
+
+(def time
+  (primitive-gen type/time time-value))
+
+
+(def code
+  (primitive-gen type/code code-value))
+
+
+(def id
+  (primitive-gen type/id id-value))
+
+
+(def unsignedInt
+  (primitive-gen type/unsignedInt unsignedInt-value))
+
+
+(defn attachment
+  [& {:keys [id extension contentType language data url size hash title creation]
+      :or {id (gen/return nil)
+           extension (gen/return nil)
+           contentType (rare-nil (code))
+           language (nilable (code))
+           data (rare-nil (base64Binary))
+           url (often-nil (url))
+           size (often-nil (unsignedInt))
+           hash (often-nil (base64Binary))
+           title (often-nil (string))
+           creation (often-nil (dateTime))}}]
+  (->> (gen/tuple id extension contentType language data url size hash title
+                  creation)
+       (to-map [:id :extension :contentType :language :data :url :size :hash
+                :title :creation])
+       (gen/fmap type/attachment)))
+
+
+(defn extension
+  [& {:keys [id extension value]
+      :or {id (gen/return nil)
+           extension (gen/return nil)
+           value (gen/return nil)}}]
+  (->> (gen/tuple id extension uri-value value)
+       (to-map [:id :extension :url :value])
+       (gen/fmap type/extension)))
+
+
+(defn coding
+  [& {:keys [id extension system version code display user-selected]
+      :or {id (gen/return nil)
+           extension (extensions)
+           system (rare-nil (uri))
+           version (often-nil (string))
+           code (rare-nil (blaze.fhir.spec.generators/code))
+           display (often-nil (string))
+           user-selected (often-nil (boolean))}}]
+  (->> (gen/tuple id extension system version code display user-selected)
+       (to-map [:id :extension :system :version :code :display :userSelected])
+       (gen/fmap type/coding)))
+
+
+(defn codeable-concept
+  [& {:keys [id extension coding text]
+      :or {id (gen/return nil)
+           extension (extensions)
+           coding (gen/vector (coding))
+           text (often-nil (string))}}]
+  (->> (gen/tuple id extension coding text)
+       (to-map [:id :extension :coding :text])
+       (gen/fmap type/codeable-concept)))
+
+
+(defn quantity
+  [& {:keys [id extension value comparator unit system code]
+      :or {id (gen/return nil)
+           extension (extensions)
+           value (rare-nil (decimal))
+           comparator (often-nil (code))
+           unit (rare-nil (string))
+           system (rare-nil (uri))
+           code (rare-nil (code))}}]
+  (->> (gen/tuple id extension value comparator unit system code)
+       (to-map [:id :extension :value :comparator :unit :system :code])
+       (gen/fmap type/quantity)))
+
+
+(defn period
+  [& {:keys [id extension start end]
+      :or {id (gen/return nil)
+           extension (extensions)
+           start (nilable (dateTime))
+           end (nilable (dateTime))}}]
+  (->> (gen/tuple id extension start end)
+       (to-map [:id :extension :start :end])
+       (gen/fmap type/period)))
+
+
+(declare reference)
+
+
+(defn identifier
+  [& {:keys [id extension use type system value period assigner]
+      :or {id (gen/return nil)
+           extension (extensions)
+           use (rare-nil (code))
+           type (nilable (codeable-concept))
+           system (rare-nil (uri))
+           value (rare-nil (string))
+           period (often-nil (period))
+           assigner (gen/return nil)}}]
+  (->> (gen/tuple id extension use type system value period assigner)
+       (to-map [:id :extension :use :type :system :value :period :assigner])
+       (gen/fmap type/identifier)))
+
+
+(defn human-name
+  [& {:keys [id extension use text family given prefix suffix period]
+      :or {id (gen/return nil)
+           extension (extensions)
+           use (rare-nil (code))
+           text (often-nil (string))
+           family (rare-nil (string))
+           given (gen/vector (string))
+           prefix (gen/scale #(/ % 5) (gen/vector (string)))
+           suffix (gen/scale #(/ % 5) (gen/vector (string)))
+           period (often-nil (period))}}]
+  (->> (gen/tuple id extension use text family given prefix suffix period)
+       (to-map [:id :extension :use :text :family :given :prefix :suffix :period])
+       (gen/fmap type/human-name)))
+
+
+(defn address
+  [& {:keys [id extension use type text line city district state postalCode
+             country period]
+      :or {id (gen/return nil)
+           extension (extensions)
+           use (rare-nil (code))
+           type (rare-nil (code))
+           text (often-nil (string))
+           line (gen/vector (string))
+           city (rare-nil (string))
+           district (rare-nil (string))
+           state (rare-nil (string))
+           postalCode (rare-nil (string))
+           country (rare-nil (string))
+           period (often-nil (period))}}]
+  (->> (gen/tuple id extension use type text line city district state postalCode
+                  country period)
+       (to-map [:id :extension :use :type :text :line :city :district :state
+                :postalCode :country :period])
+       (gen/fmap type/address)))
+
+
+(defn reference
+  [& {:keys [id extension reference type identifier display]
+      :or {id (gen/return nil)
+           extension (extensions)
+           reference (rare-nil (string))
+           type (often-nil (uri))
+           identifier (often-nil (identifier))
+           display (often-nil (string))}}]
+  (->> (gen/tuple id extension reference type identifier display)
+       (to-map [:id :extension :reference :type :identifier :display])
+       (gen/fmap type/reference)))
+
+
+(defn meta
+  [& {:keys [id extension versionId lastUpdated source profile security tag]
+      :or {id (gen/return nil)
+           extension (extensions)
+           versionId (rare-nil (blaze.fhir.spec.generators/id))
+           lastUpdated (rare-nil (instant))
+           source (nilable (uri))
+           profile (gen/vector (canonical))
+           security (gen/vector (coding))
+           tag (gen/vector (coding))}}]
+  (->> (gen/tuple id extension versionId lastUpdated source profile security tag)
+       (to-map [:id :extension :versionId :lastUpdated :source :profile
+                :security :tag])
+       (gen/fmap type/meta)))
+
+
+(defn bundle-entry-search
+  [& {:keys [id extension mode score]
+      :or {id (gen/return nil)
+           extension (extensions)
+           mode (rare-nil (code))
+           score (often-nil (decimal))}}]
+  (->> (gen/tuple id extension mode score)
+       (to-map [:id :extension :mode :score])
+       (gen/fmap type/bundle-entry-search)))
+
+
+(defn- fhir-type [fhir-type gen]
+  (gen/fmap #(assoc % :fhir/type fhir-type) gen))
+
+
+(defn patient
+  [& {:keys [gender birthDate]
+      :or {gender (rare-nil (code))
+           birthDate (rare-nil (date))}}]
+  (->> (gen/tuple gender birthDate)
+       (to-map [:gender :birthDate])
+       (fhir-type :fhir/Patient)))
+
+
+(defn- observation-value []
+  (gen/one-of [(quantity) (codeable-concept) (string) (boolean) (integer)
+               #_(range) #_(ratio) #_(sampled-data) (time) (dateTime) (period)]))
+
+
+(defn observation
+  [& {:keys [identifier status category code subject encounter value]
+      :or {identifier (gen/vector (identifier))
+           status (rare-nil (code))
+           category (gen/vector (codeable-concept))
+           code (rare-nil (codeable-concept))
+           subject (rare-nil (reference))
+           encounter (rare-nil (reference))
+           value (rare-nil (observation-value))}}]
+  (->> (gen/tuple identifier status category code subject encounter value)
+       (to-map [:identifier :status :category :code :subject :encounter :value])
+       (fhir-type :fhir/Observation)))
+
+
+(defn procedure
+  [& {:keys [identifier instantiatesCanonical instantiatesUri status category
+             code subject encounter]
+      :or {identifier (gen/vector (identifier))
+           instantiatesCanonical (gen/vector (canonical))
+           instantiatesUri (gen/vector (uri))
+           status (rare-nil (code))
+           category (codeable-concept)
+           code (rare-nil (codeable-concept))
+           subject (rare-nil (reference))
+           encounter (rare-nil (reference))}}]
+  (->> (gen/tuple identifier instantiatesCanonical instantiatesUri status
+                  category code subject encounter)
+       (to-map [:identifier :instantiatesCanonical :instantiatesUri :status
+                :category :code :subject :encounter])
+       (fhir-type :fhir/Procedure)))
+
+
+(defn allergy-intolerance
+  [& {:keys [category]
+      :or {category (gen/vector (code))}}]
+  (->> (gen/tuple category)
+       (to-map [:category])
+       (fhir-type :fhir/AllergyIntolerance)))

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl/xml_spec.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl/xml_spec.clj
@@ -1,0 +1,11 @@
+(ns blaze.fhir.spec.impl.xml-spec
+  (:require
+    [blaze.fhir.spec.impl.xml :as xml]
+    [clojure.spec.alpha :as s])
+  (:import
+    [java.util.regex Pattern]))
+
+
+(s/fdef xml/value-matches?
+  :args (s/cat :regex #(instance? Pattern %) :element xml/element?)
+  :ret boolean?)

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
@@ -4,6 +4,8 @@
     [blaze.fhir.spec.impl-spec]
     [blaze.fhir.spec.impl.specs :as specs]
     [blaze.fhir.spec.impl.util-spec]
+    [blaze.fhir.spec.impl.xml :as xml]
+    [blaze.fhir.spec.impl.xml-spec]
     [blaze.fhir.spec.type :as type]
     [blaze.fhir.structure-definition-repo :as u]
     [blaze.test-util :refer [with-system]]
@@ -64,9 +66,9 @@
               {:key :fhir.xml/boolean
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "true|false" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "true|false" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Boolean type/to-xml))}
               {:key :fhir.cbor/boolean
@@ -83,9 +85,9 @@
               {:key :fhir.xml/integer
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "-?([0]|([1-9][0-9]*))" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "-?([0]|([1-9][0-9]*))" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Integer type/to-xml))}
               {:key :fhir.cbor/integer
@@ -102,9 +104,9 @@
               {:key :fhir.xml/string
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "[ \\r\\n\\t\\S]+" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->String type/to-xml))}
               {:key :fhir.cbor/string
@@ -121,9 +123,9 @@
               {:key :fhir.xml/decimal
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Decimal type/to-xml))}
               {:key :fhir.cbor/decimal
@@ -139,9 +141,9 @@
               {:key :fhir.xml/uri
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "\\S*" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "\\S*" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Uri type/to-xml))}
               {:key :fhir.cbor/uri
@@ -157,9 +159,9 @@
               {:key :fhir.xml/canonical
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "\\S*" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "\\S*" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Canonical type/to-xml))}
               {:key :fhir.cbor/canonical
@@ -175,9 +177,9 @@
               {:key :fhir.xml/base64Binary
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "([0-9a-zA-Z\\\\+/=]{4})+" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "([0-9a-zA-Z\\\\+/=]{4})+" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Base64Binary type/to-xml))}
               {:key :fhir.cbor/base64Binary
@@ -193,9 +195,9 @@
               {:key :fhir.xml/code
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "[^\\s]+(\\s[^\\s]+)*" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "[^\\s]+(\\s[^\\s]+)*" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Code type/to-xml))}
               {:key :fhir.cbor/code
@@ -211,9 +213,9 @@
               {:key :fhir.xml/unsignedInt
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "[0]|([1-9][0-9]*)" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "[0]|([1-9][0-9]*)" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->UnsignedInt type/to-xml))}
               {:key :fhir.cbor/unsignedInt
@@ -229,9 +231,9 @@
               {:key :fhir.xml/positiveInt
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "[1-9][0-9]*" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "[1-9][0-9]*" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->PositiveInt type/to-xml))}
               {:key :fhir.cbor/positiveInt
@@ -247,9 +249,9 @@
               {:key :fhir.xml/uuid
                :spec-form
                `(s2/and
-                  impl/element?
-                  (fn [~'e] (impl/xml-value-matches? "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" ~'e))
-                  (s2/conformer impl/remove-character-content impl/set-extension-tag)
+                  xml/element?
+                  (fn [~'e] (xml/value-matches? "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" ~'e))
+                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
                   (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                   (s2/conformer type/xml->Uuid type/to-xml))}
               {:key :fhir.cbor/uuid
@@ -267,7 +269,7 @@
               {:key :fhir.xml/xhtml
                :spec-form
                `(s2/and
-                  impl/element?
+                  xml/element?
                   (s2/conformer type/xml->Xhtml type/to-xml))}
               {:key :fhir.cbor/xhtml
                :spec-form `(s2/conformer type/->Xhtml identity)}])))))
@@ -354,15 +356,15 @@
     (testing "JSON representation of Bundle.id"
       (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
         [:fhir.json.Bundle/id 0 :spec-form regexes->str]
-        := `(s2/and string? (fn [~'s] (re-matches "[A-Za-z0-9\\-\\.]{1,64}" ~'s)))))
+        := `(s2/and string? (fn [~'s] (.matches (re-matcher "[A-Za-z0-9\\-\\.]{1,64}" ~'s))))))
 
     (testing "XML representation of Bundle.id"
       (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
         [:fhir.xml.Bundle/id 0 :spec-form regexes->str]
         := `(s2/and
-              impl/element?
+              xml/element?
               (s2/conformer impl/conform-xml-value impl/unform-xml-value)
-              (fn [~'s] (re-matches "[A-Za-z0-9\\-\\.]{1,64}" ~'s)))))
+              (fn [~'s] (.matches (re-matcher "[A-Za-z0-9\\-\\.]{1,64}" ~'s))))))
 
     (testing "JSON representation of Bundle.entry"
       (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
@@ -473,12 +475,22 @@
     (testing "JSON representation of Quantity.unit"
       (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Quantity")))
         [:fhir.json.Quantity/unit 0 :spec-form regexes->str]
-        := `(specs/regex "[ \\r\\n\\t\\S]+" impl/intern-string)))
+        := `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/intern-string)))
+
+    (testing "XML representation of Quantity.unit"
+      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Quantity")))
+        [:fhir.xml.Quantity/unit 0 :spec-form regexes->str]
+        := `(s2/and
+              xml/element?
+              (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
+              (s2/conformer xml/remove-character-content xml/set-extension-tag)
+              (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+              (s2/conformer type/xml->InternedString type/to-xml))))
 
     (testing "CBOR representation of Quantity.unit"
       (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Quantity")))
         [:fhir.cbor.Quantity/unit 0 :spec-form regexes->str]
-        := `(s2/conformer impl/intern-string)))))
+        := `(specs/cbor-primitive type/intern-string)))))
 
 
 (deftest elem-def->spec-def-test

--- a/modules/fhir-structure/test/blaze/fhir/spec/type/json_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type/json_test.clj
@@ -1,0 +1,52 @@
+(ns blaze.fhir.spec.type.json-test
+  (:require
+    [blaze.fhir.spec.type.json :as json]
+    [blaze.test-util :refer [satisfies-prop]]
+    [clojure.spec.test.alpha :as st]
+    [clojure.test :as test :refer [deftest testing]]
+    [clojure.test.check.generators :as gen]
+    [clojure.test.check.properties :as prop])
+  (:import
+    [java.nio.charset StandardCharsets]))
+
+
+(set! *warn-on-reflection* true)
+(st/instrument)
+
+
+(defn- fixture [f]
+  (st/instrument)
+  (f)
+  (st/unstrument))
+
+
+(test/use-fixtures :each fixture)
+
+
+(deftest field-name-test
+  (testing "getValue"
+    (satisfies-prop 100
+      (prop/for-all [value gen/string-ascii]
+        (= value (.getValue (json/field-name value))))))
+
+  (testing "charLength"
+    (satisfies-prop 100
+      (prop/for-all [value gen/string-ascii]
+        (= (count value) (.charLength (json/field-name value))))))
+
+  (testing "appendQuotedUTF8"
+    (satisfies-prop 100
+      (prop/for-all [value gen/string-ascii]
+        (let [buffer (byte-array (count value))]
+          (.appendQuotedUTF8 (json/field-name value) buffer 0)
+          (= value (String. buffer StandardCharsets/UTF_8))))))
+
+  (testing "asUnquotedUTF8"
+    (satisfies-prop 100
+      (prop/for-all [value gen/string-ascii]
+        (= value (String. (.asUnquotedUTF8 (json/field-name value)) StandardCharsets/UTF_8)))))
+
+  (testing "asQuotedUTF8"
+    (satisfies-prop 100
+      (prop/for-all [value gen/string-ascii]
+        (= value (String. (.asQuotedUTF8 (json/field-name value)) StandardCharsets/UTF_8))))))

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -248,7 +248,7 @@
      (type/map->Quantity
        {:code #fhir/code"s"
         :system #fhir/uri"http://unitsofmeasure.org"
-        :unit "s"
+        :unit #fhir/string"s"
         :value (bigdec duration)})}))
 
 

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/stratifier.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/stratifier.clj
@@ -7,7 +7,8 @@
 
 
 (defn- value-concept [value]
-  (type/codeable-concept {:text (str (if (nil? value) "null" value))}))
+  (type/codeable-concept
+    {:text (type/string (str (if (nil? value) "null" value)))}))
 
 
 (defn- stratum* [population value]
@@ -25,7 +26,7 @@
 
 (defn- stratifier* [strata code]
   (cond-> {:fhir/type :fhir.MeasureReport.group/stratifier
-           :stratum (sort-by (comp :text :value) strata)}
+           :stratum (sort-by (comp type/value :text :value) strata)}
     code
     (assoc :code [code])))
 
@@ -131,7 +132,7 @@
 (defn- multi-component-stratifier* [strata codes]
   {:fhir/type :fhir.MeasureReport.group/stratifier
    :code codes
-   :stratum (sort-by (comp #(mapv (comp :text :value) %) :component) strata)})
+   :stratum (sort-by (comp #(mapv (comp type/value :text :value) %) :component) strata)})
 
 
 (defn- multi-component-stratifier

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -221,7 +221,7 @@
                            :criteria (cql-expression "InInitialPopulation")}]
                          :stratifier
                          [{:fhir/type :fhir.Measure.group/stratifier
-                           :code #fhir/CodeableConcept{:text "gender"}
+                           :code #fhir/CodeableConcept{:text #fhir/string"gender"}
                            :criteria (cql-expression "Gender")}]}]}
               params {:period [#system/date"2000" #system/date"2020"]
                       :report-type "subject"
@@ -237,8 +237,8 @@
                                     :end #system/date-time"2020"}
             [:group 0 :population 0 :code :coding 0 :code] := #fhir/code"initial-population"
             [:group 0 :population 0 :count] := 1
-            [:group 0 :stratifier 0 :code 0 :text] := "gender"
-            [:group 0 :stratifier 0 :stratum 0 :value :text] := "male"
+            [:group 0 :stratifier 0 :code 0 :text type/value] := "gender"
+            [:group 0 :stratifier 0 :stratum 0 :value :text type/value] := "male"
             [:group 0 :stratifier 0 :stratum 0 :population 0 :count] := 1))))
 
     (testing "invalid subject"
@@ -366,9 +366,9 @@
       (is (= #fhir/code"summary" (-> result :resource :type))))
 
     (given (first-stratifier-strata result)
-      [0 :value :text] := "10"
+      [0 :value :text type/value] := "10"
       [0 :population 0 :count] := 1
-      [1 :value :text] := "70"
+      [1 :value :text type/value] := "70"
       [1 :population 0 :count] := 2))
 
   (let [result (evaluate "q19-stratifier-ageclass" "subject-list")]
@@ -379,10 +379,10 @@
       (is (= #fhir/code"subject-list" (-> result :resource :type))))
 
     (given (first-stratifier-strata result)
-      [0 :value :text] := "10"
+      [0 :value :text type/value] := "10"
       [0 :population 0 :count] := 1
       [0 :population 0 :subjectResults :reference] := "List/AAAAAAAAAAAAAAAB"
-      [1 :value :text] := "70"
+      [1 :value :text type/value] := "70"
       [1 :population 0 :count] := 2
       [1 :population 0 :subjectResults :reference] := "List/AAAAAAAAAAAAAAAC")
 
@@ -398,28 +398,28 @@
       [2 1 :entry 1 :item :reference] := "Patient/2"))
 
   (given (first-stratifier-strata (evaluate "q20-stratifier-city"))
-    [0 :value :text] := "Jena"
+    [0 :value :text type/value] := "Jena"
     [0 :population 0 :count] := 3
-    [1 :value :text] := "Leipzig"
+    [1 :value :text type/value] := "Leipzig"
     [1 :population 0 :count] := 1)
 
   (given (first-stratifier-strata (evaluate "q21-stratifier-city-of-only-women"))
-    [0 :value :text] := "Jena"
+    [0 :value :text type/value] := "Jena"
     [0 :population 0 :count] := 2)
 
   (is (= ::anom/incorrect (::anom/category (evaluate "q22-stratifier-multiple-cities-fail"))))
 
   (given (first-stratifier-strata (evaluate "q23-stratifier-ageclass-and-gender"))
-    [0 :component 0 :code :text] := "age-class"
-    [0 :component 0 :value :text] := "10"
-    [0 :component 1 :code :text] := "gender"
-    [0 :component 1 :value :text] := "male"
+    [0 :component 0 :code :text type/value] := "age-class"
+    [0 :component 0 :value :text type/value] := "10"
+    [0 :component 1 :code :text type/value] := "gender"
+    [0 :component 1 :value :text type/value] := "male"
     [0 :population 0 :count] := 1
-    [1 :component 0 :value :text] := "70"
-    [1 :component 1 :value :text] := "female"
+    [1 :component 0 :value :text type/value] := "70"
+    [1 :component 1 :value :text type/value] := "female"
     [1 :population 0 :count] := 2
-    [2 :component 0 :value :text] := "70"
-    [2 :component 1 :value :text] := "male"
+    [2 :component 0 :value :text type/value] := "70"
+    [2 :component 1 :value :text type/value] := "male"
     [2 :population 0 :count] := 1)
 
   (let [result (evaluate "q23-stratifier-ageclass-and-gender" "subject-list")]
@@ -427,18 +427,18 @@
       (is (s/valid? :blaze/resource (:resource result))))
 
     (given (first-stratifier-strata result)
-      [0 :component 0 :code :text] := "age-class"
-      [0 :component 0 :value :text] := "10"
-      [0 :component 1 :code :text] := "gender"
-      [0 :component 1 :value :text] := "male"
+      [0 :component 0 :code :text type/value] := "age-class"
+      [0 :component 0 :value :text type/value] := "10"
+      [0 :component 1 :code :text type/value] := "gender"
+      [0 :component 1 :value :text type/value] := "male"
       [0 :population 0 :count] := 1
       [0 :population 0 :subjectResults :reference] := "List/AAAAAAAAAAAAAAAB"
-      [1 :component 0 :value :text] := "70"
-      [1 :component 1 :value :text] := "female"
+      [1 :component 0 :value :text type/value] := "70"
+      [1 :component 1 :value :text type/value] := "female"
       [1 :population 0 :count] := 2
       [1 :population 0 :subjectResults :reference] := "List/AAAAAAAAAAAAAAAD"
-      [2 :component 0 :value :text] := "70"
-      [2 :component 1 :value :text] := "male"
+      [2 :component 0 :value :text type/value] := "70"
+      [2 :component 1 :value :text type/value] := "male"
       [2 :population 0 :count] := 1
       [2 :population 0 :subjectResults :reference] := "List/AAAAAAAAAAAAAAAC")
 
@@ -455,43 +455,43 @@
       [3 1 :entry 1 :item :reference] := "Patient/3"))
 
   (given (first-stratifier-strata (evaluate "q25-stratifier-collection"))
-    [0 :value :text] := "Organization/collection-0"
+    [0 :value :text type/value] := "Organization/collection-0"
     [0 :population 0 :count] := 1
-    [1 :value :text] := "Organization/collection-1"
+    [1 :value :text type/value] := "Organization/collection-1"
     [1 :population 0 :count] := 1)
 
   (given (first-stratifier-strata (evaluate "q26-stratifier-bmi"))
-    [0 :value :text] := "37"
+    [0 :value :text type/value] := "37"
     [0 :population 0 :count] := 1
-    [1 :value :text] := "null"
+    [1 :value :text type/value] := "null"
     [1 :population 0 :count] := 2)
 
   (given (first-stratifier-strata (evaluate "q27-stratifier-calculated-bmi"))
-    [0 :value :text] := "26.8"
+    [0 :value :text type/value] := "26.8"
     [0 :population 0 :count] := 1
-    [1 :value :text] := "null"
+    [1 :value :text type/value] := "null"
     [1 :population 0 :count] := 2)
 
   (given (first-stratifier-strata (evaluate "q29-stratifier-sample-material-type"))
-    [0 :value :text] := "liquid"
+    [0 :value :text type/value] := "liquid"
     [0 :population 0 :count] := 1
-    [1 :value :text] := "tissue"
+    [1 :value :text type/value] := "tissue"
     [1 :population 0 :count] := 1)
 
   (given (first-stratifier-strata (evaluate "q30-stratifier-with-missing-expression"))
-    [0 :value :text] := "null"
+    [0 :value :text type/value] := "null"
     [0 :population 0 :count] := 2)
 
   (given (first-stratifier-strata (evaluate "q31-stratifier-storage-temperature"))
-    [0 :value :text] := "temperature2to10"
+    [0 :value :text type/value] := "temperature2to10"
     [0 :population 0 :count] := 1
-    [1 :value :text] := "temperatureGN"
+    [1 :value :text type/value] := "temperatureGN"
     [1 :population 0 :count] := 1)
 
   (given (first-stratifier-strata (evaluate "q32-stratifier-underweight"))
-    [0 :value :text] := "false"
+    [0 :value :text type/value] := "false"
     [0 :population 0 :count] := 2
-    [1 :value :text] := "true"
+    [1 :value :text type/value] := "true"
     [1 :population 0 :count] := 1))
 
 (comment

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -400,7 +400,7 @@
                 [:extension 0 :url] := "https://samply.github.io/blaze/fhir/StructureDefinition/eval-duration"
                 [:extension 0 :value :code] := #fhir/code"s"
                 [:extension 0 :value :system] := #fhir/uri"http://unitsofmeasure.org"
-                [:extension 0 :value :unit] := "s"
+                [:extension 0 :value :unit] := #fhir/string"s"
                 [:extension 0 :value :value] :instanceof BigDecimal
                 :status := #fhir/code"complete"
                 :type := #fhir/code"summary"
@@ -429,7 +429,7 @@
                     :criteria (cql-expression "InInitialPopulation")}]
                   :stratifier
                   [{:fhir/type :fhir.Measure.group/stratifier
-                    :code #fhir/CodeableConcept{:text "gender"}
+                    :code #fhir/CodeableConcept{:text #fhir/string"gender"}
                     :criteria (cql-expression "Gender")}]}]}]
               [:put
                {:fhir/type :fhir/Library :id "0"
@@ -471,19 +471,19 @@
                 [:group 0 :population 0 :code :coding 0 :code]
                 := #fhir/code"initial-population"
                 [:group 0 :population 0 :count] := 3
-                [:group 0 :stratifier 0 :code 0 :text] := "gender"
+                [:group 0 :stratifier 0 :code 0 :text] := #fhir/string"gender"
                 [:group 0 :stratifier 0 :stratum 0 :population 0 :code :coding 0 :system]
                 := #fhir/uri"http://terminology.hl7.org/CodeSystem/measure-population"
                 [:group 0 :stratifier 0 :stratum 0 :population 0 :code :coding 0 :code]
                 := #fhir/code"initial-population"
                 [:group 0 :stratifier 0 :stratum 0 :population 0 :count] := 2
-                [:group 0 :stratifier 0 :stratum 0 :value :text] := "female"
+                [:group 0 :stratifier 0 :stratum 0 :value :text] := #fhir/string"female"
                 [:group 0 :stratifier 0 :stratum 1 :population 0 :code :coding 0 :system]
                 := #fhir/uri"http://terminology.hl7.org/CodeSystem/measure-population"
                 [:group 0 :stratifier 0 :stratum 1 :population 0 :code :coding 0 :code]
                 := #fhir/code"initial-population"
                 [:group 0 :stratifier 0 :stratum 1 :population 0 :count] := 1
-                [:group 0 :stratifier 0 :stratum 1 :value :text] := "male")))))
+                [:group 0 :stratifier 0 :stratum 1 :value :text] := #fhir/string"male")))))
 
       (testing "as POST request"
         (with-handler [handler]


### PR DESCRIPTION
All explicit modelled complex types will intern if they consist only of interned extensions. This will save memory for complex types tagged with a data absent reason extension.

Also some optimizations regarding encoding of resources as JSON were done in order to preserve encoding times reached before implementing extended primitive types.
