### PR TITLE
Increase V-Hash Size from 32 Bit to 64 Bit

### DIFF
--- a/modules/db-resource-store/src/blaze/db/resource_store/spec.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store/spec.clj
@@ -5,5 +5,9 @@
     [clojure.spec.alpha :as s]))
 
 
+(defn resource-store? [x]
+  (satisfies? rs/ResourceStore x))
+
+
 (s/def :blaze.db/resource-store
-  #(satisfies? rs/ResourceStore %))
+  resource-store?)

--- a/modules/db/src/blaze/db/impl/codec.clj
+++ b/modules/db/src/blaze/db/impl/codec.clj
@@ -22,11 +22,10 @@
 ;; ---- Sizes of Byte Arrays --------------------------------------------------
 
 (def ^:const ^long c-hash-size Integer/BYTES)
-(def ^:const ^long v-hash-size Integer/BYTES)
+(def ^:const ^long v-hash-size Long/BYTES)
 (def ^:const ^long tid-size Integer/BYTES)
 (def ^:const ^long t-size Long/BYTES)
 (def ^:const ^long state-size Long/BYTES)
-(def ^:const ^long tx-time-size Long/BYTES)
 (def ^:const ^long max-id-size 64)
 
 
@@ -304,7 +303,7 @@
 
 
 (defn v-hash [value]
-  (-> (Hashing/murmur3_32_fixed)
+  (-> (Hashing/farmHashFingerprint64)
       (.hashString value StandardCharsets/UTF_8)
       (.asBytes)
       bs/from-byte-array))

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -388,11 +388,7 @@
     [:blaze.db/enforce-referential-integrity]))
 
 
-(def ^:private expected-kv-store-version 0)
-
-
-(defn- kv-store-version [kv-store]
-  (or (some-> (kv/get kv-store version/key) version/decode-value) 0))
+(def ^:private expected-kv-store-version 1)
 
 
 (def ^:private incompatible-kv-store-version-msg
@@ -412,13 +408,14 @@
            {:actual-version actual-version :expected-version expected-version}))
 
 
-(defn- check-version! [kv-store]
-  (when (tx-success/last-t kv-store)
-    (let [actual-kv-store-version (kv-store-version kv-store)]
+(defn- check-and-set-version! [kv-store]
+  (if (tx-success/last-t kv-store)
+    (let [actual-kv-store-version (version/get kv-store)]
       (if (= actual-kv-store-version expected-kv-store-version)
         (log/info "Index store version is" actual-kv-store-version)
         (throw (incompatible-kv-store-version-ex actual-kv-store-version
-                                                 expected-kv-store-version))))))
+                                                 expected-kv-store-version))))
+    (version/set! kv-store expected-kv-store-version)))
 
 
 (defmethod ig/init-key :blaze.db/node
@@ -427,7 +424,7 @@
       :or {poll-timeout (time/seconds 1)}
       :as config}]
   (init-msg config)
-  (check-version! kv-store)
+  (check-and-set-version! kv-store)
   (let [node (->Node (ctx config) tx-log resource-handle-cache tx-cache kv-store
                      resource-store search-param-registry resource-indexer
                      (atom (initial-state kv-store))

--- a/modules/db/src/blaze/db/node/version.clj
+++ b/modules/db/src/blaze/db/node/version.clj
@@ -1,7 +1,8 @@
 (ns blaze.db.node.version
-  (:refer-clojure :exclude [key])
+  (:refer-clojure :exclude [get key])
   (:require
-    [blaze.byte-buffer :as bb])
+    [blaze.byte-buffer :as bb]
+    [blaze.db.kv :as kv])
   (:import
     [java.nio.charset StandardCharsets]))
 
@@ -19,5 +20,13 @@
       (bb/array)))
 
 
-(defn decode-value [bytes]
+(defn- decode-value [bytes]
   (bb/get-int! (bb/wrap bytes)))
+
+
+(defn get [store]
+  (or (some-> (kv/get store key) decode-value) 0))
+
+
+(defn set! [store version]
+  (kv/put! store key (encode-value version)))

--- a/modules/db/src/blaze/db/search_param_registry/spec.clj
+++ b/modules/db/src/blaze/db/search_param_registry/spec.clj
@@ -5,8 +5,12 @@
     [clojure.spec.alpha :as s]))
 
 
+(defn search-param-registry? [x]
+  (satisfies? sr/SearchParamRegistry x))
+
+
 (s/def :blaze.db/search-param-registry
-  #(satisfies? sr/SearchParamRegistry %))
+  search-param-registry?)
 
 
 (s/def :blaze.db/search-param

--- a/modules/db/src/blaze/db/spec.clj
+++ b/modules/db/src/blaze/db/spec.clj
@@ -19,12 +19,20 @@
   node?)
 
 
+(defn cache? [x]
+  (instance? Cache x))
+
+
 (s/def :blaze.db/resource-handle-cache
-  #(instance? Cache %))
+  cache?)
+
+
+(defn loading-cache? [x]
+  (instance? LoadingCache x))
 
 
 (s/def :blaze.db/tx-cache
-  #(instance? LoadingCache %))
+  loading-cache?)
 
 
 (s/def :blaze.db/resource-cache

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -2185,29 +2185,29 @@
                  (:kv-store node)
                  :type :id :hash-prefix :code :v-hash)
                [["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "value-quantity" #blaze/byte-string"0000000080"]
+                 "value-quantity" #blaze/byte-string"4F40902F3B6AE19A80"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "value-quantity" #blaze/byte-string"5C38E45A80"]
+                 "value-quantity" #blaze/byte-string"9CEABF1B055DDDCF80"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "value-quantity" #blaze/byte-string"9B780D9180"]
+                 "value-quantity" #blaze/byte-string"B658D8AF4F417A2B80"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "combo-value-quantity" #blaze/byte-string"0000000080"]
+                 "combo-value-quantity" #blaze/byte-string"4F40902F3B6AE19A80"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "combo-value-quantity" #blaze/byte-string"5C38E45A80"]
+                 "combo-value-quantity" #blaze/byte-string"9CEABF1B055DDDCF80"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "combo-value-quantity" #blaze/byte-string"9B780D9180"]
+                 "combo-value-quantity" #blaze/byte-string"B658D8AF4F417A2B80"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
-                 "_id" #blaze/byte-string"165494C5"]
+                 "_id" #blaze/byte-string"490E5C1C8B04CCEC"]
                 ["Observation" "id-0" #blaze/hash-prefix"36A9F36D"
                  "_lastUpdated" #blaze/byte-string"80008001"]
                 ["TestScript" "id-0" #blaze/hash-prefix"51E67D28"
-                 "context-quantity" #blaze/byte-string"0000000080"]
+                 "context-quantity" #blaze/byte-string"4F40902F3B6AE19A80"]
                 ["TestScript" "id-0" #blaze/hash-prefix"51E67D28"
-                 "context-quantity" #blaze/byte-string"5C38E45A80"]
+                 "context-quantity" #blaze/byte-string"9CEABF1B055DDDCF80"]
                 ["TestScript" "id-0" #blaze/hash-prefix"51E67D28"
-                 "context-quantity" #blaze/byte-string"9B780D9180"]
+                 "context-quantity" #blaze/byte-string"B658D8AF4F417A2B80"]
                 ["TestScript" "id-0" #blaze/hash-prefix"51E67D28"
-                 "_id" #blaze/byte-string"165494C5"]
+                 "_id" #blaze/byte-string"490E5C1C8B04CCEC"]
                 ["TestScript" "id-0" #blaze/hash-prefix"51E67D28"
                  "_lastUpdated" #blaze/byte-string"80008001"]])))
 

--- a/modules/db/test/blaze/db/impl/codec_test.clj
+++ b/modules/db/test/blaze/db/impl/codec_test.clj
@@ -55,6 +55,12 @@
          (apply codec/descending-long [(apply codec/descending-long [t])])))))
 
 
+(deftest v-hash-test
+  (testing "no collisions"
+    (let [n (long 1e7)]
+      (is (= n (count (into #{} (map (comp codec/v-hash str)) (repeatedly n random-uuid))))))))
+
+
 (deftest tid-test
   (check `codec/tid))
 

--- a/modules/db/test/blaze/db/impl/search_param/composite_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite_test.clj
@@ -63,7 +63,7 @@
 
 
 (defn- split-value [bs]
-  [(bs/subs bs 0 4) (bs/subs bs 4)])
+  [(bs/subs bs 0 codec/v-hash-size) (bs/subs bs codec/v-hash-size)])
 
 
 (defn compile-code-quantity-value [search-param-registry value]

--- a/modules/db/test/blaze/db/node/resource_indexer_test.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_test.clj
@@ -16,7 +16,8 @@
     [blaze.db.node.resource-indexer-spec]
     [blaze.db.resource-store :as rs]
     [blaze.db.resource-store.kv :as rs-kv]
-    [blaze.db.search-param-registry :as sr]
+    [blaze.db.resource-store.spec :refer [resource-store?]]
+    [blaze.db.search-param-registry.spec :refer [search-param-registry?]]
     [blaze.executors :as ex]
     [blaze.fhir-path :as fhir-path]
     [blaze.fhir.hash :as hash]
@@ -82,7 +83,7 @@
       [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
       [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))
       [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :executor))
-      [:explain ::s/problems 3 :pred] := `(fn ~'[%] (satisfies? rs/ResourceStore ~'%))
+      [:explain ::s/problems 3 :pred] := `resource-store?
       [:explain ::s/problems 3 :val] := ::invalid))
 
   (testing "invalid search-param-registry"
@@ -92,7 +93,7 @@
       [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
       [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
       [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :executor))
-      [:explain ::s/problems 3 :pred] := `(fn ~'[%] (satisfies? sr/SearchParamRegistry ~'%))
+      [:explain ::s/problems 3 :pred] := `search-param-registry?
       [:explain ::s/problems 3 :val] := ::invalid))
 
   (testing "invalid executor"
@@ -245,13 +246,14 @@
                       kv-store :type :id :hash-prefix)))
         (is (= (sp-vr-tu/decode-index-entries kv-store :code :v-hash)
                [["patient" (codec/v-hash "Patient/id-145552")]
+                ["patient" (codec/v-hash "id-145552")]
                 ["patient" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-145552"))]
-                ["patient" (codec/v-hash "id-145552")]
-                ["code" (codec/v-hash "code-204441")]
-                ["code" (codec/v-hash "system-204435|")]
+
                 ["code" (codec/v-hash "system-204435|code-204441")]
+                ["code" (codec/v-hash "system-204435|")]
+                ["code" (codec/v-hash "code-204441")]
                 ["onset-date" (codec/date-lb-ub
                                 (codec/date-lb
                                   (ZoneId/systemDefault)
@@ -260,10 +262,10 @@
                                   (ZoneId/systemDefault)
                                   (LocalDate/of 2020 1 30)))]
                 ["subject" (codec/v-hash "Patient/id-145552")]
+                ["subject" (codec/v-hash "id-145552")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-145552"))]
-                ["subject" (codec/v-hash "id-145552")]
                 ["_profile" (codec/v-hash "url-164445")]
                 ["_id" (codec/v-hash "id-204446")]
                 ["_lastUpdated" #blaze/byte-string"80008001"]])))
@@ -274,13 +276,13 @@
                       kv-store :type :id :hash-prefix)))
         (is (= (r-sp-v-tu/decode-index-entries kv-store :code :v-hash)
                [["patient" (codec/v-hash "Patient/id-145552")]
+                ["patient" (codec/v-hash "id-145552")]
                 ["patient" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-145552"))]
-                ["patient" (codec/v-hash "id-145552")]
-                ["code" (codec/v-hash "code-204441")]
-                ["code" (codec/v-hash "system-204435|")]
                 ["code" (codec/v-hash "system-204435|code-204441")]
+                ["code" (codec/v-hash "system-204435|")]
+                ["code" (codec/v-hash "code-204441")]
                 ["onset-date" (codec/date-lb-ub
                                 (codec/date-lb
                                   (ZoneId/systemDefault)
@@ -289,10 +291,10 @@
                                   (ZoneId/systemDefault)
                                   (LocalDate/of 2020 1 30)))]
                 ["subject" (codec/v-hash "Patient/id-145552")]
+                ["subject" (codec/v-hash "id-145552")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-145552"))]
-                ["subject" (codec/v-hash "id-145552")]
                 ["_profile" (codec/v-hash "url-164445")]
                 ["_id" (codec/v-hash "id-204446")]
                 ["_lastUpdated" #blaze/byte-string"80008001"]])))
@@ -308,13 +310,13 @@
                       kv-store :compartment :type :id :hash-prefix)))
         (is (= (c-sp-vr-tu/decode-index-entries kv-store :code :v-hash)
                [["patient" (codec/v-hash "Patient/id-145552")]
+                ["patient" (codec/v-hash "id-145552")]
                 ["patient" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-145552"))]
-                ["patient" (codec/v-hash "id-145552")]
-                ["code" (codec/v-hash "code-204441")]
-                ["code" (codec/v-hash "system-204435|")]
                 ["code" (codec/v-hash "system-204435|code-204441")]
+                ["code" (codec/v-hash "system-204435|")]
+                ["code" (codec/v-hash "code-204441")]
                 ["onset-date" (codec/date-lb-ub
                                 (codec/date-lb
                                   (ZoneId/systemDefault)
@@ -323,10 +325,10 @@
                                   (ZoneId/systemDefault)
                                   (LocalDate/of 2020 1 30)))]
                 ["subject" (codec/v-hash "Patient/id-145552")]
+                ["subject" (codec/v-hash "id-145552")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-145552"))]
-                ["subject" (codec/v-hash "id-145552")]
                 ["_profile" (codec/v-hash "url-164445")]
                 ["_id" (codec/v-hash "id-204446")]
                 ["_lastUpdated" #blaze/byte-string"80008001"]]))))))
@@ -377,18 +379,6 @@
                       kv-store :type :id :hash-prefix)))
         (is (= (sp-vr-tu/decode-index-entries kv-store :code :v-hash)
                [["code-value-quantity"
-                 #blaze/byte-string"82821D0F00000000900926"]
-                ["code-value-quantity"
-                 #blaze/byte-string"82821D0F32690DC8900926"]
-                ["code-value-quantity"
-                 #blaze/byte-string"82821D0FA3C37576900926"]
-                ["code-value-quantity"
-                 #blaze/byte-string"9F7C9B9400000000900926"]
-                ["code-value-quantity"
-                 #blaze/byte-string"9F7C9B9432690DC8900926"]
-                ["code-value-quantity"
-                 #blaze/byte-string"9F7C9B94A3C37576900926"]
-                ["code-value-quantity"
                  (bs/concat (codec/v-hash "code-193824")
                             (codec/quantity "" 23.42M))]
                 ["code-value-quantity"
@@ -398,6 +388,18 @@
                  (bs/concat (codec/v-hash "code-193824")
                             (codec/quantity "http://unitsofmeasure.org|kg/m2"
                                             23.42M))]
+                ["code-value-quantity"
+                 #blaze/byte-string"B02358E02AD0942D4F40902F3B6AE19A900926"]
+                ["code-value-quantity"
+                 #blaze/byte-string"B02358E02AD0942DE95B25E4B02F01AF900926"]
+                ["code-value-quantity"
+                 #blaze/byte-string"B02358E02AD0942DF35972C2DDEDDFE6900926"]
+                ["code-value-quantity"
+                 #blaze/byte-string"D47C56F6D0C25BA34F40902F3B6AE19A900926"]
+                ["code-value-quantity"
+                 #blaze/byte-string"D47C56F6D0C25BA3E95B25E4B02F01AF900926"]
+                ["code-value-quantity"
+                 #blaze/byte-string"D47C56F6D0C25BA3F35972C2DDEDDFE6900926"]
                 ["date" (codec/date-lb-ub
                           (codec/date-lb
                             (ZoneId/systemDefault)
@@ -405,49 +407,49 @@
                           (codec/date-ub
                             (ZoneId/systemDefault)
                             (LocalDate/of 2005 6 17)))]
-                ["category" (codec/v-hash "system-193558|code-193603")]
                 ["category" (codec/v-hash "system-193558|")]
                 ["category" (codec/v-hash "code-193603")]
+                ["category" (codec/v-hash "system-193558|code-193603")]
                 ["patient" (codec/v-hash "id-180857")]
                 ["patient" (codec/tid-id
                              (codec/tid "Patient")
                              (codec/id-byte-string "id-180857"))]
                 ["patient" (codec/v-hash "Patient/id-180857")]
+                ["code" (codec/v-hash "code-193824")]
                 ["code" (codec/v-hash "system-193821|")]
                 ["code" (codec/v-hash "system-193821|code-193824")]
-                ["code" (codec/v-hash "code-193824")]
                 ["value-quantity" (codec/quantity "" 23.42M)]
                 ["value-quantity" (codec/quantity "kg/m2" 23.42M)]
                 ["value-quantity" (codec/quantity
                                     "http://unitsofmeasure.org|kg/m2"
                                     23.42M)]
+                ["combo-code" (codec/v-hash "code-193824")]
                 ["combo-code" (codec/v-hash "system-193821|")]
                 ["combo-code" (codec/v-hash "system-193821|code-193824")]
-                ["combo-code" (codec/v-hash "code-193824")]
                 ["combo-value-quantity"
-                 #blaze/byte-string"00000000900926"]
+                 #blaze/byte-string"4F40902F3B6AE19A900926"]
                 ["combo-value-quantity"
-                 #blaze/byte-string"32690DC8900926"]
+                 #blaze/byte-string"E95B25E4B02F01AF900926"]
                 ["combo-value-quantity"
-                 #blaze/byte-string"A3C37576900926"]
+                 #blaze/byte-string"F35972C2DDEDDFE6900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"82821D0F00000000900926"]
+                 #blaze/byte-string"825F9E2AAE526A184F40902F3B6AE19A900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"82821D0F32690DC8900926"]
+                 #blaze/byte-string"825F9E2AAE526A18E95B25E4B02F01AF900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"82821D0FA3C37576900926"]
+                 #blaze/byte-string"825F9E2AAE526A18F35972C2DDEDDFE6900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"9F7C9B9400000000900926"]
+                 #blaze/byte-string"B02358E02AD0942D4F40902F3B6AE19A900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"9F7C9B9432690DC8900926"]
+                 #blaze/byte-string"B02358E02AD0942DE95B25E4B02F01AF900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"9F7C9B94A3C37576900926"]
+                 #blaze/byte-string"B02358E02AD0942DF35972C2DDEDDFE6900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"A75DEC9D00000000900926"]
+                 #blaze/byte-string"D47C56F6D0C25BA34F40902F3B6AE19A900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"A75DEC9D32690DC8900926"]
+                 #blaze/byte-string"D47C56F6D0C25BA3E95B25E4B02F01AF900926"]
                 ["combo-code-value-quantity"
-                 #blaze/byte-string"A75DEC9DA3C37576900926"]
+                 #blaze/byte-string"D47C56F6D0C25BA3F35972C2DDEDDFE6900926"]
                 ["subject" (codec/v-hash "id-180857")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")

--- a/modules/db/test/blaze/db/node/version_spec.clj
+++ b/modules/db/test/blaze/db/node/version_spec.clj
@@ -1,0 +1,19 @@
+(ns blaze.db.node.version-spec
+  (:require
+    [blaze.db.kv.spec]
+    [blaze.db.node.version :as version]
+    [clojure.spec.alpha :as s]))
+
+
+(s/fdef version/encode-value
+  :args (s/cat :version nat-int?)
+  :ret bytes?)
+
+
+(s/fdef version/get
+  :args (s/cat :store :blaze.db/kv-store)
+  :ret (s/nilable nat-int?))
+
+
+(s/fdef version/set!
+  :args (s/cat :store :blaze.db/kv-store :version nat-int?))

--- a/modules/db/test/blaze/db/node_test.clj
+++ b/modules/db/test/blaze/db/node_test.clj
@@ -14,9 +14,13 @@
     [blaze.db.node.resource-indexer :as resource-indexer]
     [blaze.db.node.tx-indexer :as-alias tx-indexer]
     [blaze.db.node.version :as version]
+    [blaze.db.node.version-spec]
     [blaze.db.resource-handle-cache]
     [blaze.db.resource-store :as rs]
+    [blaze.db.resource-store.spec :refer [resource-store?]]
     [blaze.db.search-param-registry]
+    [blaze.db.search-param-registry.spec :refer [search-param-registry?]]
+    [blaze.db.spec :refer [cache? loading-cache?]]
     [blaze.db.test-util :refer [system]]
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log-spec]
@@ -33,7 +37,8 @@
     [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log])
-  (:import [java.time Instant]))
+  (:import
+    [java.time Instant]))
 
 
 (set! *warn-on-reflection* true)
@@ -88,8 +93,9 @@
 
 (defn- with-index-store-version [system version]
   (assoc-in system [[::kv/mem :blaze.db/index-kv-store] :init-data]
-            [[version/key (version/encode-value version)]
-             (tx-success/index-entry 1 Instant/EPOCH)]))
+            (cond-> [(tx-success/index-entry 1 Instant/EPOCH)]
+              (pos? version)
+              (conj [version/key (version/encode-value version)]))))
 
 
 (deftest init-test
@@ -113,40 +119,74 @@
       [:explain ::s/problems 7 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))))
 
   (testing "invalid tx-log"
-    (given-thrown (ig/init {:blaze.db/node {:tx-log ::invalid}})
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :tx-log] ::invalid))
       :key := :blaze.db/node
       :reason := ::ig/build-failed-spec
-      [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :resource-handle-cache))
-      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :tx-cache))
-      [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :indexer-executor))
-      [:explain ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
-      [:explain ::s/problems 4 :pred] := `(fn ~'[%] (contains? ~'% :resource-indexer))
-      [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
-      [:explain ::s/problems 6 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))
-      [:explain ::s/problems 7 :pred] := `(fn ~'[%] (satisfies? tx-log/TxLog ~'%))
-      [:explain ::s/problems 7 :val] := ::invalid))
+      [:explain ::s/problems 0 :pred] := `(fn ~'[%] (satisfies? tx-log/TxLog ~'%))
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid resource-handle-cache"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :resource-handle-cache] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `cache?
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid tx-cache"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :tx-cache] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `loading-cache?
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid indexer-executor"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :indexer-executor] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `ex/executor?
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid kv-store"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :kv-store] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `kv/store?
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid resource-indexer"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :resource-indexer] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `map?
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid resource-store"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :resource-store] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `resource-store?
+      [:explain ::s/problems 0 :val] := ::invalid))
+
+  (testing "invalid search-param-registry"
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :search-param-registry] ::invalid))
+      :key := :blaze.db/node
+      :reason := ::ig/build-failed-spec
+      [:explain ::s/problems 0 :pred] := `search-param-registry?
+      [:explain ::s/problems 0 :val] := ::invalid))
 
   (testing "invalid enforce-referential-integrity"
-    (given-thrown (ig/init {:blaze.db/node {:enforce-referential-integrity ::invalid}})
+    (given-thrown (ig/init (assoc-in system [:blaze.db/node :enforce-referential-integrity] ::invalid))
       :key := :blaze.db/node
       :reason := ::ig/build-failed-spec
-      [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :tx-log))
-      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :resource-handle-cache))
-      [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :tx-cache))
-      [:explain ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :indexer-executor))
-      [:explain ::s/problems 4 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
-      [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :resource-indexer))
-      [:explain ::s/problems 6 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
-      [:explain ::s/problems 7 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))
-      [:explain ::s/problems 8 :pred] := `boolean?
-      [:explain ::s/problems 8 :val] := ::invalid))
+      [:explain ::s/problems 0 :pred] := `boolean?
+      [:explain ::s/problems 0 :val] := ::invalid))
 
   (testing "incompatible version"
-    (given-thrown (ig/init (with-index-store-version system -1))
+    (given-thrown (ig/init (with-index-store-version system 0))
       :key := :blaze.db/node
       :reason := ::ig/build-threw-exception
-      [:cause-data :expected-version] := 0
-      [:cause-data :actual-version] := -1)))
+      [:cause-data :expected-version] := 1
+      [:cause-data :actual-version] := 0)))
 
 
 (deftest duration-seconds-collector-init-test
@@ -240,5 +280,10 @@
 
 
 (deftest existing-data-with-compatible-version
-  (with-system [{:blaze.db/keys [node]} (with-index-store-version system 0)]
+  (with-system [{:blaze.db/keys [node]} (with-index-store-version system 1)]
     (is node)))
+
+
+(deftest sets-db-version-on-startup
+  (with-system [{kv-store [::kv/mem :blaze.db/index-kv-store]} system]
+    (is (= 1 (version/get kv-store)))))

--- a/modules/db/test/blaze/db/resource_cache_test.clj
+++ b/modules/db/test/blaze/db/resource_cache_test.clj
@@ -7,6 +7,7 @@
     [blaze.db.resource-store :as rs]
     [blaze.db.resource-store-spec]
     [blaze.db.resource-store.kv :as rs-kv]
+    [blaze.db.resource-store.spec :refer [resource-store?]]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.test-util :as tu :refer [given-thrown with-system]]
@@ -67,7 +68,7 @@
     (given-thrown (ig/init {:blaze.db/resource-cache {:resource-store ::invalid}})
       :key := :blaze.db/resource-cache
       :reason := ::ig/build-failed-spec
-      [:explain ::s/problems 0 :pred] := `(fn ~'[%] (satisfies? rs/ResourceStore ~'%))
+      [:explain ::s/problems 0 :pred] := `resource-store?
       [:explain ::s/problems 0 :val] := ::invalid))
 
   (testing "invalid max-size"


### PR DESCRIPTION
In case we have 1 million different identifiers, we will have v-hash collisions. So we have to increase the v-hash size from 32 bit to 64 bit.