### PR TITLE
Fix Reference Resolution on Extended Primitive References

### DIFF
--- a/modules/db/test/blaze/db/node/transaction_test.clj
+++ b/modules/db/test/blaze/db/node/transaction_test.clj
@@ -35,7 +35,7 @@
       (given (tx/prepare-ops
                context
                [[:create {:fhir/type :fhir/Observation :id "0"
-                          :subject #fhir/Reference{:reference "Patient/0"}}]])
+                          :subject #fhir/Reference{:reference #fhir/string"Patient/0"}}]])
         [0 0 :op] := "create"
         [0 0 :type] := "Observation"
         [0 0 :id] := "0"
@@ -43,13 +43,34 @@
         [0 0 :refs] := [["Patient" "0"]]
         [1 0 0] := #blaze/hash"7B3980C2BFCF43A8CDD61662E1AABDA9CA6431964820BC8D52958AEC9A270378"
         [1 0 1] := {:fhir/type :fhir/Observation :id "0"
-                    :subject #fhir/Reference{:reference "Patient/0"}})
+                    :subject #fhir/Reference{:reference #fhir/string"Patient/0"}})
+
+      (testing "with extended reference.reference"
+        (given (tx/prepare-ops
+                 context
+                 [[:create
+                   {:fhir/type :fhir/Observation :id "0"
+                    :subject #fhir/Reference
+                           {:reference #fhir/string
+                                   {:extension [#fhir/Extension{:url "foo"}]
+                                    :value "Patient/190740"}}}]])
+          [0 0 :refs] := [["Patient" "190740"]])
+
+        (testing "without value"
+          (given (tx/prepare-ops
+                 context
+                 [[:create
+                   {:fhir/type :fhir/Observation :id "0"
+                    :subject #fhir/Reference
+                           {:reference #fhir/string
+                                   {:extension [#fhir/Extension{:url "foo"}]}}}]])
+          [0 0 :refs] :? empty?)))
 
       (testing "with disabled referential integrity check"
         (given (tx/prepare-ops
                  {:blaze.db/enforce-referential-integrity false}
                  [[:create {:fhir/type :fhir/Observation :id "0"
-                            :subject #fhir/Reference{:reference "Patient/0"}}]])
+                            :subject #fhir/Reference{:reference #fhir/string"Patient/0"}}]])
           [0 0 :refs] :? empty?)))
 
     (testing "conditional"
@@ -75,7 +96,7 @@
       (given (tx/prepare-ops
                context
                [[:put {:fhir/type :fhir/Observation :id "0"
-                       :subject #fhir/Reference{:reference "Patient/0"}}]])
+                       :subject #fhir/Reference{:reference #fhir/string"Patient/0"}}]])
         [0 0 :op] := "put"
         [0 0 :type] := "Observation"
         [0 0 :id] := "0"
@@ -83,12 +104,12 @@
         [0 0 :refs] := [["Patient" "0"]]
         [1 0 0] := #blaze/hash"7B3980C2BFCF43A8CDD61662E1AABDA9CA6431964820BC8D52958AEC9A270378"
         [1 0 1] := {:fhir/type :fhir/Observation :id "0"
-                    :subject #fhir/Reference{:reference "Patient/0"}})
+                    :subject #fhir/Reference{:reference #fhir/string"Patient/0"}})
 
       (testing "with disabled referential integrity check"
         (given (tx/prepare-ops {:blaze.db/enforce-referential-integrity false}
                                [[:put {:fhir/type :fhir/Observation :id "0"
-                                       :subject #fhir/Reference{:reference "Patient/0"}}]])
+                                       :subject #fhir/Reference{:reference #fhir/string"Patient/0"}}]])
           [0 0 :refs] :? empty?)))
 
     (testing "with matches"

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -36,7 +36,7 @@
 (xml-name/alias-uri 'f "http://hl7.org/fhir")
 
 
-;;(set! *warn-on-reflection* true)
+(set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
 
@@ -1209,7 +1209,7 @@
    ^:primitive-string display]
   :hash-num 43
   :references
-  (-> (transient (or (some-> reference reference-reference) []))
+  (-> (transient (or (some-> reference value reference-reference) []))
     (macros/into! (p/-references extension))
     (macros/into! (p/-references type))
     (macros/into! (p/-references identifier))

--- a/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
@@ -22,7 +22,8 @@
     [com.fasterxml.jackson.databind ObjectMapper]
     [com.google.common.hash Hashing]
     [java.nio.charset StandardCharsets]
-    [java.time Instant LocalTime OffsetDateTime ZoneOffset]))
+    [java.time Instant LocalTime OffsetDateTime ZoneOffset]
+    [com.fasterxml.jackson.core SerializableString]))
 
 
 (xml-name/alias-uri 'f "http://hl7.org/fhir")
@@ -489,27 +490,27 @@
     (testing "getValue"
       (satisfies-prop 10
         (prop/for-all [value fg/uri-value]
-          (= value (.getValue (type/uri value))))))
+          (= value (.getValue ^SerializableString (type/uri value))))))
 
     (testing "appendQuotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/uri-value]
           (let [expected-buffer (.quoteAsUTF8 (JsonStringEncoder/getInstance) value)
                 buffer (byte-array (count expected-buffer))]
-            (.appendQuotedUTF8 (type/uri value) buffer 0)
+            (.appendQuotedUTF8 ^SerializableString (type/uri value) buffer 0)
             (= (bb/wrap expected-buffer) (bb/wrap buffer))))))
 
     (testing "asUnquotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/uri-value]
           (= (bb/wrap (.encodeAsUTF8 (JsonStringEncoder/getInstance) ^String value))
-             (bb/wrap (.asUnquotedUTF8 (type/uri value)))))))
+             (bb/wrap (.asUnquotedUTF8 ^SerializableString (type/uri value)))))))
 
     (testing "asQuotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/uri-value]
           (= (bb/wrap (.quoteAsUTF8 (JsonStringEncoder/getInstance) value))
-             (bb/wrap (.asQuotedUTF8 (type/uri value)))))))))
+             (bb/wrap (.asQuotedUTF8 ^SerializableString (type/uri value)))))))))
 
 
 (deftest url-test
@@ -666,27 +667,27 @@
     (testing "getValue"
       (satisfies-prop 10
         (prop/for-all [value fg/canonical-value]
-          (= value (.getValue (type/canonical value))))))
+          (= value (.getValue ^SerializableString (type/canonical value))))))
 
     (testing "appendQuotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/canonical-value]
           (let [expected-buffer (.quoteAsUTF8 (JsonStringEncoder/getInstance) value)
                 buffer (byte-array (count expected-buffer))]
-            (.appendQuotedUTF8 (type/canonical value) buffer 0)
+            (.appendQuotedUTF8 ^SerializableString (type/canonical value) buffer 0)
             (= (bb/wrap expected-buffer) (bb/wrap buffer))))))
 
     (testing "asUnquotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/canonical-value]
           (= (bb/wrap (.encodeAsUTF8 (JsonStringEncoder/getInstance) ^String value))
-             (bb/wrap (.asUnquotedUTF8 (type/canonical value)))))))
+             (bb/wrap (.asUnquotedUTF8 ^SerializableString (type/canonical value)))))))
 
     (testing "asQuotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/canonical-value]
           (= (bb/wrap (.quoteAsUTF8 (JsonStringEncoder/getInstance) value))
-             (bb/wrap (.asQuotedUTF8 (type/canonical value)))))))))
+             (bb/wrap (.asQuotedUTF8 ^SerializableString (type/canonical value)))))))))
 
 
 (deftest base64Binary-test
@@ -1004,7 +1005,7 @@
     (testing "equals"
       (satisfies-prop 100
         (prop/for-all [date (s/gen :system/date)]
-          (.equals date date)))
+          (.equals ^Object date date)))
       (is (not (.equals #fhir/date"2020-01-01" #fhir/date"2020-01-02")))
       (is (not (.equals #fhir/date"2020-01-01" "2020-01-01"))))
 
@@ -1421,7 +1422,7 @@
         (is (= extended-date-time-element (type/to-xml extended-date-time))))
 
       (testing "equals"
-        (is (.equals (type/dateTime {:extension [string-extension] :value "2020"}) extended-date-time)))
+        (is (.equals ^Object (type/dateTime {:extension [string-extension] :value "2020"}) extended-date-time)))
 
       (testing "hash-into"
         (are [x hex] (= hex (murmur3 x))
@@ -1577,27 +1578,27 @@
     (testing "getValue"
       (satisfies-prop 10
         (prop/for-all [value fg/code-value]
-          (= value (.getValue (type/code value))))))
+          (= value (.getValue ^SerializableString (type/code value))))))
 
     (testing "appendQuotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/code-value]
           (let [expected-buffer (.quoteAsUTF8 (JsonStringEncoder/getInstance) value)
                 buffer (byte-array (count expected-buffer))]
-            (.appendQuotedUTF8 (type/code value) buffer 0)
+            (.appendQuotedUTF8 ^SerializableString (type/code value) buffer 0)
             (= (bb/wrap expected-buffer) (bb/wrap buffer))))))
 
     (testing "asUnquotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/code-value]
           (= (bb/wrap (.encodeAsUTF8 (JsonStringEncoder/getInstance) ^String value))
-             (bb/wrap (.asUnquotedUTF8 (type/code value)))))))
+             (bb/wrap (.asUnquotedUTF8 ^SerializableString (type/code value)))))))
 
     (testing "asQuotedUTF8"
       (satisfies-prop 100
         (prop/for-all [value fg/code-value]
           (= (bb/wrap (.quoteAsUTF8 (JsonStringEncoder/getInstance) value))
-             (bb/wrap (.asQuotedUTF8 (type/code value)))))))))
+             (bb/wrap (.asQuotedUTF8 ^SerializableString (type/code value)))))))))
 
 
 (deftest oid-test
@@ -2588,7 +2589,7 @@
       #fhir/Reference{:extension [#fhir/Extension{}]}
       "210e3eb7"
 
-      #fhir/Reference{:reference "Patient/0"}
+      #fhir/Reference{:reference #fhir/string"Patient/0"}
       "cd80b8ac"
 
       #fhir/Reference{:type #fhir/uri"type-161222"}
@@ -2597,7 +2598,7 @@
       #fhir/Reference{:identifier #fhir/Identifier{}}
       "eb066d27"
 
-      #fhir/Reference{:display "display-161314"}
+      #fhir/Reference{:display #fhir/string"display-161314"}
       "543cf75f"))
 
   (testing "references"
@@ -2610,23 +2611,36 @@
 
       #fhir/Reference
               {:extension
-               [#fhir/Extension{:value #fhir/Reference{:reference "Patient/1"}}]}
+               [#fhir/Extension
+                       {:value #fhir/Reference
+                               {:reference #fhir/string"Patient/1"}}]}
       [["Patient" "1"]]
 
-      #fhir/Reference{:reference "Patient/0"}
+      #fhir/Reference{:reference #fhir/string"Patient/0"}
       [["Patient" "0"]]
 
-      #fhir/Reference{:reference "Patient"}
+      #fhir/Reference{:reference #fhir/string"Patient"}
       []
 
-      #fhir/Reference{:reference ""}
+      #fhir/Reference{:reference #fhir/string""}
       []
 
       #fhir/Reference
               {:extension
-               [#fhir/Extension{:value #fhir/Reference{:reference "Patient/1"}}]
-               :reference "Patient/0"}
-      [["Patient" "0"] ["Patient" "1"]]))
+               [#fhir/Extension
+                       {:value #fhir/Reference
+                               {:reference #fhir/string"Patient/1"}}]
+               :reference #fhir/string"Patient/0"}
+      [["Patient" "0"] ["Patient" "1"]]
+
+      #fhir/Reference
+              {:reference #fhir/string{:extension [#fhir/Extension{:url "foo"}]}}
+      []
+
+      #fhir/Reference
+              {:reference #fhir/string{:extension [#fhir/Extension{:url "foo"}]
+                                       :value "Patient/0"}}
+      [["Patient" "0"]]))
 
   (testing "print"
     (are [v s] (= s (pr-str v))


### PR DESCRIPTION
This bug was introduced by #722. Reference resolution only works on non-extended Reference.reference string types. On extended string types however the value of the extended string has to be obtained by calling the value function. which also works on non-extended strings.

Closes: #758