### PR TITLE
Remove Bare Polymorph JSON Properties

### DIFF
--- a/.github/scripts/evaluate-measure-subject-list.sh
+++ b/.github/scripts/evaluate-measure-subject-list.sh
@@ -71,15 +71,15 @@ cat <<END
   "parameter": [
     {
       "name": "periodStart",
-      "value": "2000"
+      "valueDate": "2000"
     },
     {
       "name": "periodEnd",
-      "value": "2030"
+      "valueDate": "2030"
     },
     {
       "name": "reportType",
-      "value": "subject-list"
+      "valueCode": "subject-list"
     }
   ]
 }

--- a/docs/cql-queries/api.md
+++ b/docs/cql-queries/api.md
@@ -159,7 +159,7 @@ Under `group[0].population[0].count` the result of the query can be found.
 By default, the evaluation results in a MeasureReport of type `summary`. Such a MeasureReport contains only the number of resources of each population. However, if you also need the resources itself, you can have a MeasureReport of type `subject-list` generated. This works as follows:
 
 ```sh
-curl -sd '{"resourceType": "Parameters", "parameter": [{"name": "periodStart", "value": "2000"}, {"name": "periodEnd", "value": "2030"}, {"name": "measure", "value": "urn:uuid:49f4c7de-3320-4208-8e60-ecc0d8824e08"}, {"name": "reportType", "value": "subject-list"}]}' -H "Content-Type: application/fhir+json" 'http://localhost:8080/fhir/Measure/$evaluate-measure'
+curl -sd '{"resourceType": "Parameters", "parameter": [{"name": "periodStart", "valueDate": "2000"}, {"name": "periodEnd", "valueDate": "2030"}, {"name": "measure", "valueString": "urn:uuid:49f4c7de-3320-4208-8e60-ecc0d8824e08"}, {"name": "reportType", "valueCode": "subject-list"}]}' -H "Content-Type: application/fhir+json" 'http://localhost:8080/fhir/Measure/$evaluate-measure'
 ```
 
 the result should be the following MeasureReport:

--- a/evaluate-measure.sh
+++ b/evaluate-measure.sh
@@ -89,7 +89,7 @@ evaluate-measure() {
 }
 
 evaluate-measure-list() {
-  curl -sd '{"resourceType": "Parameters", "parameter": [{"name": "periodStart", "value": "2000"}, {"name": "periodEnd", "value": "2030"}, {"name": "reportType", "value": "subject-list"}]}' \
+  curl -sd '{"resourceType": "Parameters", "parameter": [{"name": "periodStart", "valueDate": "2000"}, {"name": "periodEnd", "valueDate": "2030"}, {"name": "reportType", "valueCode": "subject-list"}]}' \
     -H "Content-Type: application/fhir+json" "$BASE/Measure/$1/\$evaluate-measure"
 }
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -374,14 +374,16 @@
 
 
 (defn remove-choice-type
-  "Removes the type suffix from the first key of a choice typed data element."
+  "Removes the type suffix from the first key of a choice typed data element.
+
+  Also removes bare properties with key `key` if no typed keys were found."
   [m typed-keys key]
   (loop [[k & keys] typed-keys]
     (if k
       (if-some [v (get m k)]
         (-> (dissoc m k) (assoc key v))
         (recur keys))
-      m)))
+      (dissoc m key))))
 
 
 (def ^:private choice-type-key-cache
@@ -392,7 +394,7 @@
             (keyword (str (name key) (str/capital (name type)))))))))
 
 
-(defn choice-type-key [key type]
+(defn- choice-type-key [key type]
   (.get ^LoadingCache choice-type-key-cache [key type]))
 
 

--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -4332,9 +4332,9 @@
                 [#fhir/Extension
                         {:value #fhir/Reference{:reference "Patient/153540"}}]}
         #fhir/uri
-               {:extension
-                [#fhir/Extension
-                        {:value #fhir/Reference{:reference "Observation/153628"}}]}]}
+                {:extension
+                 [#fhir/Extension
+                         {:value #fhir/Reference{:reference "Observation/153628"}}]}]}
       [["Procedure" "153904"]
        ["Condition" "153931"]
        ["Patient" "153540"]
@@ -4380,6 +4380,28 @@
       [["Patient" "204750"]
        ["Observation" "204754"]])))
 
+
+(deftest task-test
+  (testing "conforming"
+    (s2/form :fhir.json.Task/output)
+    (testing "JSON"
+      (are [json fhir] (= fhir (s2/conform :fhir.json/Task json))
+        {:resourceType "Task"
+         :output
+         [{:valueReference {:reference "bar"}}]}
+        {:fhir/type :fhir/Task
+         :output
+         [{:fhir/type :fhir.Task/output
+           :value #fhir/Reference{:reference "bar"}}]})
+
+      (testing "bare :value properties are removed"
+        (are [json fhir] (= fhir (s2/conform :fhir.json/Task json))
+          {:resourceType "Task"
+           :output
+           [{:value {:reference "bar"}}]}
+          {:fhir/type :fhir/Task
+           :output
+           [{:fhir/type :fhir.Task/output}]})))))
 
 (deftest primitive-val-test
   (are [x] (fhir-spec/primitive-val? x)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/middleware/params_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/middleware/params_test.clj
@@ -140,7 +140,7 @@
                  :value #fhir/date"2015"}
                 {:fhir/type :fhir.Parameters/parameter
                  :name "measure"
-                 :value "measure-202606"}]}}]]
+                 :value #fhir/string"measure-202606"}]}}]]
       (let [{:blaze.fhir.operation.evaluate-measure/keys [params]}
             @(handler request)]
 

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -503,7 +503,7 @@
                      :parameter
                      [{:fhir/type :fhir.Parameters/parameter
                        :name "measure"
-                       :value "url-181501"}
+                       :value #fhir/string"url-181501"}
                       {:fhir/type :fhir.Parameters/parameter
                        :name "periodStart"
                        :value #fhir/date"2014"}


### PR DESCRIPTION
The example is a Task resource were the output value is given as with the bare "value" key instead of one of the concrete keys like "valueReference". Such properties can't be assigned a type and have to be removed.