### PR TITLE
Migrate to Eclipse Temurin because OpenJDK is Deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:17-oracle
+FROM eclipse-temurin:17-jre
 
-RUN microdnf upgrade && microdnf remove expat fontconfig freetype \
-  aajohan-comfortaa-fonts fontpackages-filesystem gzip bzip2 tar libpng \
-  binutils && microdnf clean all
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get purge curl libbinutils libctf0 libctf-nobfd0 libncurses6 -y && \
+    apt-get autoremove -y && apt-get clean
 
 RUN mkdir -p /app/data && chown 1001:1001 /app/data
 COPY target/blaze-standalone.jar /app/

--- a/docs/deployment/manual-deployment.md
+++ b/docs/deployment/manual-deployment.md
@@ -1,6 +1,6 @@
 # Manual Deployment
 
-The installation works under Windows, Linux and macOS. The only dependency is an installed OpenJDK 11. Blaze is tested with [AdoptOpenJDK][1].
+The installation works under Windows, Linux and macOS. The only dependency is an installed OpenJDK 11 or 17 with 17 recommended. Blaze is tested with [Eclipse Temurin][1].
 
 Blaze runs on the JVM and comes as single JAR file. Download the most recent version [here](https://github.com/samply/blaze/releases/tag/v0.17.11). Look for `blaze-0.17.11-standalone.jar`.
 
@@ -68,5 +68,5 @@ that should return:
 
 Blaze will be configured through environment variables which are documented [here][2].
 
-[1]: <https://adoptopenjdk.net>
+[1]: <https://adoptium.net>
 [2]: <environment-variables.md>

--- a/modules/server/deps.edn
+++ b/modules/server/deps.edn
@@ -6,7 +6,7 @@
   {:local/root "../module-base"}
 
   org.eclipse.jetty/jetty-server
-  {:mvn/version "9.4.46.v20220331"}
+  {:mvn/version "9.4.48.v20220622"}
 
   ring/ring-jetty-adapter
   {:mvn/version "1.9.5"


### PR DESCRIPTION
The former used image openjdk:17-oracle is now 3 month old while the new image eclipse-temurin:17 is only 1 day old.