### PR TITLE
Switch to Ubuntu 20.04 to Prevent Clone3 Call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-focal
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get purge curl libbinutils libctf0 libctf-nobfd0 libncurses6 -y && \


### PR DESCRIPTION
As one can read in this [comment][1] and this [commit][2] the glibc of
Ubuntu 22.04 uses a clone3 call which older versions of Docker do not
fail with the right error number. So on older versions of Docker the JVM
can't create threads.

[1]: <https://github.com/adoptium/containers/issues/215#issuecomment-1142046045>
[2]: <https://github.com/moby/moby/commit/9f6b562dd12ef7b1f9e2f8e6f2ab6477790a6594>