### PR TITLE
Fix Storage of Bundles with References

### DIFF
--- a/.github/test-data/bundle-with-references/bundle.json
+++ b/.github/test-data/bundle-with-references/bundle.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "type": "transaction",
+        "entry": [
+          {
+            "resource": {
+              "resourceType": "Condition",
+              "subject": {
+                "reference": "Patient/db03f428-4fea-4006-bb90-aeaa7c6e9d1d"
+              }
+            },
+            "request": {
+              "method": "POST",
+              "url": "Condition"
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "POST",
+        "url": "Bundle"
+      }
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -601,6 +601,37 @@ jobs:
     - name: Test Include
       run: .github/scripts/include-without-referential-integrity.sh
 
+  # Test that a transaction can create a transaction bundle with references that will be taken "as-is" and not tried to
+  # resolve to existing resources
+  bundle-with-references-test:
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+
+    - name: Install Blazectl
+      run: .github/scripts/install-blazectl.sh
+
+    - name: Download Blaze Image
+      uses: actions/download-artifact@v3
+      with:
+        name: blaze-image
+        path: /tmp
+
+    - name: Load Blaze Image
+      run: docker load --input /tmp/blaze.tar
+
+    - name: Run Blaze
+      run: docker run --rm -d -e JAVA_TOOL_OPTIONS=-Xmx1g -p 8080:8080 blaze:latest
+
+    - name: Wait for Blaze
+      run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
+
+    - name: Load Data
+      run: blazectl --no-progress --server http://localhost:8080/fhir upload .github/test-data/bundle-with-references
+
   jepsen-test:
     needs: build
     runs-on: ubuntu-20.04

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -1103,7 +1103,9 @@
         (p/-hash-into (k m) sink))
       (sort (keys m))))
   (-references [m]
-    (transduce (mapcat p/-references) conj [] (vals m))))
+    ;; Bundle entries have no references, because Bundles itself are stored "as-is"
+    (when-not (identical? :fhir.Bundle/entry (p/-type m))
+      (transduce (mapcat p/-references) conj [] (vals m)))))
 
 
 (declare attachment)

--- a/modules/fhir-structure/test/blaze/fhir/spec/generators.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/generators.clj
@@ -482,3 +482,12 @@
   (->> (gen/tuple category)
        (to-map [:category])
        (fhir-type :fhir/AllergyIntolerance)))
+
+
+(defn bundle-entry
+  [& {:keys [id extension resource]
+      :or {id (gen/return nil)
+           extension (extensions)}}]
+  (->> (gen/tuple id extension resource)
+       (to-map [:id :extension :resource])
+       (fhir-type :fhir.Bundle/entry)))

--- a/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
@@ -109,9 +109,7 @@
       (is (= "0" (murmur3 nil))))
 
     (testing "references"
-      (are [x refs] (= refs (type/references x))
-        nil
-        nil))))
+      (is (nil? (type/references nil))))))
 
 
 (deftest Object-test

--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -4206,6 +4206,45 @@
         {:score 1.1M}))))
 
 
+(deftest bundle-entry-reference-test
+  (testing "transforming"
+    (testing "JSON"
+      (satisfies-prop 100
+        (prop/for-all [x (fg/bundle-entry {:resource (fg/patient)})]
+          (= (->> x
+                  fhir-spec/unform-json
+                  fhir-spec/parse-json
+                  (s2/conform :fhir.json.Bundle/entry))
+             x))))
+
+    (testing "XML"
+      (satisfies-prop 100
+        (prop/for-all [x (fg/bundle-entry {:resource (fg/patient)})]
+          (= (->> x
+                  (s2/unform :fhir.xml.Bundle/entry)
+                  (s2/conform :fhir.xml.Bundle/entry))
+             x))))
+
+    (testing "CBOR"
+      (satisfies-prop 100
+        (prop/for-all [x (fg/bundle-entry {:resource (fg/patient)})]
+          (= (->> x
+                  fhir-spec/unform-cbor
+                  fhir-spec/parse-cbor
+                  (s2/conform :fhir.cbor.Bundle/entry))
+             x)))))
+
+  (testing "references"
+    (satisfies-prop 10
+      (prop/for-all [x (fg/bundle-entry
+                         {:resource
+                          (fg/observation
+                            {:subject
+                             (fg/reference
+                               {:reference (gen/return "Patient/0")})})})]
+        (empty? (type/references x))))))
+
+
 
 ;; ---- Resources -------------------------------------------------------------
 


### PR DESCRIPTION
Before, references inside Bundles were tried to resolve during transactions. That required resources to exists that were referenced inside Bundles. But Bundles should be stored "as-is", opaque without resolving any references in them.

This fix, changes the function blaze.fhir.spec.type/references to not look inside Bundle entries. The integration test
"bundle-with-references-test" was added to try to issue a transaction that stores a transaction bundle with a reference in it.