### PR TITLE
Revert Purging curl for Future Docker Health Checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre
 
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get purge curl wget libbinutils libctf0 libctf-nobfd0 libncurses6 -y && \
+    apt-get purge wget libbinutils libctf0 libctf-nobfd0 libncurses6 -y && \
     apt-get autoremove -y && apt-get clean
 
 RUN mkdir -p /app/data && chown 1001:1001 /app/data


### PR DESCRIPTION
Docker health check will need curl. However I don't introduce the actual health check in this PR because I don't oversee all implications. For now we have one user that will put the health check in the Docker Compose file.