### PR TITLE
Rename blaze.metrics.Collector to Resolve Loading Issue

### DIFF
--- a/modules/metrics/build.clj
+++ b/modules/metrics/build.clj
@@ -9,4 +9,4 @@
               {:project "deps.edn"
                :compile-opts {:direct-linking true}})
      :class-dir "target/classes"
-     :ns-compile ['blaze.metrics.Collector]}))
+     :ns-compile ['blaze.metrics.collector]}))

--- a/modules/metrics/deps.edn
+++ b/modules/metrics/deps.edn
@@ -39,4 +39,4 @@
     {:mvn/version "1.2.4"}}
 
    :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
-               "-e" ".*spec$" -e "blaze.metrics.Collector"]}}}
+               "-e" ".*spec$" -e "blaze.metrics.collector"]}}}

--- a/modules/metrics/src/blaze/metrics/collector.clj
+++ b/modules/metrics/src/blaze/metrics/collector.clj
@@ -1,4 +1,4 @@
-(ns blaze.metrics.Collector
+(ns blaze.metrics.collector
   (:gen-class
     :extends io.prometheus.client.Collector
     :constructors {[Object] []}
@@ -15,4 +15,4 @@
 
 
 (defn -collect-void [this]
-  ((.-fn ^blaze.metrics.Collector this)))
+  ((.-fn ^blaze.metrics.collector this)))

--- a/modules/metrics/src/blaze/metrics/core.clj
+++ b/modules/metrics/src/blaze/metrics/core.clj
@@ -14,7 +14,7 @@
 
 
 (defmacro collector [& body]
-  `(blaze.metrics.Collector. (fn [] ~@body)))
+  `(blaze.metrics.collector. (fn [] ~@body)))
 
 
 (defn collect


### PR DESCRIPTION
At some unknown location, the namespace blaze.metrics.Collector was loaded in the lower-case form. So I renamed it to resolve this.