### PR TITLE
Remove Test Coverage Dependency from Push Image Job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1169,7 +1169,6 @@ jobs:
       
   push-image:
     needs:
-    - test-coverage
     - image-scan
     - integration-test
     - not-enforcing-referential-integrity-test


### PR DESCRIPTION
The Test Coverage job doesn't require a minimal test coverage. Instead it just upload the coverage results and Codecov will comment later in the PR. We can create the Docker image of all tests run successfully, irrespective of the coverage analysis.