### PR TITLE
[WIP] Read-only Replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [8]: <https://www.yourkit.com/youmonitor/>
 [9]: <https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size>
 [10]: <https://github.com/facebook/rocksdb/wiki/RocksDB-Basics#multi-threaded-compactions>
-[12]: <https://touchstone.aegis.net/touchstone/conformance/history?suite=FHIR4-0-1-Basic-Server&supportedOnly=true&suiteType=HL7_FHIR_SERVER&ownedBy=ALL&ps=10&published=true&pPass=0&strSVersion=6&format=ALL>
+[12]: <https://touchstone.aegis.net/touchstone/conformance/history?suite=FHIR4-0-1-Basic-Server&supportedOnly=true&suiteType=HL7_FHIR_SERVER&ownedBy=ALL&ps=10&sb=spoe&sd=DESC&published=true&pPass=0&strSVersion=22&format=ALL>

--- a/modules/cql/.clj-kondo/config.edn
+++ b/modules/cql/.clj-kondo/config.edn
@@ -36,7 +36,11 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  ;; TODO remove when https://github.com/clj-kondo/clj-kondo/issues/1949 is released
+  :aliased-namespace-var-usage
+  {:level :off}}
 
  :output
  {:exclude-files ["^test/data_readers.clj"]}

--- a/modules/db-stub/src/blaze/db/api_stub.clj
+++ b/modules/db-stub/src/blaze/db/api_stub.clj
@@ -36,9 +36,12 @@
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
+    :resource-store (ig/ref ::rs/kv)
     :clock (ig/ref :blaze.test/clock)}
+
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
+
    :blaze.test/clock {}
 
    :blaze.db/resource-handle-cache {}
@@ -73,7 +76,6 @@
 
    :blaze.db.node/resource-indexer
    {:kv-store (ig/ref :blaze.db/index-kv-store)
-    :resource-store (ig/ref ::rs/kv)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :executor (ig/ref :blaze.db.node.resource-indexer/executor)}
 

--- a/modules/db-tx-log-kafka/deps.edn
+++ b/modules/db-tx-log-kafka/deps.edn
@@ -37,4 +37,5 @@
    {cloverage/cloverage
     {:mvn/version "1.2.4"}}
 
-   :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}
+   :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
+               "-e" ".+spec"]}}}

--- a/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka/spec.clj
+++ b/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka/spec.clj
@@ -1,6 +1,9 @@
 (ns blaze.db.tx-log.kafka.spec
   (:require
+    [blaze.db.tx-log.spec]
     [blaze.executors :as ex]
+    [blaze.fhir.hash.spec]
+    [blaze.fhir.spec.spec]
     [clojure.spec.alpha :as s]))
 
 
@@ -42,3 +45,40 @@
 
 (s/def :blaze.db.tx-log.kafka/key-password
   string?)
+
+
+(defmulti tx-cmd "Transaction command" :op)
+
+
+(defmethod tx-cmd "create" [_]
+  (s/keys :req-un [:blaze.db.tx-cmd/op
+                   :blaze.db.tx-cmd/type
+                   :blaze.resource/id
+                   :blaze.resource/hash]
+          :opt-un [:blaze.db.tx-cmd/refs
+                   :blaze.db.tx-cmd/if-none-exist]))
+
+
+(defmethod tx-cmd "put" [_]
+  (s/keys :req-un [:blaze.db.tx-cmd/op
+                   :blaze.db.tx-cmd/type
+                   :blaze.resource/id
+                   :blaze.resource/hash]
+          :opt-un [:blaze.db.tx-cmd/refs
+                   :blaze.db.tx-cmd/if-match
+                   :blaze.db.tx-cmd/if-none-match]))
+
+
+(defmethod tx-cmd "delete" [_]
+  (s/keys :req-un [:blaze.db.tx-cmd/op
+                   :blaze.db.tx-cmd/type
+                   :blaze.resource/id]
+          :opt-un [:blaze.db.tx-cmd/if-match]))
+
+
+(s/def :blaze.db.tx-log.kafka/tx-cmd
+  (s/multi-spec tx-cmd :op))
+
+
+(s/def :blaze.db.tx-log.kafka/tx-cmds
+  (s/coll-of :blaze.db.tx-log.kafka/tx-cmd :kind vector?))

--- a/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka/codec_test.clj
+++ b/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka/codec_test.clj
@@ -32,7 +32,7 @@
 
 (deftest round-trip-test
   (satisfies-prop 100
-    (p/for-all [tx-cmds (s/gen :blaze.db/tx-cmds)]
+    (p/for-all [tx-cmds (s/gen :blaze.db.tx-log.kafka/tx-cmds)]
       (= tx-cmds (deserialize (serialize tx-cmds))))))
 
 

--- a/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka_test.clj
+++ b/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka_test.clj
@@ -1,6 +1,10 @@
 (ns blaze.db.tx-log.kafka-test
   (:require
     [blaze.anomaly-spec]
+    [blaze.db.kv :as kv]
+    [blaze.db.kv.mem]
+    [blaze.db.resource-store :as rs]
+    [blaze.db.resource-store.kv :as rs-kv]
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log.kafka :as kafka]
     [blaze.executors :as ex]
@@ -45,14 +49,26 @@
 (def bootstrap-servers "bootstrap-servers-182741")
 (def patient-0 {:fhir/type :fhir/Patient :id "0"})
 (def patient-hash-0 (hash/generate patient-0))
-(def tx-cmd {:op "create" :type "Patient" :id "0" :hash patient-hash-0})
+(def create-cmd {:op "create" :type "Patient" :id "0" :resource patient-0})
+(def delete-cmd {:op "delete" :type "Observation" :id "1"})
 
 
 (def system
   {::tx-log/kafka
    {:bootstrap-servers bootstrap-servers
-    :last-t-executor (ig/ref ::kafka/last-t-executor)}
-   ::kafka/last-t-executor {}})
+    :last-t-executor (ig/ref ::kafka/last-t-executor)
+    :resource-store (ig/ref ::rs/kv)}
+
+   ::kafka/last-t-executor {}
+
+   ::rs/kv
+   {:kv-store (ig/ref :blaze.db/resource-kv-store)
+    :executor (ig/ref ::rs-kv/executor)}
+
+   [::kv/mem :blaze.db/resource-kv-store]
+   {:column-families {}}
+
+   ::rs-kv/executor {}})
 
 
 (deftest init-test
@@ -67,15 +83,17 @@
       :key := ::tx-log/kafka
       :reason := ::ig/build-failed-spec
       [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :bootstrap-servers))
-      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :last-t-executor))))
+      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :last-t-executor))
+      [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))))
 
   (testing "invalid bootstrap servers"
     (given-thrown (ig/init {::tx-log/kafka {:bootstrap-servers ::invalid}})
       :key := ::tx-log/kafka
       :reason := ::ig/build-failed-spec
       [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :last-t-executor))
-      [:explain ::s/problems 1 :pred] := `string?
-      [:explain ::s/problems 1 :val] := ::invalid)))
+      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
+      [:explain ::s/problems 2 :pred] := `string?
+      [:explain ::s/problems 2 :val] := ::invalid)))
 
 
 (deftest duration-seconds-collector-init-test
@@ -101,19 +119,31 @@
 
 (deftest tx-log-test
   (testing "submit"
-    (with-redefs
-      [kafka/create-producer
-       (fn [{servers :bootstrap-servers}]
-         (assert (= bootstrap-servers servers))
-         (reify
-           Producer
-           (send [_ _ callback]
-             (.onCompletion callback (RecordMetadata. nil 0 0 0 0 0) nil))
-           AutoCloseable
-           (close [_])))
-       kafka/create-last-t-consumer no-op-consumer]
-      (with-system [{tx-log ::tx-log/kafka} system]
-        (is (= 1 @(tx-log/submit tx-log [tx-cmd] nil)))))
+    (let [record-value (volatile! nil)]
+      (with-redefs
+        [kafka/create-producer
+         (fn [{servers :bootstrap-servers}]
+           (assert (= bootstrap-servers servers))
+           (reify
+             Producer
+             (send [_ record callback]
+               (vreset! record-value (.value record))
+               (.onCompletion callback (RecordMetadata. nil 0 0 0 0 0) nil))
+             AutoCloseable
+             (close [_])))
+         kafka/create-last-t-consumer no-op-consumer]
+        (with-system [{tx-log ::tx-log/kafka} system]
+          (is (= 1 @(tx-log/submit tx-log [create-cmd delete-cmd]))))
+
+        (given @record-value
+          [0 :op] := "create"
+          [0 :type] := "Patient"
+          [0 :id] := "0"
+          [0 :hash] := patient-hash-0
+          [0 :resource] := nil
+          [1 :op] := "delete"
+          [1 :type] := "Observation"
+          [1 :id] := "1")))
 
     (testing "RecordTooLargeException"
       (with-redefs
@@ -129,7 +159,7 @@
              (close [_])))
          kafka/create-last-t-consumer no-op-consumer]
         (with-system [{tx-log ::tx-log/kafka} system]
-          (given-failed-future (tx-log/submit tx-log [tx-cmd] nil)
+          (given-failed-future (tx-log/submit tx-log [create-cmd])
             ::anom/category := ::anom/unsupported
             ::anom/message := "A transaction with 1 commands generated a Kafka message which is larger than the configured maximum of null bytes. In order to prevent this error, increase the maximum message size by setting DB_KAFKA_MAX_REQUEST_SIZE to a higher number. msg-173357"))))
 
@@ -147,7 +177,7 @@
              (close [_])))
          kafka/create-last-t-consumer no-op-consumer]
         (with-system [{tx-log ::tx-log/kafka} system]
-          (given-failed-future @(tx-log/submit tx-log [tx-cmd] nil)
+          (given-failed-future @(tx-log/submit tx-log [create-cmd])
             ::anom/category := ::anom/fault
             ::anom/message := "msg-175337")))))
 

--- a/modules/db-tx-log/src/blaze/db/tx_log.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log.clj
@@ -9,7 +9,7 @@
 
   There might be implementations of TxLog only suitable for single node setups."
 
-  (-submit [tx-log tx-cmds local-payload])
+  (-submit [tx-log tx-cmds])
 
   (-last-t [tx-log])
 
@@ -23,15 +23,11 @@
   potentially valid transaction or complete exceptionally with an anomaly in
   case of errors.
 
-  The `local-payload` will be embedded under :local-payload in the transaction
-  data returned from `poll!` if the transaction log supports this feature and
-  the poller is on the same node as the submitter.
-
   Note: This function only ensures that the transaction is committed into the
   log and will be handled in the future. So a positive return value doesn't mean
   that the transaction itself was successful."
-  [tx-log tx-cmds local-payload]
-  (-submit tx-log tx-cmds local-payload))
+  [tx-log tx-cmds]
+  (-submit tx-log tx-cmds))
 
 
 (defn last-t
@@ -56,9 +52,6 @@
 
 (defn poll!
   "Retrieves and removes the head, a collection of transaction data, of `queue`,
-  waiting up to `timeout` if necessary for transaction data to become available.
-
-  Transaction data optionally contains :local-payload if the transaction was
-  submitted on the same node and the transaction log supports this feature."
+  waiting up to `timeout` if necessary for transaction data to become available."
   [queue timeout]
   (-poll queue timeout))

--- a/modules/db-tx-log/src/blaze/db/tx_log_spec.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log_spec.clj
@@ -10,8 +10,7 @@
 
 ;; returns a CompletableFuture of :blaze.db/t
 (s/fdef tx-log/submit
-  :args (s/cat :tx-log :blaze.db/tx-log :tx-cmds :blaze.db/tx-cmds
-               :local-payload any?)
+  :args (s/cat :tx-log :blaze.db/tx-log :tx-cmds :blaze.db/submit-tx-cmds)
   :ret ac/completable-future?)
 
 

--- a/modules/db-tx-log/test/blaze/db/tx_log/spec_test.clj
+++ b/modules/db-tx-log/test/blaze/db/tx_log/spec_test.clj
@@ -1,5 +1,6 @@
 (ns blaze.db.tx-log.spec-test
   (:require
+    [blaze.async.comp :as ac]
     [blaze.db.tx-log.spec]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
@@ -30,8 +31,10 @@
     0xFFFFFFFFFFFFFF))
 
 
-(def patient-hash-0 (hash/generate {:fhir/type :fhir/Patient :id "0"}))
-(def observation-hash-0 (hash/generate {:fhir/type :fhir/Observation :id "0"}))
+(def patient-0 {:fhir/type :fhir/Patient :id "0"})
+(def patient-hash-0 (hash/generate patient-0))
+(def observation-0 {:fhir/type :fhir/Observation :id "0"})
+(def observation-hash-0 (hash/generate observation-0))
 
 
 (deftest tx-cmd-test
@@ -39,16 +42,19 @@
     {:op "create"
      :type "Patient"
      :id "0"
-     :hash patient-hash-0}
+     :hash patient-hash-0
+     :resource (ac/completed-future patient-0)}
     {:op "create"
      :type "Observation"
      :id "0"
      :hash observation-hash-0
+     :resource (ac/completed-future observation-hash-0)
      :refs [["Patient" "0"]]}
     {:op "put"
      :type "Patient"
      :id "0"
      :hash patient-hash-0
+     :resource (ac/completed-future patient-0)
      :if-match 1}
     {:op "delete"
      :type "Patient"

--- a/modules/db-tx-log/test/blaze/db/tx_log_test.clj
+++ b/modules/db-tx-log/test/blaze/db/tx_log_test.clj
@@ -32,15 +32,14 @@
 
 (deftest submit-test
   (let [tx-log (reify tx-log/TxLog
-                 (-submit [_ _ _]
+                 (-submit [_ _]
                    (ac/completed-future 1)))]
     (is (= 1 @(tx-log/submit
                 tx-log
                 [{:op "create"
                   :type "Patient"
                   :id "0"
-                  :hash patient-hash-0}]
-                nil)))))
+                  :hash patient-hash-0}])))))
 
 
 (deftest last-t-test

--- a/modules/db/.clj-kondo/config.edn
+++ b/modules/db/.clj-kondo/config.edn
@@ -27,6 +27,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  ;; TODO remove when https://github.com/clj-kondo/clj-kondo/issues/1949 is released
+  :aliased-namespace-var-usage
+  {:level :off}}
 
  :skip-comments true}

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -295,9 +295,7 @@
   (-submit-tx [_ tx-ops]
     (log/trace "submit" (count tx-ops) "tx-ops")
     (if-ok [_ (validation/validate-ops tx-ops)]
-      (let [[tx-cmds entries] (tx/prepare-ops context tx-ops)]
-        (-> (rs/put! resource-store entries)
-            (ac/then-compose (fn [_] (tx-log/submit tx-log tx-cmds entries)))))
+      (tx-log/submit tx-log (tx/prepare-ops context tx-ops))
       ac/completed-future))
 
   (-tx-result [node t]

--- a/modules/db/src/blaze/db/node/resource_indexer/spec.clj
+++ b/modules/db/src/blaze/db/node/resource_indexer/spec.clj
@@ -19,6 +19,5 @@
   (s/keys
     :req-un
     [:blaze.db/kv-store
-     :blaze.db/resource-store
      :blaze.db/search-param-registry
      :blaze.db.node.resource-indexer/executor]))

--- a/modules/db/src/blaze/db/tx_log/local.clj
+++ b/modules/db/src/blaze/db/tx_log/local.clj
@@ -1,22 +1,25 @@
 (ns blaze.db.tx-log.local
-  "A transaction log which is suitable only for standalone (single node) setups.
+  "A transaction log which is suitable for standalone (single node) setups.
 
   Uses an exclusive key-value store to persist the transaction log using the
   default column family. The single key-value index is populated where keys are
   the point in time `t` of the transaction and the values are transaction
   commands and instants.
 
-  Uses a single thread named `local-tx-log` to increment the point in time `t`,
-  store the transaction and transfers it to listening queues."
+  Instead of storing the resource contents in the transaction log index itself,
+  a hash of each resource content is generated and stored instead. The resource
+  contents are than stored in the resource store for later retrieval."
   (:require
-    [blaze.anomaly :as ba]
     [blaze.async.comp :as ac]
     [blaze.byte-buffer :as bb]
     [blaze.byte-string :as bs]
     [blaze.db.impl.iterators :as i]
     [blaze.db.kv :as kv]
+    [blaze.db.resource-store :as rs]
+    [blaze.db.resource-store.spec]
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log.local.codec :as codec]
+    [blaze.fhir.hash :as hash]
     [blaze.module :refer [reg-collector]]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
@@ -45,12 +48,25 @@
 (def ^:private ^:const max-poll-size 50)
 
 
-(defn- tx-data [kv-store offset]
+(defn- load-resource [resource-store {:keys [hash] :as tx-cmd}]
+  (cond-> tx-cmd hash (assoc :resource (rs/get resource-store hash))))
+
+
+(defn- load-resources [resource-store tx-cmds]
+  (mapv (partial load-resource resource-store) tx-cmds))
+
+
+(defn- tx-data-xf [resource-store]
+  (comp (map #(update % :tx-cmds (partial load-resources resource-store)))
+        (take max-poll-size)))
+
+
+(defn- tx-data [kv-store resource-store offset]
   (log/trace "fetch tx-data from storage offset =" offset)
   (with-open [snapshot (kv/new-snapshot kv-store)
               iter (kv/new-iterator snapshot)]
     (let [key (bs/from-byte-array (codec/encode-key offset))]
-      (into [] (take max-poll-size) (i/kvs! iter codec/decode-tx-data key)))))
+      (into [] (tx-data-xf resource-store) (i/kvs! iter codec/decode-tx-data key)))))
 
 
 (defn- poll! [^BlockingQueue queue timeout]
@@ -58,12 +74,13 @@
   (.poll queue (time/as timeout :millis) TimeUnit/MILLISECONDS))
 
 
-(deftype LocalQueue [kv-store offset queue queue-start unsubscribe!]
+(deftype LocalQueue
+  [kv-store resource-store offset queue queue-start unsubscribe!]
   tx-log/Queue
   (-poll [_ timeout]
     (let [current-offset @offset]
       (if (< current-offset queue-start)
-        (let [tx-data (tx-data kv-store current-offset)]
+        (let [tx-data (tx-data kv-store resource-store current-offset)]
           (when-let [tx-data (last tx-data)]
             (vreset! offset (inc (:t tx-data))))
           tx-data)
@@ -75,18 +92,50 @@
     (unsubscribe!)))
 
 
+(defn- prepare-entries [tx-cmds]
+  (reduce
+    (fn [r {:keys [resource] :as tx-cmd}]
+      (if resource
+        (let [hash (hash/generate resource)]
+          (-> (update r :entries assoc hash resource)
+              (update :tx-cmds conj (assoc tx-cmd :hash hash))))
+        (update r :tx-cmds conj tx-cmd)))
+    {:entries {}
+     :tx-cmds []}
+    tx-cmds))
+
+
+(defn- store-resources! [resource-store tx-cmds]
+  (let [{:keys [entries tx-cmds]} (prepare-entries tx-cmds)]
+    (-> (rs/put! resource-store entries)
+        (ac/then-apply (fn [_] tx-cmds)))))
+
+
+(defn- remove-resources [tx-cmds]
+  (mapv #(dissoc % :resource) tx-cmds))
+
+
 (defn- store-tx-data! [kv-store {:keys [t instant tx-cmds]}]
   (log/trace "store transaction data with t =" t)
-  (kv/put! kv-store (codec/encode-key t) (codec/encode-tx-data instant tx-cmds)))
+  (kv/put! kv-store (codec/encode-key t)
+           (codec/encode-tx-data instant (remove-resources tx-cmds))))
+
+
+(defn- wrap-resource-in-future [{:keys [resource] :as tx-cmd}]
+  (cond-> tx-cmd resource (update :resource ac/completed-future)))
+
+
+(defn- wrap-resources-in-futures* [tx-cmds]
+  (mapv wrap-resource-in-future tx-cmds))
+
+
+(defn- wrap-resources-in-futures [tx-data]
+  (update tx-data :tx-cmds wrap-resources-in-futures*))
 
 
 (defn- transfer-tx-data! [queues tx-data]
   (log/trace "transfer transaction data to" (count queues) "queue(s)")
-  (run! #(.put ^BlockingQueue % tx-data) queues))
-
-
-(defn- assoc-local-payload [tx-data local-payload]
-  (cond-> tx-data local-payload (assoc :local-payload local-payload)))
+  (run! #(.put ^BlockingQueue % [(wrap-resources-in-futures tx-data)]) queues))
 
 
 (defn- submit!
@@ -96,29 +145,30 @@
   consisting of the new `t`, the current time taken from `clock` and `tx-cmds`.
   Has to be run in a single thread in order to deliver transaction data in
   order."
-  [kv-store clock state tx-cmds local-payload]
+  [kv-store clock state tx-cmds]
   (let [{:keys [t queues]} (swap! state update :t inc)
         tx-data {:t t :instant (Instant/now clock) :tx-cmds tx-cmds}]
     (store-tx-data! kv-store tx-data)
-    (transfer-tx-data! (vals queues) [(assoc-local-payload tx-data local-payload)])
+    (transfer-tx-data! (vals queues) tx-data)
     t))
 
 
 ;; The state contains the following keys:
 ;;  * :t - the current point in time
 ;;  * :queues - a map of queues created through `new-queue`
-(deftype LocalTxLog [kv-store clock ^Lock submit-lock state]
+(deftype LocalTxLog [kv-store resource-store clock ^Lock submit-lock state]
   tx-log/TxLog
-  (-submit [_ tx-cmds local-payload]
+  (-submit [_ tx-cmds]
     (log/trace "submit" (count tx-cmds) "tx-cmds")
     (with-open [_ (prom/timer duration-seconds "submit")]
-      (.lock submit-lock)
-      (try
-        (-> (submit! kv-store clock state tx-cmds local-payload)
-            ba/try-anomaly
-            ac/completed-future)
-        (finally
-          (.unlock submit-lock)))))
+      (-> (store-resources! resource-store tx-cmds)
+          (ac/then-apply
+            (fn [tx-cmds]
+              (.lock submit-lock)
+              (try
+                (submit! kv-store clock state tx-cmds)
+                (finally
+                  (.unlock submit-lock))))))))
 
   (-last-t [_]
     (ac/completed-future (:t @state)))
@@ -128,7 +178,7 @@
           queue (ArrayBlockingQueue. 10)
           queue-start (inc (:t (swap! state update :queues assoc key queue)))]
       (log/trace "new-queue offset =" offset ", queue-start =" queue-start)
-      (->LocalQueue kv-store (volatile! offset) queue queue-start
+      (->LocalQueue kv-store resource-store (volatile! offset) queue queue-start
                     #(swap! state update :queues dissoc key)))))
 
 
@@ -147,13 +197,13 @@
 
 
 (defmethod ig/pre-init-spec :blaze.db.tx-log/local [_]
-  (s/keys :req-un [:blaze.db/kv-store :blaze/clock]))
+  (s/keys :req-un [:blaze.db/kv-store :blaze.db/resource-store :blaze/clock]))
 
 
 (defmethod ig/init-key :blaze.db.tx-log/local
-  [_ {:keys [kv-store clock]}]
+  [_ {:keys [kv-store resource-store clock]}]
   (log/info "Open local transaction log")
-  (->LocalTxLog kv-store clock (ReentrantLock.)
+  (->LocalTxLog kv-store resource-store clock (ReentrantLock.)
                 (atom {:t (or (last-t kv-store) 0)})))
 
 

--- a/modules/db/test-perf/blaze/db/api_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/api_test_perf.clj
@@ -39,9 +39,12 @@
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
+    :resource-store (ig/ref ::rs/kv)
     :clock (ig/ref :blaze.test/clock)}
+
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
+
    :blaze.test/clock {}
 
    :blaze.db/resource-handle-cache {:max-size 1000000}
@@ -76,7 +79,6 @@
 
    :blaze.db.node/resource-indexer
    {:kv-store (ig/ref :blaze.db/index-kv-store)
-    :resource-store (ig/ref ::rs/kv)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :executor (ig/ref :blaze.db.node.resource-indexer/executor)}
 

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -74,12 +74,6 @@
       (ac/completed-future {::anom/category ::anom/fault}))))
 
 
-(def resource-store-failing-on-put-system
-  (-> (assoc-in system [:blaze.db/node :resource-store]
-                (ig/ref ::resource-store-failing-on-put))
-      (assoc ::resource-store-failing-on-put {})))
-
-
 (deftest sync-test
   (testing "on already available database value"
     (with-system-data [{:blaze.db/keys [node]} system]
@@ -512,13 +506,6 @@
                   (map
                     #(= % (d/type-total (d/as-of db %) "Patient"))
                     (range 100))))))))))
-
-  (testing "with failing resource storage"
-    (testing "on put"
-      (with-system [{:blaze.db/keys [node]} resource-store-failing-on-put-system]
-        (given-failed-future
-          (d/transact node [[:put {:fhir/type :fhir/Patient :id "0"}]])
-          ::anom/category := ::anom/fault))))
 
   (testing "with failing resource indexer"
     (with-redefs

--- a/modules/db/test/blaze/db/node/transaction_spec.clj
+++ b/modules/db/test/blaze/db/node/transaction_spec.clj
@@ -8,4 +8,4 @@
 
 (s/fdef tx/prepare-ops
   :args (s/cat :context :blaze.db.node.transaction/context :tx-ops :blaze.db/tx-ops)
-  :ret (s/tuple :blaze.db/tx-cmds (s/map-of :blaze.resource/hash :blaze/resource)))
+  :ret :blaze.db/submit-tx-cmds)

--- a/modules/db/test/blaze/db/node/tx_indexer_spec.clj
+++ b/modules/db/test/blaze/db/node/tx_indexer_spec.clj
@@ -9,6 +9,10 @@
     [cognitect.anomalies :as anom]))
 
 
+(s/def :blaze.db.node.tx-indexer/tx-data
+  (s/keys :req-un [:blaze.db/t :blaze.db.tx/instant :blaze.db.node.tx-indexer/tx-cmds]))
+
+
 (s/fdef tx-indexer/index-tx
-  :args (s/cat :db-before :blaze.db/db :tx-data :blaze.db/tx-data)
+  :args (s/cat :db-before :blaze.db/db :tx-data :blaze.db.node.tx-indexer/tx-data)
   :ret (s/or :entries (s/coll-of :blaze.db.kv/put-entry) :anomaly ::anom/anomaly))

--- a/modules/db/test/blaze/db/test_util.clj
+++ b/modules/db/test/blaze/db/test_util.clj
@@ -30,6 +30,7 @@
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
+    :resource-store (ig/ref ::rs/kv)
     :clock (ig/ref :blaze.test/clock)}
 
    [::kv/mem :blaze.db/transaction-kv-store]
@@ -71,7 +72,6 @@
 
    :blaze.db.node/resource-indexer
    {:kv-store (ig/ref :blaze.db/index-kv-store)
-    :resource-store (ig/ref ::rs/kv)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :executor (ig/ref :blaze.db.node.resource-indexer/executor)}
 

--- a/modules/db/test/blaze/db/tx_log/local/codec_spec.clj
+++ b/modules/db/test/blaze/db/tx_log/local/codec_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.byte-buffer :as bb]
     [blaze.db.tx-log.local.codec :as codec]
+    [blaze.db.tx-log.local.spec]
     [blaze.db.tx-log.spec]
     [clojure.spec.alpha :as s]))
 
@@ -12,7 +13,7 @@
 
 
 (s/fdef codec/encode-tx-data
-  :args (s/cat :instant :blaze.db.tx/instant :tx-cmds :blaze.db/tx-cmds)
+  :args (s/cat :instant :blaze.db.tx/instant :tx-cmds :blaze.db.tx-log.local/tx-cmds)
   :ret bytes?)
 
 

--- a/modules/db/test/blaze/db/tx_log/local/spec.clj
+++ b/modules/db/test/blaze/db/tx_log/local/spec.clj
@@ -1,20 +1,12 @@
-(ns blaze.db.node.tx-indexer.verify-spec
+(ns blaze.db.tx-log.local.spec
   (:require
-    [blaze.byte-string-spec]
-    [blaze.db.impl.index-spec]
-    [blaze.db.impl.index.resource-as-of-spec]
-    [blaze.db.impl.index.rts-as-of-spec]
-    [blaze.db.impl.index.system-stats-spec]
-    [blaze.db.impl.index.type-stats-spec]
-    [blaze.db.kv.spec]
-    [blaze.db.node.tx-indexer.verify :as verify]
-    [blaze.db.spec]
     [blaze.db.tx-log.spec]
-    [clojure.spec.alpha :as s]
-    [cognitect.anomalies :as anom]))
+    [blaze.fhir.hash.spec]
+    [blaze.fhir.spec.spec]
+    [clojure.spec.alpha :as s]))
 
 
-(defmulti tx-cmd "Transaction command without resource" :op)
+(defmulti tx-cmd "Transaction command" :op)
 
 
 (defmethod tx-cmd "create" [_]
@@ -43,15 +35,9 @@
           :opt-un [:blaze.db.tx-cmd/if-match]))
 
 
-(s/def :blaze.db.node.tx-indexer/tx-cmd
+(s/def :blaze.db.tx-log.local/tx-cmd
   (s/multi-spec tx-cmd :op))
 
 
-(s/def :blaze.db.node.tx-indexer/tx-cmds
-  (s/coll-of :blaze.db.node.tx-indexer/tx-cmd :kind vector?))
-
-
-(s/fdef verify/verify-tx-cmds
-  :args (s/cat :db-before :blaze.db/db :t :blaze.db/t :cmds :blaze.db.node.tx-indexer/tx-cmds)
-  :ret (s/or :entries (s/coll-of :blaze.db.kv/put-entry)
-             :anomaly ::anom/anomaly))
+(s/def :blaze.db.tx-log.local/tx-cmds
+  (s/coll-of :blaze.db.tx-log.local/tx-cmd :kind vector?))

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -1,16 +1,21 @@
 (ns blaze.db.tx-log.local-test
   (:require
+    [blaze.async.comp :as ac]
     [blaze.byte-string :as bs]
     [blaze.db.kv :as kv]
     [blaze.db.kv.mem]
     [blaze.db.kv.mem-spec]
+    [blaze.db.resource-store :as rs]
+    [blaze.db.resource-store.kv :as rs-kv]
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log.local]
     [blaze.db.tx-log.local-spec]
     [blaze.db.tx-log.local.codec :as codec]
+    [blaze.db.tx-log.local.codec-spec]
     [blaze.db.tx-log.spec]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
+    [blaze.fhir.spec :as fhir-spec]
     [blaze.log]
     [blaze.test-util :as tu :refer [given-failed-future given-thrown with-system]]
     [clojure.spec.alpha :as s]
@@ -50,8 +55,10 @@
      :modules [bs/object-mapper-module]}))
 
 
-(def patient-hash-0 (hash/generate {:fhir/type :fhir/Patient :id "0"}))
-(def observation-hash-0 (hash/generate {:fhir/type :fhir/Observation :id "0"}))
+(def patient-0 {:fhir/type :fhir/Patient :id "0"})
+(def patient-hash-0 (hash/generate patient-0))
+(def observation-0 {:fhir/type :fhir/Observation :id "0"})
+(def observation-hash-0 (hash/generate observation-0))
 
 
 (defn invalid-cbor-content
@@ -82,9 +89,21 @@
 (def system
   {::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
+    :resource-store (ig/ref ::rs/kv)
     :clock (ig/ref :blaze.test/clock)}
+
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
+
+   ::rs/kv
+   {:kv-store (ig/ref :blaze.db/resource-kv-store)
+    :executor (ig/ref ::rs-kv/executor)}
+
+   [::kv/mem :blaze.db/resource-kv-store]
+   {:column-families {}}
+
+   ::rs-kv/executor {}
+
    :blaze.test/clock {}})
 
 
@@ -92,12 +111,27 @@
   (assoc-in system [[::kv/mem :blaze.db/transaction-kv-store] :init-data] init-data))
 
 
+(defn- assoc-resource-store-init-data [system init-data]
+  (assoc-in system [[::kv/mem :blaze.db/resource-kv-store] :init-data] init-data))
+
+
 (def failing-kv-store-system
-  {::tx-log/local
-   {:kv-store (ig/ref ::failing-kv-store)
-    :clock (ig/ref :blaze.test/clock)}
-   ::failing-kv-store {}
-   :blaze.test/clock {}})
+  (-> (assoc-in system [::tx-log/local :kv-store] (ig/ref ::failing-kv-store))
+      (assoc ::failing-kv-store {})))
+
+
+(defmethod ig/init-key ::resource-store-failing-on-put [_ _]
+  (reify
+    rs/ResourceStore
+    (-put [_ _]
+      (ac/completed-future
+        {::anom/category ::anom/fault
+         ::anom/message "resource-store-put-error"}))))
+
+
+(def resource-store-failing-on-put-system
+  (-> (assoc-in system [::tx-log/local :resource-store] (ig/ref ::resource-store-failing-on-put))
+      (assoc ::resource-store-failing-on-put {})))
 
 
 (deftest init-test
@@ -112,7 +146,8 @@
       :key := ::tx-log/local
       :reason := ::ig/build-failed-spec
       [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
-      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :clock)))))
+      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
+      [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :clock)))))
 
 
 (defn- write-cbor [x]
@@ -131,14 +166,17 @@
 
   (testing "an already filled transaction log"
     (with-system [{tx-log ::tx-log/local}
-                  (assoc-kv-store-init-data
-                    system
-                    [[(codec/encode-key 1)
-                      (codec/encode-tx-data
-                        (Instant/ofEpochSecond 0)
-                        [{:op "create" :type "Patient" :id "0"
-                          :hash patient-hash-0}
-                         {:op "delete" :type "Patient" :id "1"}])]])]
+                  (-> system
+                      (assoc-kv-store-init-data
+                        [[(codec/encode-key 1)
+                          (codec/encode-tx-data
+                            (Instant/ofEpochSecond 0)
+                            [{:op "create" :type "Patient" :id "0"
+                              :hash patient-hash-0}
+                             {:op "delete" :type "Patient" :id "1"}])]])
+                      (assoc-resource-store-init-data
+                        [[(hash/to-byte-array patient-hash-0)
+                          (fhir-spec/unform-cbor patient-0)]]))]
 
       (testing "the last `t` is one"
         (is (= 1 @(tx-log/last-t tx-log))))
@@ -151,14 +189,19 @@
             [:tx-cmds 0 :op] := "create"
             [:tx-cmds 0 :type] := "Patient"
             [:tx-cmds 0 :id] := "0"
-            [:tx-cmds 0 :hash] := patient-hash-0)))))
+            [:tx-cmds 0 :hash] := patient-hash-0
+            [:tx-cmds 0 :resource ac/join] := patient-0
+            [:tx-cmds 1 :op] := "delete"
+            [:tx-cmds 1 :type] := "Patient"
+            [:tx-cmds 1 :id] := "1"
+            [:tx-cmds 1 :hash] := nil
+            [:tx-cmds 1 :resource] := nil)))))
 
   (testing "with one submitted command in one transaction"
     (with-system [{tx-log ::tx-log/local} system]
       @(tx-log/submit
          tx-log
-         [{:op "create" :type "Patient" :id "0" :hash patient-hash-0}]
-         nil)
+         [{:op "create" :type "Patient" :id "0" :resource patient-0}])
 
       (with-open [queue (tx-log/new-queue tx-log 1)]
         (given (first (tx-log/poll! queue (time/millis 10)))
@@ -167,20 +210,19 @@
           [:tx-cmds 0 :op] := "create"
           [:tx-cmds 0 :type] := "Patient"
           [:tx-cmds 0 :id] := "0"
-          [:tx-cmds 0 :hash] := patient-hash-0))))
+          [:tx-cmds 0 :hash] := patient-hash-0
+          [:tx-cmds 0 :resource ac/join] := patient-0))))
 
   (testing "with two submitted commands in two transactions"
     (with-system [{tx-log ::tx-log/local} system]
       @(tx-log/submit
          tx-log
-         [{:op "create" :type "Patient" :id "0" :hash patient-hash-0}]
-         nil)
+         [{:op "create" :type "Patient" :id "0" :resource patient-0}])
       @(tx-log/submit
          tx-log
          [{:op "create" :type "Observation" :id "0"
-           :hash observation-hash-0
-           :refs [["Patient" "0"]]}]
-         nil)
+           :resource observation-0
+           :refs [["Patient" "0"]]}])
 
       (with-open [queue (tx-log/new-queue tx-log 1)]
         (given (second (tx-log/poll! queue (time/millis 10)))
@@ -190,39 +232,49 @@
           [:tx-cmds 0 :type] := "Observation"
           [:tx-cmds 0 :id] := "0"
           [:tx-cmds 0 :hash] := observation-hash-0
+          [:tx-cmds 0 :resource ac/join] := observation-0
           [:tx-cmds 0 :refs] := [["Patient" "0"]]))))
 
-  (testing "with local payload"
+  (testing "with one submitted command after opening the queue"
     (with-system [{tx-log ::tx-log/local} system]
       (with-open [queue (tx-log/new-queue tx-log 1)]
         @(tx-log/submit
            tx-log
-           [{:op "create" :type "Patient" :id "0" :hash patient-hash-0}]
-           ::payload)
+           [{:op "create" :type "Patient" :id "0" :resource patient-0}])
 
         (given (first (tx-log/poll! queue (time/millis 10)))
-          :local-payload := ::payload))))
+          :t := 1
+          :instant := (Instant/ofEpochSecond 0)
+          [:tx-cmds 0 :op] := "create"
+          [:tx-cmds 0 :type] := "Patient"
+          [:tx-cmds 0 :id] := "0"
+          [:tx-cmds 0 :hash] := patient-hash-0
+          [:tx-cmds 0 :resource ac/join] := patient-0))))
 
   (testing "with invalid transaction data"
     (testing "with invalid key"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array 0) (byte-array 0))
+      (with-system [{tx-log ::tx-log/local}
+                    (assoc-kv-store-init-data
+                      system
+                      [[(byte-array 0) (byte-array 0)]])]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 1)]
             (is (empty? (tx-log/poll! queue (time/millis 10))))))))
 
     (testing "with invalid key followed by valid entry"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array 0) (byte-array 0))
-        (kv/put! kv-store (codec/encode-key 1) (codec/encode-tx-data
-                                                 (Instant/ofEpochSecond 0)
-                                                 [{:op "create" :type "Patient" :id "0"
-                                                   :hash patient-hash-0}]))
+      (with-system [{tx-log ::tx-log/local}
+                    (-> system
+                        (assoc-kv-store-init-data
+                          [[(byte-array 0) (byte-array 0)]
+                           [(codec/encode-key 1)
+                            (codec/encode-tx-data
+                              (Instant/ofEpochSecond 0)
+                              [{:op "create" :type "Patient" :id "0"
+                                :hash patient-hash-0}])]])
+                        (assoc-resource-store-init-data
+                          [[(hash/to-byte-array patient-hash-0)
+                            (fhir-spec/unform-cbor patient-0)]]))]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 0)]
@@ -232,18 +284,23 @@
               [:tx-cmds 0 :op] := "create"
               [:tx-cmds 0 :type] := "Patient"
               [:tx-cmds 0 :id] := "0"
-              [:tx-cmds 0 :hash] := patient-hash-0)))))
+              [:tx-cmds 0 :hash] := patient-hash-0
+              [:tx-cmds 0 :resource ac/join] := patient-0)))))
 
     (testing "with two invalid keys followed by valid entry"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array 0) (byte-array 0))
-        (kv/put! kv-store (byte-array 1) (byte-array 0))
-        (kv/put! kv-store (codec/encode-key 1) (codec/encode-tx-data
-                                                 (Instant/ofEpochSecond 0)
-                                                 [{:op "create" :type "Patient" :id "0"
-                                                   :hash patient-hash-0}]))
+      (with-system [{tx-log ::tx-log/local}
+                    (-> system
+                        (assoc-kv-store-init-data
+                          [[(byte-array 0) (byte-array 0)]
+                           [(byte-array 1) (byte-array 0)]
+                           [(codec/encode-key 1)
+                            (codec/encode-tx-data
+                              (Instant/ofEpochSecond 0)
+                              [{:op "create" :type "Patient" :id "0"
+                                :hash patient-hash-0}])]])
+                        (assoc-resource-store-init-data
+                          [[(hash/to-byte-array patient-hash-0)
+                            (fhir-spec/unform-cbor patient-0)]]))]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 0)]
@@ -253,43 +310,44 @@
               [:tx-cmds 0 :op] := "create"
               [:tx-cmds 0 :type] := "Patient"
               [:tx-cmds 0 :id] := "0"
-              [:tx-cmds 0 :hash] := patient-hash-0)))))
+              [:tx-cmds 0 :hash] := patient-hash-0
+              [:tx-cmds 0 :resource ac/join] := patient-0)))))
 
     (testing "with empty value"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array Long/BYTES) (byte-array 0))
+      (with-system [{tx-log ::tx-log/local}
+                    (assoc-kv-store-init-data
+                      system
+                      [[(byte-array Long/BYTES) (byte-array 0)]])]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 1)]
             (is (empty? (tx-log/poll! queue (time/millis 10))))))))
 
     (testing "with invalid cbor value"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array Long/BYTES) (invalid-cbor-content))
+      (with-system [{tx-log ::tx-log/local}
+                    (assoc-kv-store-init-data
+                      system
+                      [[(byte-array Long/BYTES) (invalid-cbor-content)]])]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 1)]
             (is (empty? (tx-log/poll! queue (time/millis 10))))))))
 
     (testing "with invalid instant value"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array Long/BYTES) (write-cbor {:instant ""}))
+      (with-system [{tx-log ::tx-log/local}
+                    (assoc-kv-store-init-data
+                      system
+                      [[(byte-array Long/BYTES) (write-cbor {:instant ""})]])]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 1)]
             (is (empty? (tx-log/poll! queue (time/millis 10))))))))
 
     (testing "with invalid tx-cmd value"
-      (with-system [{tx-log ::tx-log/local
-                     kv-store [::kv/mem :blaze.db/transaction-kv-store]}
-                    system]
-        (kv/put! kv-store (byte-array Long/BYTES) (write-cbor {:tx-cmds [{}]}))
+      (with-system [{tx-log ::tx-log/local}
+                    (assoc-kv-store-init-data
+                      system
+                      [[(byte-array Long/BYTES) (write-cbor {:tx-cmds [{}]})]])]
 
         (testing "the invalid transaction data is ignored"
           (with-open [queue (tx-log/new-queue tx-log 1)]
@@ -300,9 +358,20 @@
         (-> (given-failed-future
               (tx-log/submit
                 tx-log
-                [{:op "create" :type "Patient" :id "0" :hash patient-hash-0}]
-                nil)
+                [{:op "create" :type "Patient" :id "0" :resource patient-0}])
               ::anom/message := "put-error"))
+
+        (with-open [queue (tx-log/new-queue tx-log 1)]
+          (is (empty? (tx-log/poll! queue (time/millis 10)))))))
+
+    (testing "with failing resource-store"
+      (with-system [{tx-log ::tx-log/local} resource-store-failing-on-put-system]
+        (-> (given-failed-future
+              (tx-log/submit
+                tx-log
+                [{:op "create" :type "Patient" :id "0" :resource patient-0}])
+              ::anom/category := ::anom/fault
+              ::anom/message := "resource-store-put-error"))
 
         (with-open [queue (tx-log/new-queue tx-log 1)]
           (is (empty? (tx-log/poll! queue (time/millis 10)))))))))

--- a/modules/fhir-structure/src/blaze/fhir/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec.clj
@@ -94,7 +94,7 @@
 
 
 (defn unform-cbor
-  "Returns the CBOR representation of `resource`."
+  "Returns the CBOR representation of `resource` as byte array."
   [resource]
   (let [key (transform-type-key (type/type resource) "cbor")]
     (if-let [spec (s2/get-spec key)]

--- a/modules/operation-measure-evaluate-measure/.clj-kondo/config.edn
+++ b/modules/operation-measure-evaluate-measure/.clj-kondo/config.edn
@@ -22,6 +22,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  ;; TODO remove when https://github.com/clj-kondo/clj-kondo/issues/1949 is released
+  :aliased-namespace-var-usage
+  {:level :off}}
 
  :skip-comments true}

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -141,9 +141,7 @@
 
 
 (defn encode-base64 [^String s]
-  (-> (Base64/getEncoder)
-      (.encode (.getBytes s StandardCharsets/UTF_8))
-      (String. StandardCharsets/UTF_8)))
+  (.encodeToString (Base64/getEncoder) (.getBytes s StandardCharsets/UTF_8)))
 
 
 (defn library-content [content]

--- a/modules/rocksdb/.clj-kondo/config.edn
+++ b/modules/rocksdb/.clj-kondo/config.edn
@@ -16,6 +16,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  ;; TODO remove when https://github.com/clj-kondo/clj-kondo/issues/1949 is released
+  :aliased-namespace-var-usage
+  {:level :off}}
 
  :skip-comments true}

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -190,7 +190,6 @@
 
   :blaze.db.node/resource-indexer
   {:kv-store #blaze/ref :blaze.db/index-kv-store
-   :resource-store #blaze/ref :blaze.db/resource-cache
    :search-param-registry #blaze/ref :blaze.db/search-param-registry
    :executor #blaze/ref :blaze.db.node.resource-indexer/executor}
 
@@ -294,6 +293,7 @@
    ;;
    :blaze.db.tx-log/local
    {:kv-store #blaze/ref :blaze.db/transaction-kv-store
+    :resource-store #blaze/ref :blaze.db/resource-cache
     :clock #blaze/ref :blaze/clock}
 
    :blaze.db.tx-log.local/duration-seconds {}
@@ -336,7 +336,7 @@
    ;;
    ;; Local Page Store
    ;;
-   ;; Can be referred by the super key :blaze.db/resource-store.
+   ;; Can be referred by the super key :blaze/page-store.
    ;;
    :blaze.page-store/local
    {:secure-rng #blaze/ref :blaze/secure-rng}}
@@ -444,6 +444,7 @@
    ;;
    :blaze.db.tx-log/local
    {:kv-store #blaze/ref :blaze.db/transaction-kv-store
+    :resource-store #blaze/ref :blaze.db/resource-cache
     :clock #blaze/ref :blaze/clock}
 
    :blaze.db.tx-log.local/duration-seconds {}
@@ -526,7 +527,7 @@
    ;;
    ;; Local Page Store
    ;;
-   ;; Can be referred by the super key :blaze.db/resource-store.
+   ;; Can be referred by the super key :blaze/page-store.
    ;;
    :blaze.page-store/local
    {:secure-rng #blaze/ref :blaze/secure-rng}}
@@ -649,7 +650,8 @@
     :ssl-truststore-password #blaze/cfg ["DB_KAFKA_SSL_TRUSTSTORE_PASSWORD" string?]
     :ssl-keystore-location #blaze/cfg ["DB_KAFKA_SSL_KEYSTORE_LOCATION" string?]
     :ssl-keystore-password #blaze/cfg ["DB_KAFKA_SSL_KEYSTORE_PASSWORD" string?]
-    :ssl-key-password #blaze/cfg ["DB_KAFKA_SSL_KEY_PASSWORD" string?]}
+    :ssl-key-password #blaze/cfg ["DB_KAFKA_SSL_KEY_PASSWORD" string?]
+    :resource-store #blaze/ref :blaze.db/resource-cache}
 
    :blaze.db.tx-log.kafka/last-t-executor {}
    :blaze.db.tx-log.kafka/duration-seconds {}


### PR DESCRIPTION
### Prepare Transaction Log API to Transport Resources

Before that change the transaction log API handled only resource hashes instead of whole resources. The resources itself had to be handled outside of the transaction log.

Now the API of the transaction log takes resources instead of hashes. Internally the local and the Kafka implementation still use the resource store in order to transport the resources out-of-band so that the transaction log storage itself doesn't have to contain the whole resources.

This change enables transaction log implementations that transport the resources in-band and so don't need a resource store. At least not for the resources that are not already indexed.

This change is fully compatible with the current storage model and so is a pure refactoring.