### PR TITLE
Add Evaluate Measure Timeout

### DIFF
--- a/.github/scripts/evaluate-measure-timeout.sh
+++ b/.github/scripts/evaluate-measure-timeout.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+BASE="http://localhost:8080/fhir"
+NAME="$1"
+
+DIAGNOSTICS=$(blazectl --server "$BASE" evaluate-measure ".github/scripts/cql/$NAME.yml" 2> /dev/null | grep Diagnostics | cut -d: -f2 | xargs)
+
+if [ "$DIAGNOSTICS" = "Timeout of 10 millis eclipsed while evaluating." ]; then
+  echo "Success: timeout happened"
+else
+  echo "Fail: no timeout"
+  exit 1
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@master
       with:
-        clj-kondo: '2022.10.05'
+        clj-kondo: '2023.01.20'
 
     - name: Check out Git repository
       uses: actions/checkout@v3
@@ -645,6 +645,44 @@ jobs:
     - name: Load Data
       run: blazectl --no-progress --server http://localhost:8080/fhir upload .github/test-data/big-tx
 
+  evaluate-measure-timeout-test:
+    needs: build
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+
+    - name: Install Blazectl
+      run: .github/scripts/install-blazectl.sh
+
+    - name: Download Blaze Image
+      uses: actions/download-artifact@v3
+      with:
+        name: blaze-image
+        path: /tmp
+
+    - name: Load Blaze Image
+      run: docker load --input /tmp/blaze.tar
+
+    - name: Run Blaze
+      run: docker run --name blaze -d -e JAVA_TOOL_OPTIONS=-Xmx2g -e FHIR_OPERATION_EVALUATE_MEASURE_TIMEOUT=10 -p 8080:8080 -v blaze-data:/app/data blaze:latest
+
+    - name: Wait for Blaze
+      run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
+
+    - name: Docker Logs
+      run: docker logs blaze
+
+    - name: Check Capability Statement
+      run: .github/scripts/check-capability-statement.sh
+
+    - name: Load Data
+      run: blazectl --no-progress --server http://localhost:8080/fhir upload .github/test-data/synthea
+
+    - name: Evaluate CQL Query 1
+      run: .github/scripts/evaluate-measure-timeout.sh q1
+
   include-without-referential-integrity-test:
     needs: build
     runs-on: ubuntu-22.04
@@ -1203,6 +1241,7 @@ jobs:
     - not-enforcing-referential-integrity-test
     - small-transactions-test
     - big-transaction-test
+    - evaluate-measure-timeout-test
     - include-without-referential-integrity-test
     - chaining-without-referential-integrity-test
     - bundle-with-references-test

--- a/docs/cql-queries.md
+++ b/docs/cql-queries.md
@@ -11,7 +11,7 @@ If you like to use the command line, please look into [this section](cql-queries
 
 ## API Documentation
 
-If yopu like to use the CQL Evaluation API directly, please read the [CQL API Documentation](cql-queries/api.md).
+If you'd like to use the CQL Evaluation API directly, please read the [CQL API Documentation](cql-queries/api.md).
 
 ## Install the Quality Reporting UI
 

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -86,6 +86,7 @@ More information about distributed deployment are available [here](distributed.m
 | LOG_LEVEL                               | info                       | v0.6   | —      | one of trace, debug, info, warn or error                                                       |
 | JAVA_TOOL_OPTIONS                       | —                          | —      | —      | JVM options \(Docker only\)                                                                    |
 | FHIR_OPERATION_EVALUATE_MEASURE_THREADS | 4                          | v0.8   | —      | The maximum number of parallel $evaluate-measure executions.                                   |
+| FHIR_OPERATION_EVALUATE_MEASURE_TIMEOUT | 3600000 (1h)               | v0.19  | —      | Timeout in milliseconds for $evaluate-measure executions.                                      |
 | OPENID_PROVIDER_URL                     | —                          | v0.11  | —      | [OpenID Connect][4] provider URL to enable [authentication][5]                                 |
 | ENFORCE_REFERENTIAL_INTEGRITY           | true                       | v0.14  | —      | Enforce referential integrity on resource create, update and delete.                           |
 | DB_SYNC_TIMEOUT                         | 10000                      | v0.15  | —      | Timeout in milliseconds for all reading FHIR interactions acquiring the newest database state. |

--- a/docs/performance/fhir-search/simple-code-search.sh
+++ b/docs/performance/fhir-search/simple-code-search.sh
@@ -10,7 +10,7 @@ RESOURCE_HANDLE_CACHE_SIZE=30000000
 start-blaze() {
   echo "Starting Blaze..."
   docker run --name blaze --rm -v "$VOLUME:/app/data" \
-      -e JAVA_TOOL_OPTIONS="-Xmx${HEAP_SIZE}g -Dclojure.compiler.direct-linking=true" \
+      -e JAVA_TOOL_OPTIONS="-Xmx${HEAP_SIZE}g" \
       -e LOG_LEVEL=debug \
       -e DB_BLOCK_CACHE_SIZE=$BLOCK_CACHE_SIZE \
       -e DB_RESOURCE_CACHE_SIZE=$RESOURCE_CACHE_SIZE \
@@ -19,7 +19,7 @@ start-blaze() {
       -e DB_RESOURCE_INDEXER_THREADS=16 \
       -p 8080:8080 \
       -p 8081:8081 \
-      -d samply/blaze:pr-678
+      -d samply/blaze:0.18
 
   ../../.github/scripts/wait-for-url.sh  http://localhost:8080/health
   echo "Finished"

--- a/docs/performance/import.sh
+++ b/docs/performance/import.sh
@@ -5,14 +5,14 @@ C=8
 
 import-once() {
   docker run --name blaze --rm -v blaze-data:/app/data \
-    -e JAVA_TOOL_OPTIONS="-Xmx4g -Dclojure.compiler.direct-linking=true" \
+    -e JAVA_TOOL_OPTIONS="-Xmx4g" \
     -e LOG_LEVEL=debug \
     -e DB_BLOCK_CACHE_SIZE=8192 \
     -e DB_MAX_BACKGROUND_JOBS=16 \
     -e DB_RESOURCE_INDEXER_THREADS=16 \
     -p 8080:8080 \
     -p 8081:8081 \
-    -d samply/blaze:pr-678
+    -d samply/blaze:0.18
 
   ../../.github/scripts/wait-for-url.sh  http://localhost:8080/health
 

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
@@ -19,6 +19,7 @@
     [blaze.spec]
     [clojure.spec.alpha :as s]
     [integrant.core :as ig]
+    [java-time.api :as time]
     [reitit.core :as reitit]
     [ring.util.response :as ring]
     [taoensso.timbre :as log])
@@ -123,7 +124,8 @@
 
 
 (defmethod ig/pre-init-spec ::handler [_]
-  (s/keys :req-un [:blaze.db/node ::executor :blaze/clock :blaze/rng-fn]))
+  (s/keys :req-un [:blaze.db/node ::executor :blaze/clock :blaze/rng-fn]
+          :opt-un [::timeout]))
 
 
 (defmethod ig/init-key ::handler [_ context]
@@ -131,6 +133,14 @@
   (-> (handler context)
       wrap-coerce-params
       (wrap-observe-request-duration "operation-evaluate-measure")))
+
+
+(defmethod ig/pre-init-spec ::timeout [_]
+  (s/keys :req-un [:blaze.fhir.operation.evaluate-measure.timeout/millis]))
+
+
+(defmethod ig/init-key ::timeout [_ {:keys [millis]}]
+  (time/millis millis))
 
 
 (defmethod ig/pre-init-spec ::executor [_]

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/spec.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/spec.clj
@@ -1,12 +1,22 @@
 (ns blaze.fhir.operation.evaluate-measure.spec
   (:require
     [blaze.executors :as ex]
-    [clojure.spec.alpha :as s]))
+    [blaze.fhir.operation.evaluate-measure :as-alias measure]
+    [clojure.spec.alpha :as s]
+    [java-time.api :as time]))
 
 
-(s/def :blaze.fhir.operation.evaluate-measure/executor
+(s/def ::measure/executor
   ex/executor?)
 
 
-(s/def :blaze.fhir.operation.evaluate-measure/num-threads
+(s/def ::measure/num-threads
+  pos-int?)
+
+
+(s/def ::measure/timeout
+  time/duration?)
+
+
+(s/def :blaze.fhir.operation.evaluate-measure.timeout/millis
   nat-int?)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql/spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql/spec.clj
@@ -1,0 +1,31 @@
+(ns blaze.fhir.operation.evaluate-measure.cql.spec
+  (:require
+    [blaze.elm.compiler :as-alias compiler]
+    [blaze.fhir.operation.evaluate-measure.cql :as-alias cql]
+    [clojure.spec.alpha :as s]
+    [java-time.api :as time]))
+
+
+(s/def ::cql/now
+  time/offset-date-time?)
+
+
+(s/def ::cql/timeout-eclipsed?
+  ifn?)
+
+
+(s/def ::cql/timeout
+  time/duration?)
+
+
+(s/def ::cql/context
+  (s/keys :req-un [:blaze.db/db ::cql/now ::cql/timeout-eclipsed? ::cql/timeout
+                   ::compiler/expression-defs]))
+
+
+(s/def ::cql/parameters
+  (s/map-of string? any?))
+
+
+(s/def ::cql/individual-context
+  (s/merge ::cql/context (s/keys :opt-un [::cql/parameters])))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_spec.clj
@@ -1,43 +1,26 @@
 (ns blaze.fhir.operation.evaluate-measure.cql-spec
   (:require
     [blaze.db.spec]
-    [blaze.elm.compiler :as-alias compiler]
     [blaze.elm.compiler.library-spec]
     [blaze.elm.expression-spec]
     [blaze.fhir.operation.evaluate-measure.cql :as cql]
+    [blaze.fhir.operation.evaluate-measure.cql.spec]
     [blaze.fhir.operation.evaluate-measure.measure :as-alias measure]
     [blaze.fhir.operation.evaluate-measure.measure.spec]
     [blaze.fhir.spec]
     [clojure.spec.alpha :as s]
-    [cognitect.anomalies :as anom]
-    [java-time.api :as time]))
-
-
-(s/def ::now
-  time/offset-date-time?)
-
-
-(s/def ::parameters
-  (s/map-of string? any?))
-
-
-(s/def ::context
-  (s/keys :req-un [:blaze.db/db ::now ::compiler/expression-defs]))
-
-
-(s/def ::individual-context
-  (s/keys :req-un [:blaze.db/db ::now ::compiler/expression-defs] :opt-un [::parameters]))
+    [cognitect.anomalies :as anom]))
 
 
 (s/fdef cql/evaluate-expression
-  :args (s/cat :context ::context :name string? :subject-type :fhir.resource/type
+  :args (s/cat :context ::cql/context :name string? :subject-type :fhir.resource/type
                :population-basis (s/alt :subject-based #{:boolean} :other :fhir.resource/type))
   :ret (s/or :handles ::measure/handles
              :anomaly ::anom/anomaly))
 
 
 (s/fdef cql/evaluate-individual-expression
-  :args (s/cat :context ::individual-context
+  :args (s/cat :context ::cql/individual-context
                :subject-handle :blaze.db/resource-handle
                :name string?)
   :ret (s/or :value any?
@@ -45,7 +28,7 @@
 
 
 (s/fdef cql/calc-strata
-  :args (s/cat :context ::context
+  :args (s/cat :context ::cql/context
                :expression-name string?
                :handles ::measure/handles)
   :ret (s/or :strata (s/map-of any? ::measure/handles)
@@ -53,7 +36,7 @@
 
 
 (s/fdef cql/calc-function-strata
-  :args (s/cat :context ::context
+  :args (s/cat :context ::cql/context
                :function-name string?
                :handles ::measure/handles)
   :ret (s/or :strata (s/map-of any? ::measure/handles)
@@ -61,7 +44,7 @@
 
 
 (s/fdef cql/calc-multi-component-strata
-  :args (s/cat :context ::context
+  :args (s/cat :context ::cql/context
                :expression-names (s/coll-of string?)
                :handles ::measure/handles)
   :ret (s/or :strata (s/map-of (s/coll-of any?) ::measure/handles)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/population/spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/population/spec.clj
@@ -1,0 +1,21 @@
+(ns blaze.fhir.operation.evaluate-measure.measure.population.spec
+  (:require
+    [blaze.db.spec]
+    [blaze.fhir.operation.evaluate-measure.cql :as-alias cql]
+    [blaze.fhir.operation.evaluate-measure.cql.spec]
+    [blaze.fhir.operation.evaluate-measure.measure.population :as-alias population]
+    [blaze.fhir.spec.spec]
+    [clojure.spec.alpha :as s]))
+
+
+(s/def ::population/subject-type
+  :fhir.resource/type)
+
+
+(s/def ::population/subject-handle
+  :blaze.db/resource-handle)
+
+
+(s/def ::population/context
+  (s/merge ::cql/context
+           (s/keys :req-un [(or ::population/subject-type ::population/subject-handle)])))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/population_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/population_spec.clj
@@ -1,23 +1,9 @@
 (ns blaze.fhir.operation.evaluate-measure.measure.population-spec
   (:require
-    [blaze.fhir.operation.evaluate-measure.cql-spec :as cql-spec]
     [blaze.fhir.operation.evaluate-measure.measure.population :as population]
-    [blaze.fhir.spec.spec]
+    [blaze.fhir.operation.evaluate-measure.measure.population.spec]
     [clojure.spec.alpha :as s]))
 
 
-(s/def ::subject-type
-  :fhir.resource/type)
-
-
-(s/def ::subject-handle
-  :blaze.db/resource-handle)
-
-
-(s/def ::context
-  (s/merge (s/keys :req-un [(or ::subject-type ::subject-handle)])
-           ::cql-spec/context))
-
-
 (s/fdef population/evaluate
-  :args (s/cat :context ::context :idx nat-int? :population map?))
+  :args (s/cat :context ::population/context :idx nat-int? :population map?))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier/spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier/spec.clj
@@ -1,0 +1,19 @@
+(ns blaze.fhir.operation.evaluate-measure.measure.stratifier.spec
+  (:require
+    [blaze.fhir.operation.evaluate-measure.cql :as-alias cql]
+    [blaze.fhir.operation.evaluate-measure.cql.spec]
+    [blaze.fhir.operation.evaluate-measure.measure :as-alias measure]
+    [blaze.fhir.operation.evaluate-measure.measure.stratifier :as-alias stratifier]
+    [clojure.spec.alpha :as s]))
+
+
+(s/def ::stratifier/handles
+  (s/coll-of ::measure/handles))
+
+
+(s/def ::stratifier/evaluated-populations
+  (s/keys :req-un [::handles]))
+
+
+(s/def ::stratifier/context
+  (s/merge ::cql/context (s/keys :req-un [::measure/report-type])))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier_spec.clj
@@ -1,25 +1,14 @@
 (ns blaze.fhir.operation.evaluate-measure.measure.stratifier-spec
   (:require
     [blaze.fhir.operation.evaluate-measure.cql-spec]
-    [blaze.fhir.operation.evaluate-measure.measure :as-alias measure]
     [blaze.fhir.operation.evaluate-measure.measure.spec]
     [blaze.fhir.operation.evaluate-measure.measure.stratifier :as stratifier]
+    [blaze.fhir.operation.evaluate-measure.measure.stratifier.spec]
     [blaze.fhir.operation.evaluate-measure.measure.util-spec]
     [clojure.spec.alpha :as s]))
 
 
-(s/def ::handles
-  (s/coll-of ::measure/handles))
-
-
-(s/def ::evaluated-populations
-  (s/keys :req-un [::handles]))
-
-
-(s/def ::context
-  (s/keys :req-un [::measure/report-type]))
-
-
 (s/fdef stratifier/evaluate
-  :args (s/cat :context ::context :evaluated-populations ::evaluated-populations
+  :args (s/cat :context ::stratifier/context
+               :evaluated-populations ::stratifier/evaluated-populations
                :stratifier map?))

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -144,7 +144,11 @@
   {:node #blaze/ref :blaze.db/node
    :executor #blaze/ref :blaze.fhir.operation.evaluate-measure/executor
    :clock #blaze/ref :blaze/clock
-   :rng-fn #blaze/ref :blaze/rng-fn}
+   :rng-fn #blaze/ref :blaze/rng-fn
+   :timeout #blaze/ref :blaze.fhir.operation.evaluate-measure/timeout}
+
+  :blaze.fhir.operation.evaluate-measure/timeout
+  {:millis #blaze/cfg ["FHIR_OPERATION_EVALUATE_MEASURE_TIMEOUT" nat-int? 3600000]}
 
   :blaze.fhir.operation.evaluate-measure/executor
   {:num-threads #blaze/cfg ["FHIR_OPERATION_EVALUATE_MEASURE_THREADS" pos-int? 4]}


### PR DESCRIPTION
The environment variable FHIR_OPERATION_EVALUATE_MEASURE_TIMEOUT can be used to set a evaluate measure timeout in milliseconds. The default value will be 1 hour in order to prevent overly long evaluations from slowing down Blaze. At the same time the default should not change the behaviour of normal evaluations.