### PR TITLE
Fix _lastUpdated Search Returning a Resource more than Once

### DIFF
--- a/modules/db-stub/src/blaze/db/api_stub.clj
+++ b/modules/db-stub/src/blaze/db/api_stub.clj
@@ -36,10 +36,10 @@
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
-    :clock (ig/ref :blaze.test/clock)}
+    :clock (ig/ref :blaze.test/fixed-clock)}
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
-   :blaze.test/clock {}
+   :blaze.test/fixed-clock {}
 
    :blaze.db/resource-handle-cache {}
 

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -17,6 +17,7 @@
     [blaze.db.impl.index.type-as-of :as tao]
     [blaze.db.impl.index.type-stats :as type-stats]
     [blaze.db.impl.protocols :as p]
+    [blaze.db.impl.search-param.all :as search-param-all]
     [blaze.db.impl.search-param.util :as u]
     [blaze.db.kv :as kv])
   (:import
@@ -230,11 +231,17 @@
 
 
 (defn- decode-clauses [clauses]
-  (mapv
-    (fn [[search-param modifier values]]
-      (if (#{"asc" "desc"} modifier)
-        [:sort (:code search-param) (keyword modifier)]
-        (into [(cond-> (:code search-param) modifier (str ":" modifier))] values)))
+  (into
+    []
+    (keep
+      (fn [[search-param modifier values]]
+        (cond
+          (= search-param-all/search-param search-param)
+          nil
+          (#{"asc" "desc"} modifier)
+          [:sort (:code search-param) (keyword modifier)]
+          :else
+          (into [(cond-> (:code search-param) modifier (str ":" modifier))] values))))
     clauses))
 
 

--- a/modules/db/src/blaze/db/impl/search_param/all.clj
+++ b/modules/db/src/blaze/db/impl/search_param/all.clj
@@ -1,0 +1,25 @@
+(ns blaze.db.impl.search-param.all
+  "A internal search parameter returning all resources of a type.
+
+  This search param is used to put the date search param on _lastUpdated into
+  second position if no other search param is available for the first position.
+
+  The date search param on _lastUpdated can't be in first position, because it
+  will return resources more than once if multiple updates with the same hash
+  are index with different lastUpdate times."
+  (:require
+    [blaze.db.impl.index.resource-as-of :as rao]
+    [blaze.db.impl.protocols :as p]))
+
+
+(def search-param
+  (reify p/SearchParam
+    (-compile-value [_ _ _])
+
+    (-resource-handles [_ context tid _ _]
+      (rao/type-list context tid))
+
+    (-resource-handles [_ context tid _ _ start-id]
+      (rao/type-list context tid start-id))
+
+    (-index-values [_ _ _])))

--- a/modules/db/src/blaze/db/impl/search_param/date.clj
+++ b/modules/db/src/blaze/db/impl/search_param/date.clj
@@ -93,17 +93,23 @@
                         (resource-value! context c-hash tid start-id) start-id))
 
 
+(def ^:private drop-value
+  (map #(subvec % 1)))
+
+
 (defn- eq-keys!
-  "Returns a reducible collection of `[value id hash-prefix]` triples of all
+  "Returns a reducible collection of `[id hash-prefix]` triples of all
   keys with overlapping date/time intervals with the interval specified by
   `lower-bound` and `upper-bound` starting at `start-id` (optional)."
   ([{:keys [svri]} c-hash tid lower-bound upper-bound]
    (coll/eduction
-     (eq-filter lower-bound upper-bound)
+     (comp (eq-filter lower-bound upper-bound)
+           drop-value)
      (sp-vr/all-keys! svri c-hash tid)))
   ([context c-hash tid lower-bound upper-bound start-id]
    (coll/eduction
-     (eq-filter lower-bound upper-bound)
+     (comp (eq-filter lower-bound upper-bound)
+           drop-value)
      (all-keys! context c-hash tid start-id))))
 
 
@@ -119,16 +125,18 @@
 
 
 (defn- ge-keys!
-  "Returns a reducible collection of `[value id hash-prefix]` triples of all
+  "Returns a reducible collection of `[id hash-prefix]` triples of all
   keys with overlapping date/time intervals with the interval specified by
   `lower-bound` and an infinite upper bound starting at `start-id` (optional)."
   ([{:keys [svri]} c-hash tid lower-bound]
    (coll/eduction
-     (ge-filter lower-bound)
+     (comp (ge-filter lower-bound)
+           drop-value)
      (sp-vr/all-keys! svri c-hash tid)))
   ([context c-hash tid lower-bound start-id]
    (coll/eduction
-     (ge-filter lower-bound)
+     (comp (ge-filter lower-bound)
+           drop-value)
      (all-keys! context c-hash tid start-id))))
 
 
@@ -144,16 +152,18 @@
 
 
 (defn- gt-keys!
-  "Returns a reducible collection of `[value id hash-prefix]` triples of all
+  "Returns a reducible collection of `[id hash-prefix]` triples of all
   keys with overlapping date/time intervals with the interval specified by
   `lower-bound` and an infinite upper bound starting at `start-id` (optional)."
   ([{:keys [svri]} c-hash tid lower-bound]
    (coll/eduction
-     (gt-filter lower-bound)
+     (comp (gt-filter lower-bound)
+           drop-value)
      (sp-vr/all-keys! svri c-hash tid)))
   ([context c-hash tid lower-bound start-id]
    (coll/eduction
-     (gt-filter lower-bound)
+     (comp (gt-filter lower-bound)
+           drop-value)
      (all-keys! context c-hash tid start-id))))
 
 
@@ -169,16 +179,18 @@
 
 
 (defn- le-keys!
-  "Returns a reducible collection of `[value id hash-prefix]` triples of all
+  "Returns a reducible collection of `[id hash-prefix]` triples of all
   keys with overlapping date/time intervals with the interval specified by
   an infinite lower bound and `upper-bound` starting at `start-id` (optional)."
   ([{:keys [svri]} c-hash tid upper-bound]
    (coll/eduction
-     (le-filter upper-bound)
+     (comp (le-filter upper-bound)
+           drop-value)
      (sp-vr/all-keys! svri c-hash tid)))
   ([context c-hash tid upper-bound start-id]
    (coll/eduction
-     (le-filter upper-bound)
+     (comp (le-filter upper-bound)
+           drop-value)
      (all-keys! context c-hash tid start-id))))
 
 
@@ -194,16 +206,18 @@
 
 
 (defn- lt-keys!
-  "Returns a reducible collection of `[value id hash-prefix]` triples of all
+  "Returns a reducible collection of `[id hash-prefix]` triples of all
   keys with overlapping date/time intervals with the interval specified by
   an infinite lower bound and `upper-bound` starting at `start-id` (optional)."
   ([{:keys [svri]} c-hash tid upper-bound]
    (coll/eduction
-     (lt-filter upper-bound)
+     (comp (lt-filter upper-bound)
+           drop-value)
      (sp-vr/all-keys! svri c-hash tid)))
-  ([context c-hash tid lower-bound start-id]
+  ([context c-hash tid upper-bound start-id]
    (coll/eduction
-     (lt-filter lower-bound)
+     (comp (lt-filter upper-bound)
+           drop-value)
      (all-keys! context c-hash tid start-id))))
 
 
@@ -267,32 +281,26 @@
 
   (-resource-handles [_ context tid _ value]
     (coll/eduction
-      (comp
-        (map (fn [[_value id hash-prefix]] [id hash-prefix]))
-        (u/resource-handle-mapper context tid))
+      (u/resource-handle-mapper context tid)
       (resource-keys! context c-hash tid value)))
 
   (-resource-handles [_ context tid _ value start-id]
     (coll/eduction
-      (comp
-        (map (fn [[_value id hash-prefix]] [id hash-prefix]))
-        (u/resource-handle-mapper context tid))
+      (u/resource-handle-mapper context tid)
       (resource-keys! context c-hash tid value start-id)))
 
   (-sorted-resource-handles [_ context tid direction]
     (coll/eduction
-      (comp
-        (map (fn [[_value id hash-prefix]] [id hash-prefix]))
-        (u/resource-handle-mapper context tid))
+      (comp drop-value
+            (u/resource-handle-mapper context tid))
       (if (= :asc direction)
         (sp-vr/all-keys! (:svri context) c-hash tid)
         (sp-vr/all-keys-prev! (:svri context) c-hash tid))))
 
   (-sorted-resource-handles [_ context tid direction start-id]
     (coll/eduction
-      (comp
-        (map (fn [[_value id hash-prefix]] [id hash-prefix]))
-        (u/resource-handle-mapper context tid))
+      (comp drop-value
+            (u/resource-handle-mapper context tid))
       (if (= :asc direction)
         (all-keys! context c-hash tid start-id)
         (all-keys-prev! context c-hash tid start-id))))

--- a/modules/db/src/blaze/db/impl/search_param/quantity.clj
+++ b/modules/db/src/blaze/db/impl/search_param/quantity.clj
@@ -86,6 +86,10 @@
     (take-while (fn [[prefix]] (bs/<= prefix prefix-key)))))
 
 
+(def ^:private drop-value
+  (map #(subvec % 1)))
+
+
 (defn- eq-keys!
   "Returns a reducible collection of `[id hash-prefix]` tuples of values between
   `lower-bound` and `upper-bound` starting at `start-id` (optional).
@@ -98,14 +102,14 @@
    (coll/eduction
      (comp
        (take-while-less-equal c-hash tid upper-bound)
-       (map (fn [[_prefix id hash-prefix]] [id hash-prefix])))
+       drop-value)
      (sp-vr/keys! svri (sp-vr/encode-seek-key c-hash tid lower-bound))))
   ([{:keys [svri] :as context} c-hash tid lower-bound-prefix upper-bound
     start-id]
    (coll/eduction
      (comp
        (take-while-less-equal c-hash tid upper-bound)
-       (map (fn [[_prefix id hash-prefix]] [id hash-prefix])))
+       drop-value)
      (sp-vr/keys! svri (id-start-key! context c-hash tid lower-bound-prefix
                                       start-id)))))
 
@@ -224,7 +228,7 @@
   (coll/eduction
     (comp
       (take-while-compartment-less-equal compartment c-hash tid upper-bound)
-      (map (fn [[_prefix id hash-prefix]] [id hash-prefix])))
+      drop-value)
     (c-sp-vr/keys! csvri (c-sp-vr/encode-seek-key compartment c-hash tid
                                                   lower-bound))))
 

--- a/modules/db/src/blaze/db/impl/search_param/util.clj
+++ b/modules/db/src/blaze/db/impl/search_param/util.clj
@@ -49,14 +49,17 @@
 
 (defn- resource-handle-mapper* [{:keys [resource-handle]} tid]
   (keep
-    (fn [tuples]
-      (let [id (-> tuples (coll/nth 0) (coll/nth 0))]
-        (when-let [handle (resource-handle tid id)]
-          (when (some (contains-hash-prefix-pred handle) tuples)
-            handle))))))
+    (fn [[[id] :as tuples]]
+      (when-let [handle (resource-handle tid id)]
+        (when (some (contains-hash-prefix-pred handle) tuples)
+          handle)))))
 
 
-(defn resource-handle-mapper [context tid]
+(defn resource-handle-mapper
+  "Transducer which groups `[id hash-prefix]` tuples by `id` and maps them to
+  a resource handle with `tid` if there is a current one with matching hash
+  prefix."
+  [context tid]
   (comp
     by-id-grouper
     (resource-handle-mapper* context tid)))

--- a/modules/db/test-perf/blaze/db/api_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/api_test_perf.clj
@@ -39,10 +39,10 @@
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
-    :clock (ig/ref :blaze.test/clock)}
+    :clock (ig/ref :blaze.test/fixed-clock)}
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
-   :blaze.test/clock {}
+   :blaze.test/fixed-clock {}
 
    :blaze.db/resource-handle-cache {:max-size 1000000}
 

--- a/modules/db/test/blaze/db/test_util.clj
+++ b/modules/db/test/blaze/db/test_util.clj
@@ -30,12 +30,13 @@
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
-    :clock (ig/ref :blaze.test/clock)}
+    :clock (ig/ref :blaze.test/fixed-clock)}
 
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
 
-   :blaze.test/clock {}
+   :blaze.test/fixed-clock {}
+   :blaze.test/system-clock {}
 
    :blaze.db/resource-handle-cache {}
 

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -82,10 +82,10 @@
 (def system
   {::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)
-    :clock (ig/ref :blaze.test/clock)}
+    :clock (ig/ref :blaze.test/fixed-clock)}
    [::kv/mem :blaze.db/transaction-kv-store]
    {:column-families {}}
-   :blaze.test/clock {}})
+   :blaze.test/fixed-clock {}})
 
 
 (defn- assoc-kv-store-init-data [system init-data]
@@ -95,9 +95,9 @@
 (def failing-kv-store-system
   {::tx-log/local
    {:kv-store (ig/ref ::failing-kv-store)
-    :clock (ig/ref :blaze.test/clock)}
+    :clock (ig/ref :blaze.test/fixed-clock)}
    ::failing-kv-store {}
-   :blaze.test/clock {}})
+   :blaze.test/fixed-clock {}})
 
 
 (deftest init-test

--- a/modules/fhir-structure/src/blaze/fhir/hash.clj
+++ b/modules/fhir-structure/src/blaze/fhir/hash.clj
@@ -88,6 +88,7 @@
 
 
 (defn prefix
+  "Returns the first 4 bytes of `hash`."
   {:inline
    (fn [hash]
      `(.prefix ~(with-meta hash {:tag `Hash})))}

--- a/modules/interaction/test/blaze/interaction/create_test.clj
+++ b/modules/interaction/test/blaze/interaction/create_test.clj
@@ -83,7 +83,7 @@
     :blaze.interaction/create
     {:node (ig/ref :blaze.db/node)
      :executor (ig/ref :blaze.test/executor)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
     :blaze.test/executor {}
     :blaze.test/fixed-rng-fn {}))

--- a/modules/interaction/test/blaze/interaction/history/instance_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/instance_test.clj
@@ -83,7 +83,7 @@
   (assoc mem-node-system
     :blaze.interaction.history/instance
     {:node (ig/ref :blaze.db/node)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
     :blaze.test/fixed-rng-fn {}))
 

--- a/modules/interaction/test/blaze/interaction/history/system_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/system_test.clj
@@ -85,7 +85,7 @@
   (assoc mem-node-system
     :blaze.interaction.history/system
     {:node (ig/ref :blaze.db/node)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
     :blaze.test/fixed-rng-fn {}))
 

--- a/modules/interaction/test/blaze/interaction/history/type_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/type_test.clj
@@ -86,7 +86,7 @@
   (assoc mem-node-system
     :blaze.interaction.history/type
     {:node (ig/ref :blaze.db/node)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
     :blaze.test/fixed-rng-fn {}))
 

--- a/modules/interaction/test/blaze/interaction/search_compartment_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_compartment_test.clj
@@ -88,7 +88,7 @@
 (def system
   (assoc mem-node-system
     :blaze.interaction/search-compartment
-    {:clock (ig/ref :blaze.test/clock)
+    {:clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
      :page-store (ig/ref :blaze.page-store/local)}
     :blaze.test/fixed-rng-fn {}

--- a/modules/interaction/test/blaze/interaction/search_system_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_system_test.clj
@@ -90,7 +90,7 @@
   (assoc mem-node-system
     :blaze.interaction/search-system
     {:node (ig/ref :blaze.db/node)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
      :page-store (ig/ref :blaze.page-store/local)}
     :blaze.test/fixed-rng-fn {}

--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -159,7 +159,7 @@
 (def system
   (assoc mem-node-system
     :blaze.interaction/search-type
-    {:clock (ig/ref :blaze.test/clock)
+    {:clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
      :page-store (ig/ref :blaze.page-store/local)}
     :blaze.test/fixed-rng-fn {}

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -133,18 +133,18 @@
     :blaze.interaction/transaction
     {:node (ig/ref :blaze.db/node)
      :executor (ig/ref :blaze.interaction.transaction/executor)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
 
     :blaze.interaction/create
     {:node (ig/ref :blaze.db/node)
      :executor (ig/ref :blaze.test/executor)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
 
     :blaze.interaction/search-type
     {:node (ig/ref :blaze.db/node)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
      :page-store (ig/ref :blaze.page-store/local)}
 

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
@@ -106,10 +106,10 @@
   (fn [_ _ _] (throw (Exception. ^String msg))))
 
 
-(defn- context [{:blaze.db/keys [node] :blaze.test/keys [clock]} library]
+(defn- context [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock]} library]
   (let [{:keys [expression-defs function-defs]} (compile-library node library)]
     {:db (d/db node)
-     :now (now clock)
+     :now (now fixed-clock)
      :timeout-eclipsed? (constantly false)
      :timeout (time/seconds 42)
      :expression-defs expression-defs

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier_test.clj
@@ -176,10 +176,10 @@
      :criteria (cql-expression "Age")}]})
 
 
-(defn- context [{:blaze.db/keys [node] :blaze.test/keys [clock]} library]
+(defn- context [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock]} library]
   (let [{:keys [expression-defs function-defs]} (compile-library node library)]
     {:db (d/db node)
-     :now (now clock)
+     :now (now fixed-clock)
      :timeout-eclipsed? (constantly false)
      :timeout (time/seconds 42)
      :expression-defs expression-defs

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -96,11 +96,11 @@
    (evaluate name "population"))
   ([name report-type]
    (with-system-data
-     [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+     [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
      [(tx-ops (:entry (read-data name)))]
 
      (let [db (d/db node)
-           context {:clock clock :rng-fn fixed-rng-fn :db db
+           context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                     :blaze/base-url "" ::reitit/router router}
            period [#system/date"2000" #system/date"2020"]]
        (measure/evaluate-measure context
@@ -180,7 +180,7 @@
 (deftest evaluate-measure-test
   (testing "Encounter population basis"
     (with-system-data
-      [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+      [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
       [[[:put {:fhir/type :fhir/Patient :id "0"}]
         [:put {:fhir/type :fhir/Encounter :id "0-0" :subject #fhir/Reference{:reference "Patient/0"}}]
         [:put {:fhir/type :fhir/Patient :id "1"}]
@@ -191,7 +191,7 @@
                :content [(library-content library-encounter)]}]]]
 
       (let [db (d/db node)
-            context {:clock clock :rng-fn fixed-rng-fn :db db
+            context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                      :blaze/base-url "" ::reitit/router router}
             measure {:fhir/type :fhir/Measure :id "0"
                      :library [#fhir/canonical"0"]
@@ -234,12 +234,12 @@
 
   (testing "missing criteria"
     (with-system-data
-      [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+      [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
       [[[:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                :content [(library-content library-gender)]}]]]
 
       (let [db (d/db node)
-            context {:clock clock :rng-fn fixed-rng-fn :db db
+            context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                      :blaze/base-url "" ::reitit/router router}
             measure-id "measure-id-133021"
             measure {:fhir/type :fhir/Measure :id measure-id
@@ -260,13 +260,13 @@
 
   (testing "evaluation timeout"
     (with-system-data
-      [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+      [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
       [[[:put {:fhir/type :fhir/Patient :id "0"}]]
        [[:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                :content [(library-content library-gender)]}]]]
 
       (let [db (d/db node)
-            context {:clock clock :rng-fn fixed-rng-fn
+            context {:clock fixed-clock :rng-fn fixed-rng-fn
                      :db db :timeout (time/seconds 0)
                      :blaze/base-url "" ::reitit/router router}
             measure-id "measure-id-132321"
@@ -288,13 +288,13 @@
   (testing "single subject"
     (doseq [subject-ref ["0" ["Patient" "0"]]]
       (with-system-data
-        [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+        [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
         [[[:put {:fhir/type :fhir/Patient :id "0"}]
           [:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                  :content [(library-content library-gender)]}]]]
 
         (let [db (d/db node)
-              context {:clock clock :rng-fn fixed-rng-fn :db db
+              context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                        :blaze/base-url "" ::reitit/router router}
               measure {:fhir/type :fhir/Measure :id "0"
                        :library [#fhir/canonical"0"]
@@ -321,13 +321,13 @@
 
     (testing "with stratifiers"
       (with-system-data
-        [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+        [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
         [[[:put {:fhir/type :fhir/Patient :id "0" :gender #fhir/code"male"}]
           [:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                  :content [(library-content library-gender)]}]]]
 
         (let [db (d/db node)
-              context {:clock clock :rng-fn fixed-rng-fn :db db
+              context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                        :blaze/base-url "" ::reitit/router router}
               measure {:fhir/type :fhir/Measure :id "0"
                        :library [#fhir/canonical"0"]
@@ -361,12 +361,12 @@
 
     (testing "invalid subject"
       (with-system-data
-        [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+        [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
         [[[:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                  :content [(library-content library-gender)]}]]]
 
         (let [db (d/db node)
-              context {:clock clock :rng-fn fixed-rng-fn :db db
+              context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                        :blaze/base-url "" ::reitit/router router}
               measure {:fhir/type :fhir/Measure :id "0"
                        :library [#fhir/canonical"0"]
@@ -385,12 +385,12 @@
 
     (testing "missing subject"
       (with-system-data
-        [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+        [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
         [[[:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                  :content [(library-content library-gender)]}]]]
 
         (let [db (d/db node)
-              context {:clock clock :rng-fn fixed-rng-fn :db db
+              context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                        :blaze/base-url "" ::reitit/router router}
               measure {:fhir/type :fhir/Measure :id "0"
                        :library [#fhir/canonical"0"]
@@ -409,14 +409,14 @@
 
     (testing "deleted subject"
       (with-system-data
-        [{:blaze.db/keys [node] :blaze.test/keys [clock fixed-rng-fn]} system]
+        [{:blaze.db/keys [node] :blaze.test/keys [fixed-clock fixed-rng-fn]} system]
         [[[:put {:fhir/type :fhir/Patient :id "0"}]
           [:put {:fhir/type :fhir/Library :id "0" :url #fhir/uri"0"
                  :content [(library-content library-gender)]}]]
          [[:delete "Patient" "0"]]]
 
         (let [db (d/db node)
-              context {:clock clock :rng-fn fixed-rng-fn :db db
+              context {:clock fixed-clock :rng-fn fixed-rng-fn :db db
                        :blaze/base-url "" ::reitit/router router}
               measure {:fhir/type :fhir/Measure :id "0"
                        :library [#fhir/canonical"0"]

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -167,7 +167,7 @@
     ::evaluate-measure/handler
     {:node (ig/ref :blaze.db/node)
      :executor (ig/ref :blaze.test/executor)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
     :blaze.test/executor {}
     :blaze.test/fixed-rng-fn {}))

--- a/modules/test-util/src/blaze/test_util.clj
+++ b/modules/test-util/src/blaze/test_util.clj
@@ -42,9 +42,14 @@
          (ig/halt! system#)))))
 
 
-(defmethod ig/init-key :blaze.test/clock
+(defmethod ig/init-key :blaze.test/fixed-clock
   [_ _]
   (Clock/fixed Instant/EPOCH (ZoneId/of "UTC")))
+
+
+(defmethod ig/init-key :blaze.test/system-clock
+  [_ _]
+  (Clock/systemUTC))
 
 
 (defmethod ig/init-key :blaze.test/fixed-rng-fn

--- a/test/blaze/system_test.clj
+++ b/test/blaze/system_test.clj
@@ -102,22 +102,22 @@
     :blaze.interaction/transaction
     {:node (ig/ref :blaze.db/node)
      :executor (ig/ref :blaze.test/executor)
-     :clock (ig/ref :blaze.test/clock)
+     :clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
     :blaze.interaction/read {}
     :blaze.interaction/delete
     {:node (ig/ref :blaze.db/node)
      :executor (ig/ref :blaze.test/executor)}
     :blaze.interaction/search-system
-    {:clock (ig/ref :blaze.test/clock)
+    {:clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
      :page-store (ig/ref ::page-store)}
     :blaze.interaction/search-type
-    {:clock (ig/ref :blaze.test/clock)
+    {:clock (ig/ref :blaze.test/fixed-clock)
      :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
      :page-store (ig/ref ::page-store)}
     :blaze.test/executor {}
-    :blaze.test/clock {}
+    :blaze.test/fixed-clock {}
     :blaze.test/fixed-rng-fn {}
     ::page-store {}))
 


### PR DESCRIPTION
Searching resources by _lastUpdated can return a resource more than once.

The problem with the meta.lastUpdated property is that it doesn't contribute to the content hash of a resource because it's not part of the resource content. This results in multiple entries into the SearchParamValueResource index having the same content hash. If that content hash is equal to the current one, the resource is returned multiple times.

The fix moves the _lastUpdated search clause away from the first position because the first clause uses the SearchParamValueResource index.

Closes: #882