### PR TITLE
Allow Writing Large Binary Resources in XML Format

### DIFF
--- a/.github/scripts/generate-large-binary-resource.sh
+++ b/.github/scripts/generate-large-binary-resource.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# generate 8 MB random data as Base64
+DATA=$(openssl rand -base64 8388608)
+
+echo "<Binary xmlns=\"http://hl7.org/fhir\"><data value=\"$DATA\"/></Binary>" > large-binary.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -904,6 +904,35 @@ jobs:
     - name: Compare Source and Destination Patients
       run: diff src-patients.ndjson dst-patients.ndjson
 
+  big-binary-test:
+    needs: build
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+
+    - name: Download Blaze Image
+      uses: actions/download-artifact@v3
+      with:
+        name: blaze-image
+        path: /tmp
+
+    - name: Load Blaze Image
+      run: docker load --input /tmp/blaze.tar
+
+    - name: Run Blaze
+      run: docker run --name blaze -d -e JAVA_TOOL_OPTIONS=-Xmx2g -p 8080:8080 -v blaze-data:/app/data blaze:latest
+
+    - name: Wait for Blaze
+      run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
+
+    - name: Generate Large Binary Resource
+      run: .github/scripts/generate-large-binary-resource.sh
+
+    - name: Post Large Binary Resource
+      run:  curl -f -H Content-Type:application/fhir+xml -d @large-binary.xml http://localhost:8080/fhir/Binary
+
   distributed-test:
     needs: build
     runs-on: ubuntu-22.04
@@ -1299,6 +1328,7 @@ jobs:
     - jepsen-test
     - openid-auth-test
     - doc-copy-data-test
+    - big-binary-test
     - distributed-test
     - jepsen-distributed-test
     runs-on: ubuntu-22.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       BASE_URL: "http://localhost:8080"
       JAVA_TOOL_OPTIONS: "-Xmx2g"
+      LOG_LEVEL: "debug"
     ports:
     - "8080:8080"
     volumes:

--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -22,6 +22,9 @@
   com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
   {:mvn/version "2.14.2"}
 
+  com.fasterxml.jackson.dataformat/jackson-dataformat-xml
+  {:mvn/version "2.14.2"}
+
   com.taoensso/timbre
   {:mvn/version "5.2.1"}
 

--- a/modules/rest-api/test/blaze/rest_api/middleware/resource_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/middleware/resource_test.clj
@@ -109,6 +109,12 @@
           fhir-spec/fhir-type := :fhir/Patient)
         (is (true? @closed?)))))
 
+  (testing "long attribute values are allowed"
+    (given @(resource-handler
+              {:headers {"content-type" "application/fhir+xml"}
+               :body (input-stream (str "<Binary xmlns=\"http://hl7.org/fhir\"><data value=\"" (apply str (repeat (* 8 1024 1024) \a)) "\"/></Binary>"))})
+      fhir-spec/fhir-type := :fhir/Binary))
+
   (testing "body with invalid XML"
     (given @(resource-handler
               {:request-method :post
@@ -118,7 +124,7 @@
       [:body fhir-spec/fhir-type] := :fhir/OperationOutcome
       [:body :issue 0 :severity] := #fhir/code"error"
       [:body :issue 0 :code] := #fhir/code"invalid"
-      [:body :issue 0 :diagnostics] := "ParseError at [row,col]:[1,48]\nMessage: Attribute name \"value\" associated with an element type \"id\" must be followed by the ' = ' character."))
+      [:body :issue 0 :diagnostics] := "Unexpected character '\"' (code 34) expected '='\n at [row,col {unknown-source}]: [1,48]"))
 
   (testing "body with invalid resource"
     (given @(resource-handler


### PR DESCRIPTION
The Woodstox XML Parser has a default limit of 524288 bytes for XML attribute values in order to prevent DOS attacks. However for FHIR Binary resources that limit is just to low. I decided against a configurable limit, because the possibility to do so is implementation specific to Woodstox and I can't guarantee that I can implement it using other libraries. So I disabled the limit completely.