### PR TITLE
Fix Indexing Error during Soundex Calculation

### DIFF
--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -37,9 +37,8 @@
   blaze/spec
   {:local/root "../spec"}
 
-  ;; Warning: version 0.4.1 is from 2017 but has no dependencies
-  clj-fuzzy/clj-fuzzy
-  {:mvn/version "0.4.1"}}
+  commons-codec/commons-codec
+  {:mvn/version "1.15"}}
 
  :aliases
  {:test

--- a/modules/db/src/blaze/db/impl/search_param/util.clj
+++ b/modules/db/src/blaze/db/impl/search_param/util.clj
@@ -7,7 +7,9 @@
     [blaze.db.impl.index.resource-handle :as rh]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.spec :as fhir-spec]
-    [clojure.string :as str]))
+    [clojure.string :as str])
+  (:import
+    [org.apache.commons.codec.language Soundex]))
 
 
 (set! *warn-on-reflection* true)
@@ -110,3 +112,10 @@
      :lower-bound (f (.subtract decimal-value delta))
      :exact-value (f decimal-value)
      :upper-bound (f (.add decimal-value delta))}))
+
+
+(let [soundex (Soundex.)]
+  (defn soundex [s]
+    (try
+      (.soundex soundex s)
+      (catch IllegalArgumentException _))))

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -1145,6 +1145,21 @@
             ::anom/category := ::anom/not-found
             ::anom/message := "The search-param with code `foo` and type `Observation` was not found.")))))
 
+  (testing "Patient phonetic"
+    (with-system-data [{:blaze.db/keys [node]} system]
+      [[[:put {:fhir/type :fhir/Patient :id "0"
+               :name [#fhir/HumanName{:family "Doe" :given ["John"]}]}]]]
+
+      (testing "family"
+        (given (pull-type-query node "Patient" [["phonetic" "Day"]])
+          count := 1
+          [0 :id] := "0"))
+
+      (testing "given"
+        (given (pull-type-query node "Patient" [["phonetic" "Jane"]])
+          count := 1
+          [0 :id] := "0"))))
+
   (testing "Patient"
     (with-system-data [{:blaze.db/keys [node]} system]
       [[[:put {:fhir/type :fhir/Patient

--- a/modules/db/test/blaze/db/impl/search_param/string_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/string_test.clj
@@ -9,13 +9,13 @@
     [blaze.db.impl.search-param-spec]
     [blaze.db.impl.search-param.string :as sps]
     [blaze.db.impl.search-param.string-spec]
+    [blaze.db.impl.search-param.util :as u]
     [blaze.db.search-param-registry :as sr]
     [blaze.fhir-path :as fhir-path]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.structure-definition-repo]
     [blaze.test-util :as tu :refer [with-system]]
-    [clj-fuzzy.phonetics :as phonetics]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
@@ -62,6 +62,16 @@
                         (phonetic-param search-param-registry) [] hash
                         patient)))))
 
+      (testing "unmappable char in family is not a problem"
+        (let [patient {:fhir/type :fhir/Patient
+                       :id "id-164114"
+                       :name [#fhir/HumanName{:family "Õ"}]}
+              hash (hash/generate patient)]
+
+          (is (empty? (search-param/index-entries
+                        (phonetic-param search-param-registry) [] hash
+                        patient)))))
+
       (let [patient {:fhir/type :fhir/Patient
                      :id "id-122929"
                      :name [#fhir/HumanName{:family "family-102508"}]}
@@ -74,7 +84,7 @@
           (given (sp-vr-tu/decode-key-human (bb/wrap k0))
             :code := "phonetic"
             :type := "Patient"
-            :v-hash := (codec/string (phonetics/soundex "family-102508"))
+            :v-hash := (codec/string (u/soundex "family-102508"))
             :id := "id-122929"
             :hash-prefix := (hash/prefix hash)))
 
@@ -84,7 +94,7 @@
             :id := "id-122929"
             :hash-prefix := (hash/prefix hash)
             :code := "phonetic"
-            :v-hash := (codec/string (phonetics/soundex "family-102508"))))))
+            :v-hash := (codec/string (u/soundex "family-102508"))))))
 
     (testing "Patient address"
       (let [patient {:fhir/type :fhir/Patient

--- a/modules/db/test/blaze/db/impl/search_param/util_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param/util_spec.clj
@@ -23,3 +23,8 @@
 (s/fdef u/eq-value
   :args (s/cat :f ifn? :decimal-value decimal?)
   :ret map?)
+
+
+(s/fdef u/soundex
+  :args (s/cat :s string?)
+  :ret (s/nilable string?))

--- a/modules/db/test/blaze/db/impl/search_param/util_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/util_test.clj
@@ -1,10 +1,12 @@
 (ns blaze.db.impl.search-param.util-test
   (:require
-    [blaze.db.impl.search-param.util :as util]
+    [blaze.db.impl.search-param.util :as u]
     [blaze.db.impl.search-param.util-spec]
-    [blaze.test-util :as tu]
+    [blaze.test-util :as tu :refer [satisfies-prop]]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [are deftest is]]
+    [clojure.test :as test :refer [are deftest is testing]]
+    [clojure.test.check.generators :as gen]
+    [clojure.test.check.properties :as prop]
     [taoensso.timbre :as log]))
 
 
@@ -16,7 +18,7 @@
 
 
 (deftest separate-op-test
-  (are [value tuple] (= tuple (util/separate-op value))
+  (are [value tuple] (= tuple (u/separate-op value))
     "1" [:eq "1"]
     " 1" [:eq "1"]
     "1 " [:eq "1"]
@@ -29,5 +31,27 @@
 
 
 (deftest format-skip-indexing-msg-test
-  (is (= (util/format-skip-indexing-msg "value-132537" "url-132522" "type-132528")
+  (is (= (u/format-skip-indexing-msg "value-132537" "url-132522" "type-132528")
          "Skip indexing value `value-132537` of type `:fhir/string` for search parameter `url-132522` with type `type-132528` because the rule is missing.")))
+
+
+(deftest soundex-test
+  (testing "question mark from issue #903"
+    (is (empty? (u/soundex "?"))))
+
+  (testing "unmapped character"
+    (are [s] (nil? (u/soundex s))
+      "Õ"
+      "ü"
+      "Müller"))
+
+  (testing "similar words"
+    (are [a b] (= (u/soundex a) (u/soundex b))
+      "Doe" "Day"
+      "John" "Jane"))
+
+  (testing "random strings"
+    (satisfies-prop 10000
+      (prop/for-all [s gen/string]
+        (let [r (u/soundex s)]
+          (or (string? r) (nil? r)))))))


### PR DESCRIPTION
There was a bug in clj-fuzzy.phonetics/soundex crashing with a question mark as input. I switched to org.apache.commons.codec.language.Soundex ans added property-based tests testing 10.000 random strings.

I also skip indexing strings with chars that have no mapping. This decision might be changed later. For example words with German umlauts are not index at all now.

I also tested the old implementation against the new one with the alpha words from https://github.com/dwyl/english-words. Only about 10 words were different.

I also fixed phonetic search at all, because the search value was not normalized using the soudex algorithm. Only indexing was done using it. So before this commit the phonetic search did actually not work.

Closes: #903