### PR TITLE
Fix URL Generation

### DIFF
--- a/.github/scripts/authenticated-request.sh
+++ b/.github/scripts/authenticated-request.sh
@@ -9,7 +9,7 @@ fi
 
 BASE="http://localhost:8080/fhir"
 
-if [ "200" = "$(curl -s --oauth2-bearer "$ACCESS_TOKEN" -o /dev/null -w ''%{http_code}'' "$BASE")" ]; then
+if [ "200" = "$(curl -s --oauth2-bearer "$ACCESS_TOKEN" -o /dev/null -w '%{response_code}' "$BASE")" ]; then
   echo "OK: successful authenticated system search request"
 else
   echo "Fail: failed authenticated system search request"

--- a/.github/scripts/check-capability-statement.sh
+++ b/.github/scripts/check-capability-statement.sh
@@ -4,5 +4,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 . "$SCRIPT_DIR/util.sh"
 
 BASE="http://localhost:8080/fhir"
+CAPABILITY_STATEMENT=$(curl -sH 'Accept: application/fhir+json' "$BASE/metadata")
 
-test "software name" "$(curl -s "$BASE/metadata" | jq -r .software.name)" "Blaze"
+test "software name" "$(echo "$CAPABILITY_STATEMENT" | jq -r .software.name)" "Blaze"
+test "URL" "$(echo "$CAPABILITY_STATEMENT" | jq -r .implementation.url)" "http://localhost:8080/fhir"

--- a/.github/scripts/create-patient.sh
+++ b/.github/scripts/create-patient.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+HEADERS=$(curl -s -H 'Content-Type: application/fhir+json' -H 'Accept: application/fhir+json' -d "{\"resourceType\": \"Patient\"}" -o /dev/null -D - "$BASE/Patient")
+LOCATION_HEADER=$(echo "$HEADERS" | grep -i location | tr -d '\r')
+
+test "Location header prefix" "$(echo "\"${LOCATION_HEADER:10}\"" | jq -r '[split("/") | limit(5;.[])] | join("/")')" "$BASE/Patient"

--- a/.github/scripts/not-acceptable.sh
+++ b/.github/scripts/not-acceptable.sh
@@ -2,7 +2,7 @@
 
 BASE="http://localhost:8080/fhir"
 
-if [ "406" = "$(curl -s -o /dev/null -w ''%{http_code}'' -H 'Accept: text/plain' "$BASE")" ]; then
+if [ "406" = "$(curl -s -o /dev/null -w '%{response_code}' -H 'Accept: text/plain' "$BASE")" ]; then
   echo "OK: text/plain is a not acceptable media type"
 else
   echo "Fail"

--- a/.github/scripts/wait-for-url.sh
+++ b/.github/scripts/wait-for-url.sh
@@ -9,6 +9,6 @@ eclipsed() {
 }
 
 # wait at maximum 120 seconds
-while [[ ($(eclipsed) -lt 120) && ("$(curl -s -o /dev/null -w ''%{http_code}'' "$URL")" != "200") ]]; do
+while [[ ($(eclipsed) -lt 120) && ("$(curl -s -o /dev/null -w '%{response_code}' "$URL")" != "200") ]]; do
   sleep 2
 done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
     - name: Check out Git repository
       uses: actions/checkout@v3
 
-    - name: Run Trivy vulnerability scanner
+    - name: Run Trivy Vulnerability Scanner
       uses: aquasecurity/trivy-action@master
       with:
         image-ref: blaze:latest
@@ -249,7 +249,7 @@ jobs:
         severity: 'CRITICAL,HIGH'
         timeout: '15m0s'
 
-    - name: Upload Trivy scan results to GitHub Security tab
+    - name: Upload Trivy Scan Results to GitHub Security Tab
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: trivy-results.sarif
@@ -537,6 +537,9 @@ jobs:
 
     - name: GraphQL Observation
       run: .github/scripts/graphql.sh Observation
+
+    - name: Create Patient
+      run: .github/scripts/create-patient.sh
 
   not-enforcing-referential-integrity-test:
     needs: build
@@ -1250,6 +1253,9 @@ jobs:
 
     - name: GraphQL Observation
       run: .github/scripts/graphql.sh Observation
+
+    - name: Create Patient
+      run: .github/scripts/create-patient.sh
 
     - name: Docker Stats
       run: docker stats --no-stream

--- a/modules/interaction/src/blaze/interaction/history/util.clj
+++ b/modules/interaction/src/blaze/interaction/history/util.clj
@@ -62,10 +62,10 @@
     :delete #fhir/code"DELETE"}))
 
 
-(defn- url [context type id resource]
+(defn- url [{:fhir/keys [type] :keys [id] :as resource}]
   (if (-> resource meta :blaze.db/op #{:create})
-    (fhir-util/type-url context type)
-    (fhir-util/instance-url context type id)))
+    (name type)
+    (str (name type) "/" id)))
 
 
 (defn- status [resource]
@@ -83,7 +83,7 @@
      :request
      {:fhir/type :fhir.Bundle.entry/request
       :method (method resource)
-      :url (url (assoc context :blaze/base-url "") (name type) id resource)}
+      :url (url resource)}
      :response
      {:fhir/type :fhir.Bundle.entry/response
       :status (status resource)

--- a/modules/interaction/test/blaze/interaction/create_test.clj
+++ b/modules/interaction/test/blaze/interaction/create_test.clj
@@ -34,6 +34,7 @@
 
 
 (def base-url "base-url-134418")
+(def context-path "/context-path-141016")
 
 
 (def router
@@ -41,7 +42,8 @@
     [["/Patient" {:name :Patient/type}]
      ["/Observation" {:name :Observation/type}]
      ["/Bundle" {:name :Bundle/type}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (deftest init-test
@@ -174,7 +176,7 @@
           (is (= 201 status))
 
           (testing "Location header"
-            (is (= (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/1")
+            (is (= (str base-url context-path "/Patient/AAAAAAAAAAAAAAAA/_history/1")
                    (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
@@ -201,7 +203,7 @@
           (is (= 201 status))
 
           (testing "Location header"
-            (is (= (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/1")
+            (is (= (str base-url context-path "/Patient/AAAAAAAAAAAAAAAA/_history/1")
                    (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
@@ -224,7 +226,7 @@
           (is (= 201 status))
 
           (testing "Location header"
-            (is (= (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/1")
+            (is (= (str base-url context-path "/Patient/AAAAAAAAAAAAAAAA/_history/1")
                    (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
@@ -251,7 +253,7 @@
           (is (= 201 status))
 
           (testing "Location header"
-            (is (= (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/1")
+            (is (= (str base-url context-path "/Patient/AAAAAAAAAAAAAAAA/_history/1")
                    (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
@@ -365,7 +367,7 @@
         (is (= 201 status))
 
         (testing "Location header"
-          (is (= (str base-url "/Observation/AAAAAAAAAAAAAAAA/_history/1")
+          (is (= (str base-url context-path "/Observation/AAAAAAAAAAAAAAAA/_history/1")
                  (get headers "Location"))))
 
         (testing "Transaction time in Last-Modified header"
@@ -402,7 +404,7 @@
         (is (= 201 status))
 
         (testing "Location header"
-          (is (= (str base-url "/Bundle/AAAAAAAAAAAAAAAA/_history/1")
+          (is (= (str base-url context-path "/Bundle/AAAAAAAAAAAAAAAA/_history/1")
                  (get headers "Location"))))
 
         (testing "Transaction time in Last-Modified header"

--- a/modules/interaction/test/blaze/interaction/history/instance_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/instance_test.clj
@@ -33,12 +33,14 @@
 
 
 (def base-url "base-url-135814")
+(def context-path "/context-path-181842")
 
 
 (def router
   (reitit/router
     [["/Patient" {:name :Patient/type}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (def match
@@ -46,7 +48,7 @@
     {:data
      {:blaze/base-url ""
       :fhir.resource/type "Patient"}
-     :path "/Patient/0/_history"}))
+     :path (str context-path "/Patient/0/_history")}))
 
 
 (deftest init-test
@@ -138,13 +140,13 @@
 
         (is (= "self" (-> body :link first :relation)))
 
-        (is (= "base-url-135814/Patient/0/_history?__t=1&__page-t=1"
+        (is (= (str base-url context-path "/Patient/0/_history?__t=1&__page-t=1")
                (-> body :link first :url)))
 
         (given (-> body :entry first)
-          :fullUrl := "base-url-135814/Patient/0"
+          :fullUrl := (str base-url context-path "/Patient/0")
           [:request :method] := #fhir/code"PUT"
-          [:request :url] := "/Patient/0"
+          [:request :url] := "Patient/0"
           [:resource :id] := "0"
           [:resource :fhir/type] := :fhir/Patient
           [:resource :meta :versionId] := #fhir/id"1"
@@ -179,14 +181,14 @@
 
         (is (= "self" (-> body :link first :relation)))
 
-        (is (= "base-url-135814/Patient/0/_history?__t=2&__page-t=2"
+        (is (= (str base-url context-path "/Patient/0/_history?__t=2&__page-t=2")
                (-> body :link first :url)))
 
         (testing "first entry"
           (given (-> body :entry first)
-            :fullUrl := "base-url-135814/Patient/0"
+            :fullUrl := (str base-url context-path "/Patient/0")
             [:request :method] := #fhir/code"DELETE"
-            [:request :url] := "/Patient/0"
+            [:request :url] := "Patient/0"
             keys :!> #{:resource}
             [:response :status] := "204"
             [:response :etag] := "W/\"2\""
@@ -194,9 +196,9 @@
 
         (testing "second entry"
           (given (-> body :entry second)
-            :fullUrl := "base-url-135814/Patient/0"
+            :fullUrl := (str base-url context-path "/Patient/0")
             [:request :method] := #fhir/code"PUT"
-            [:request :url] := "/Patient/0"
+            [:request :url] := "Patient/0"
             [:resource :id] := "0"
             [:resource :fhir/type] := :fhir/Patient
             [:resource :meta :versionId] := #fhir/id"1"
@@ -217,7 +219,7 @@
 
         (is (= "next" (-> body :link second :relation)))
 
-        (is (= "base-url-135814/Patient/0/_history?_count=1&__t=2&__page-t=1"
+        (is (= (str base-url context-path "/Patient/0/_history?_count=1&__t=2&__page-t=1")
                (-> body :link second :url))))))
 
   (testing "with two versions, calling the second page"

--- a/modules/interaction/test/blaze/interaction/history/system_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/system_test.clj
@@ -31,19 +31,21 @@
 
 
 (def base-url "base-url-135844")
+(def context-path "/context-path-182356")
 
 
 (def router
   (reitit/router
     [["/Patient" {:name :Patient/type}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (def match
   (reitit/map->Match
     {:data
      {:blaze/base-url ""}
-     :path "/_history"}))
+     :path (str context-path "/_history")}))
 
 
 (defn- link-url [body link-relation]
@@ -140,16 +142,16 @@
         (is (= #fhir/unsignedInt 1 (:total body)))
 
         (testing "has a self link"
-          (is (= "base-url-135844/_history?__t=1&__page-t=1&__page-type=Patient&__page-id=0"
+          (is (= (str base-url context-path "/_history?__t=1&__page-t=1&__page-type=Patient&__page-id=0")
                  (link-url body "self"))))
 
         (testing "the bundle contains one entry"
           (is (= 1 (count (:entry body)))))
 
         (given (-> body :entry first)
-          :fullUrl := "base-url-135844/Patient/0"
+          :fullUrl := (str base-url context-path "/Patient/0")
           [:request :method] := #fhir/code"PUT"
-          [:request :url] := "/Patient/0"
+          [:request :url] := "Patient/0"
           [:resource :id] := "0"
           [:resource :fhir/type] := :fhir/Patient
           [:resource :meta :versionId] := #fhir/id"1"
@@ -167,7 +169,7 @@
               @(handler {:query-params {"_count" "1"}})]
 
           (testing "hash next link"
-            (is (= "base-url-135844/_history?_count=1&__t=1&__page-t=1&__page-type=Patient&__page-id=1"
+            (is (= (str base-url context-path "/_history?_count=1&__t=1&__page-t=1&__page-type=Patient&__page-id=1")
                    (link-url body "next")))))))
 
     (testing "calling the second page shows the patient with the higher id"
@@ -208,7 +210,7 @@
 
           (is (= "next" (-> body :link second :relation)))
 
-          (is (= "base-url-135844/_history?_count=1&__t=2&__page-t=1&__page-type=Patient&__page-id=0"
+          (is (= (str base-url context-path "/_history?_count=1&__t=2&__page-t=1&__page-type=Patient&__page-id=0")
                  (-> body :link second :url))))))
 
     (testing "calling the second page shows the patient from the first transaction"

--- a/modules/interaction/test/blaze/interaction/history/type_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/type_test.clj
@@ -31,12 +31,14 @@
 
 
 (def base-url "base-url-144600")
+(def context-path "/context-path-182518")
 
 
 (def router
   (reitit/router
     [["/Patient" {:name :Patient/type}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (def match
@@ -44,7 +46,7 @@
     {:data
      {:blaze/base-url ""
       :fhir.resource/type "Patient"}
-     :path "/Patient/_history"}))
+     :path (str context-path "/Patient/_history")}))
 
 
 (defn- link-url [body link-relation]
@@ -141,16 +143,16 @@
         (is (= #fhir/unsignedInt 1 (:total body)))
 
         (testing "has self link"
-          (is (= "base-url-144600/Patient/_history?__t=1&__page-t=1&__page-id=0"
+          (is (= (str base-url context-path "/Patient/_history?__t=1&__page-t=1&__page-id=0")
                  (link-url body "self"))))
 
         (testing "the bundle contains one entry"
           (is (= 1 (count (:entry body)))))
 
         (given (-> body :entry first)
-          :fullUrl := "base-url-144600/Patient/0"
+          :fullUrl := (str base-url context-path "/Patient/0")
           [:request :method] := #fhir/code"PUT"
-          [:request :url] := "/Patient/0"
+          [:request :url] := "Patient/0"
           [:resource :id] := "0"
           [:resource :fhir/type] := :fhir/Patient
           [:resource :meta :versionId] := #fhir/id"1"

--- a/modules/interaction/test/blaze/interaction/history/util_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_test.clj
@@ -53,15 +53,21 @@
       ["3" "4"] 3)))
 
 
+(def base-url "base-url-183028")
+(def context-path "/context-path-183031")
+
+
 (def router
   (reitit/router
     [["/Patient" {:name :Patient/type}]
      ["/Patient/{id}" {:name :Patient/instance}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (def context
-  {:blaze/base-url "http://localhost:8080" ::reitit/router router})
+  {:blaze/base-url base-url
+   ::reitit/router router})
 
 
 (deftest build-entry-test
@@ -76,9 +82,9 @@
           {:blaze.db/op :create
            :blaze.db/num-changes 1
            :blaze.db/tx {:blaze.db.tx/instant Instant/EPOCH}}))
-      :fullUrl := "http://localhost:8080/Patient/0"
+      :fullUrl := (str base-url context-path "/Patient/0")
       [:request :method] := #fhir/code"POST"
-      [:request :url] := "/Patient"
+      [:request :url] := "Patient"
       [:resource :fhir/type] := :fhir/Patient
       [:resource :id] := "0"
       [:response :status] := "201"
@@ -97,9 +103,9 @@
           {:blaze.db/op :put
            :blaze.db/num-changes 1
            :blaze.db/tx {:blaze.db.tx/instant Instant/EPOCH}}))
-      :fullUrl := "http://localhost:8080/Patient/0"
+      :fullUrl := (str base-url context-path "/Patient/0")
       [:request :method] := #fhir/code"PUT"
-      [:request :url] := "/Patient/0"
+      [:request :url] := "Patient/0"
       [:resource :fhir/type] := :fhir/Patient
       [:resource :id] := "0"
       [:response :status] := "201"
@@ -118,9 +124,9 @@
           {:blaze.db/op :put
            :blaze.db/num-changes 2
            :blaze.db/tx {:blaze.db.tx/instant Instant/EPOCH}}))
-      :fullUrl := "http://localhost:8080/Patient/0"
+      :fullUrl := (str base-url context-path "/Patient/0")
       [:request :method] := #fhir/code"PUT"
-      [:request :url] := "/Patient/0"
+      [:request :url] := "Patient/0"
       [:resource :fhir/type] := :fhir/Patient
       [:resource :id] := "0"
       [:response :status] := "200"
@@ -139,9 +145,9 @@
           {:blaze.db/op :delete
            :blaze.db/num-changes 2
            :blaze.db/tx {:blaze.db.tx/instant Instant/EPOCH}}))
-      :fullUrl := "http://localhost:8080/Patient/0"
+      :fullUrl := (str base-url context-path "/Patient/0")
       [:request :method] := #fhir/code"DELETE"
-      [:request :url] := "/Patient/0"
+      [:request :url] := "Patient/0"
       [:response :status] := "204"
       [:response :lastModified] := Instant/EPOCH
       [:response :etag] := "W/\"2\"")))

--- a/modules/interaction/test/blaze/interaction/search_compartment_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_compartment_test.clj
@@ -33,20 +33,22 @@
 
 
 (def base-url "base-url-114238")
+(def context-path "/context-path-173854")
 
 
 (def router
   (reitit/router
     [["/Patient/{id}/{type}" {:name :Patient/compartment}]
      ["/Observation" {:name :Observation/type}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (def match
   (reitit/map->Match
     {:data
      {:fhir.compartment/code "Patient"}
-     :path "/Patient/0/Observation"}))
+     :path (str context-path "/Patient/0/Observation")}))
 
 
 (defn- link-url [body link-relation]
@@ -206,7 +208,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?_count=50&__t=1&__page-offset=0")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -241,7 +243,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?_summary=count&_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?_summary=count&_count=50&__t=1&__page-offset=0")
                          (link-url body "self"))))))))
 
         (testing "with another search parameter"
@@ -280,7 +282,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?status=preliminary&_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_count=50&__t=1&__page-offset=0")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -318,7 +320,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?status=preliminary&_summary=count&_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_summary=count&_count=50&__t=1&__page-offset=0")
                          (link-url body "self"))))))))))
 
     (testing "with default handling"
@@ -353,7 +355,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?_count=50&__t=1&__page-offset=0")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -387,7 +389,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?_summary=count&_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?_summary=count&_count=50&__t=1&__page-offset=0")
                          (link-url body "self"))))))))
 
         (testing "with another search parameter"
@@ -421,7 +423,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?status=preliminary&_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_count=50&__t=1&__page-offset=0")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -458,7 +460,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-114238/Patient/0/Observation?status=preliminary&_summary=count&_count=50&__t=1&__page-offset=0"
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_summary=count&_count=50&__t=1&__page-offset=0")
                          (link-url body "self")))))))))))
 
   (testing "Returns an empty Bundle on Non-Existing Compartment"
@@ -538,7 +540,7 @@
               (is (= #fhir/unsignedInt 2 (:total body))))
 
             (testing "has a self link"
-              (is (= "base-url-114238/Patient/0/Observation?_count=50&__t=1&__page-offset=0"
+              (is (= (str base-url context-path "/Patient/0/Observation?_count=50&__t=1&__page-offset=0")
                      (link-url body "self"))))
 
             (testing "the bundle contains two entries"
@@ -546,12 +548,12 @@
 
             (testing "the first entry"
               (given (-> body :entry first)
-                :fullUrl := "base-url-114238/Observation/0"
+                :fullUrl := (str base-url context-path "/Observation/0")
                 [:resource :fhir/type] := :fhir/Observation
                 [:resource :id] := "0"))
 
             (testing "the second entry"
               (given (-> body :entry second)
-                :fullUrl := "base-url-114238/Observation/1"
+                :fullUrl := (str base-url context-path "/Observation/1")
                 [:resource :fhir/type] := :fhir/Observation
                 [:resource :id] := "1"))))))))

--- a/modules/interaction/test/blaze/interaction/search_system_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_system_test.clj
@@ -132,7 +132,7 @@
             (is (= #fhir/unsignedInt 0 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_count=50&__t=0"
+            (is (= (str base-url "?_count=50&__t=0")
                    (link-url body "self"))))
 
           (testing "the bundle contains no entry"
@@ -161,14 +161,14 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_count=50&__t=1&__page-type=Patient&__page-id=0"
+            (is (= (str base-url "?_count=50&__t=1&__page-type=Patient&__page-id=0")
                    (link-url body "self"))))
 
           (testing "the bundle contains one entry"
             (is (= 1 (count (:entry body)))))
 
           (testing "the entry has the right fullUrl"
-            (is (= "base-url-114650/Patient/0"
+            (is (= (str base-url "/Patient/0")
                    (-> body :entry first :fullUrl))))
 
           (testing "the entry has the right resource"
@@ -197,7 +197,7 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_summary=count&_count=50&__t=1"
+            (is (= (str base-url "?_summary=count&_count=50&__t=1")
                    (link-url body "self"))))
 
           (testing "the bundle contains no entries"
@@ -219,7 +219,7 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_count=0&__t=1" (link-url body "self"))))
+            (is (= (str base-url "?_count=0&__t=1") (link-url body "self"))))
 
           (testing "the bundle contains no entries"
             (is (empty? (:entry body))))))))
@@ -237,11 +237,11 @@
             (is (= #fhir/unsignedInt 2 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_count=1&__t=1&__page-type=Patient&__page-id=0"
+            (is (= (str base-url "?_count=1&__t=1&__page-type=Patient&__page-id=0")
                    (link-url body "self"))))
 
           (testing "has a next link"
-            (is (= "base-url-114650/__page?_count=1&__t=1&__page-type=Patient&__page-id=1"
+            (is (= (str base-url "/__page?_count=1&__t=1&__page-type=Patient&__page-id=1")
                    (link-url body "next"))))
 
           (testing "the bundle contains one entry"
@@ -257,11 +257,11 @@
             (is (= #fhir/unsignedInt 2 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_count=1&__t=1&__page-type=Patient&__page-id=0"
+            (is (= (str base-url "?_count=1&__t=1&__page-type=Patient&__page-id=0")
                    (link-url body "self"))))
 
           (testing "has a next link"
-            (is (= "base-url-114650/__page?_count=1&__t=1&__page-type=Patient&__page-id=1"
+            (is (= (str base-url "/__page?_count=1&__t=1&__page-type=Patient&__page-id=1")
                    (link-url body "next"))))
 
           (testing "the bundle contains one entry"
@@ -277,7 +277,7 @@
             (is (= #fhir/unsignedInt 2 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-114650?_count=1&__t=1&__page-type=Patient&__page-id=1"
+            (is (= (str base-url "?_count=1&__t=1&__page-type=Patient&__page-id=1")
                    (link-url body "self"))))
 
           (testing "has no next link"

--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -38,6 +38,7 @@
 
 
 (def base-url "base-url-113047")
+(def context-path "/context-path-173858")
 
 
 (def router
@@ -54,14 +55,15 @@
      ["/Medication" {:name :Medication/type}]
      ["/Organization" {:name :Organization/type}]
      ["/Encounter" {:name :Encounter/type}]]
-    {:syntax :bracket}))
+    {:syntax :bracket
+     :path context-path}))
 
 
 (def patient-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "Patient"}
-     :path "/Patient"}))
+     :path (str context-path "/Patient")}))
 
 
 (def patient-search-match
@@ -69,7 +71,7 @@
     {:data
      {:name :Patient/search
       :fhir.resource/type "Patient"}
-     :path "/Patient"}))
+     :path (str context-path "/Patient")}))
 
 
 (def patient-page-match
@@ -77,49 +79,49 @@
     {:data
      {:name :Patient/page
       :fhir.resource/type "Patient"}
-     :path "/Patient"}))
+     :path (str context-path "/Patient")}))
 
 
 (def measure-report-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "MeasureReport"}
-     :path "/MeasureReport"}))
+     :path (str context-path "/MeasureReport")}))
 
 
 (def list-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "List"}
-     :path "/List"}))
+     :path (str context-path "/List")}))
 
 
 (def observation-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "Observation"}
-     :path "/Observation"}))
+     :path (str context-path "/Observation")}))
 
 
 (def condition-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "Condition"}
-     :path "/Condition"}))
+     :path (str context-path "/Condition")}))
 
 
 (def encounter-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "Encounter"}
-     :path "/Encounter"}))
+     :path (str context-path "/Encounter")}))
 
 
 (def medication-statement-match
   (reitit/map->Match
     {:data
      {:fhir.resource/type "MedicationStatement"}
-     :path "/MedicationStatement"}))
+     :path (str context-path "/MedicationStatement")}))
 
 
 (defn- link-url [body link-relation]
@@ -246,7 +248,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?_count=50&__t=1&__page-id=0"
+                  (is (= (str base-url context-path "/Patient?_count=50&__t=1&__page-id=0")
                          (link-url body "self"))))))
 
             (testing "summary result"
@@ -274,7 +276,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?_summary=count&_count=50&__t=1"
+                  (is (= (str base-url context-path "/Patient?_summary=count&_count=50&__t=1")
                          (link-url body "self"))))))))
 
         (testing "with another search parameter"
@@ -308,7 +310,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?active=true&_count=50&__t=1&__page-id=1"
+                  (is (= (str base-url context-path "/Patient?active=true&_count=50&__t=1&__page-id=1")
                          (link-url body "self"))))))
 
             (testing "summary result"
@@ -336,7 +338,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?active=true&_summary=count&_count=50&__t=1"
+                  (is (= (str base-url context-path "/Patient?active=true&_summary=count&_count=50&__t=1")
                          (link-url body "self"))))))))))
 
     (testing "with default handling"
@@ -369,7 +371,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?_count=50&__t=1&__page-id=0"
+                  (is (= (str base-url context-path "/Patient?_count=50&__t=1&__page-id=0")
                          (link-url body "self"))))))
 
             (testing "summary result"
@@ -396,7 +398,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?_summary=count&_count=50&__t=1"
+                  (is (= (str base-url context-path "/Patient?_summary=count&_count=50&__t=1")
                          (link-url body "self"))))))))
 
         (testing "with another search parameter"
@@ -429,7 +431,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?active=true&_count=50&__t=1&__page-id=1"
+                  (is (= (str base-url context-path "/Patient?active=true&_count=50&__t=1&__page-id=1")
                          (link-url body "self"))))))
 
             (testing "summary result"
@@ -456,7 +458,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Patient?active=true&_summary=count&_count=50&__t=1"
+                  (is (= (str base-url context-path "/Patient?active=true&_summary=count&_count=50&__t=1")
                          (link-url body "self")))))))))))
 
   (testing "on unsupported second sort parameter"
@@ -578,14 +580,14 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_count=50&__t=1&__page-id=0"
+            (is (= (str base-url context-path "/Patient?_count=50&__t=1&__page-id=0")
                    (link-url body "self"))))
 
           (testing "the bundle contains one entry"
             (is (= 1 (count (:entry body)))))
 
           (testing "the entry has the right fullUrl"
-            (is (= "base-url-113047/Patient/0"
+            (is (= (str base-url context-path "/Patient/0")
                    (-> body :entry first :fullUrl))))
 
           (testing "the entry has the right resource"
@@ -618,7 +620,7 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_summary=count&_count=50&__t=1"
+            (is (= (str base-url context-path "/Patient?_summary=count&_count=50&__t=1")
                    (link-url body "self"))))
 
           (testing "the bundle contains no entries"
@@ -642,7 +644,7 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_count=0&__t=1"
+            (is (= (str base-url context-path "/Patient?_count=0&__t=1")
                    (link-url body "self"))))
 
           (testing "the bundle contains no entries"
@@ -663,11 +665,11 @@
             (is (= #fhir/unsignedInt 2 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_count=1&__t=1&__page-id=0"
+            (is (= (str base-url context-path "/Patient?_count=1&__t=1&__page-id=0")
                    (link-url body "self"))))
 
           (testing "has a next link"
-            (is (= "base-url-113047/Patient/__page?_count=1&__t=1&__page-id=1"
+            (is (= (str base-url context-path "/Patient/__page?_count=1&__t=1&__page-id=1")
                    (link-url body "next"))))
 
           (testing "the bundle contains one entry"
@@ -683,11 +685,11 @@
             (is (= #fhir/unsignedInt 2 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_count=1&__t=1&__page-id=0"
+            (is (= (str base-url context-path "/Patient?_count=1&__t=1&__page-id=0")
                    (link-url body "self"))))
 
           (testing "has a next link"
-            (is (= "base-url-113047/Patient/__page?_count=1&__t=1&__page-id=1"
+            (is (= (str base-url context-path "/Patient/__page?_count=1&__t=1&__page-id=1")
                    (link-url body "next"))))
 
           (testing "the bundle contains one entry"
@@ -703,7 +705,7 @@
             (is (= #fhir/unsignedInt 2 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_count=1&__t=1&__page-id=1"
+            (is (= (str base-url context-path "/Patient?_count=1&__t=1&__page-id=1")
                    (link-url body "self"))))
 
           (testing "has no next link"
@@ -750,11 +752,11 @@
               (is (nil? (:total body))))
 
             (testing "has a self link"
-              (is (= "base-url-113047/Patient?active=true&_count=1&__t=1&__page-id=1"
+              (is (= (str base-url context-path "/Patient?active=true&_count=1&__t=1&__page-id=1")
                      (link-url body "self"))))
 
             (testing "has a next link with search params"
-              (is (= "base-url-113047/Patient/__page?active=true&_count=1&__t=1&__page-id=2"
+              (is (= (str base-url context-path "/Patient/__page?active=true&_count=1&__t=1&__page-id=2")
                      (link-url body "next"))))
 
             (testing "the bundle contains one entry"
@@ -772,11 +774,11 @@
               (is (nil? (:total body))))
 
             (testing "has a self link"
-              (is (= "base-url-113047/Patient?active=true&_count=1&__t=1&__page-id=1"
+              (is (= (str base-url context-path "/Patient?active=true&_count=1&__t=1&__page-id=1")
                      (link-url body "self"))))
 
             (testing "has a next link with token"
-              (is (= "base-url-113047/Patient/__page?__token=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB&_count=1&__t=1&__page-id=2"
+              (is (= (str base-url context-path "/Patient/__page?__token=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB&_count=1&__t=1&__page-id=2")
                      (link-url body "next"))))
 
             (testing "the bundle contains one entry"
@@ -793,11 +795,11 @@
             (is (nil? (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?active=true&_count=1&__t=1&__page-id=1"
+            (is (= (str base-url context-path "/Patient?active=true&_count=1&__t=1&__page-id=1")
                    (link-url body "self"))))
 
           (testing "has a next link with search params"
-            (is (= "base-url-113047/Patient/__page?active=true&_count=1&__t=1&__page-id=2"
+            (is (= (str base-url context-path "/Patient/__page?active=true&_count=1&__t=1&__page-id=2")
                    (link-url body "next"))))
 
           (testing "the bundle contains one entry"
@@ -814,7 +816,7 @@
             (is (nil? (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?active=true&_count=1&__t=1&__page-id=2"
+            (is (= (str base-url context-path "/Patient?active=true&_count=1&__t=1&__page-id=2")
                    (link-url body "self"))))
 
           (testing "has no next link"
@@ -838,7 +840,7 @@
                     :params {"active" "true" "_count" "1"}})]
 
             (testing "has a next link with search params"
-              (is (= "base-url-113047/Patient/__page?active=true&_count=1&__t=1&__page-id=2"
+              (is (= (str base-url context-path "/Patient/__page?active=true&_count=1&__t=1&__page-id=2")
                      (link-url body "next"))))
 
             (testing "the bundle contains one entry"
@@ -851,7 +853,7 @@
                     :params {"active" "true" "_count" "1" "__t" "1" "__page-id" "2"}})]
 
             (testing "has a next link with search params"
-              (is (= "base-url-113047/Patient/__page?active=true&_count=1&__t=1&__page-id=3"
+              (is (= (str base-url context-path "/Patient/__page?active=true&_count=1&__t=1&__page-id=3")
                      (link-url body "next"))))
 
             (testing "the bundle contains one entry"
@@ -865,7 +867,7 @@
                     :params {"active" "true" "_count" "1"}})]
 
             (testing "has a next link with token"
-              (is (= "base-url-113047/Patient/__page?__token=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB&_count=1&__t=1&__page-id=2"
+              (is (= (str base-url context-path "/Patient/__page?__token=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB&_count=1&__t=1&__page-id=2")
                      (link-url body "next"))))))
 
         (testing "following the next link"
@@ -875,7 +877,7 @@
                     :params {"__token" "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB" "_count" "1" "__t" "1" "__page-id" "2"}})]
 
             (testing "has a next link with token"
-              (is (= "base-url-113047/Patient/__page?__token=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB&_count=1&__t=1&__page-id=3"
+              (is (= (str base-url context-path "/Patient/__page?__token=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB&_count=1&__t=1&__page-id=3")
                      (link-url body "next")))))))))
 
 
@@ -904,7 +906,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Patient/0"
+          (is (= (str base-url context-path "/Patient/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -938,11 +940,11 @@
             (is (= 2 (count (:entry body)))))
 
           (testing "the first entry has the right fullUrl"
-            (is (= "base-url-113047/Patient/0"
+            (is (= (str base-url context-path "/Patient/0")
                    (-> body :entry first :fullUrl))))
 
           (testing "the second entry has the right fullUrl"
-            (is (= "base-url-113047/Patient/2"
+            (is (= (str base-url context-path "/Patient/2")
                    (-> body :entry second :fullUrl))))
 
           (testing "the first entry has the right resource"
@@ -1049,7 +1051,7 @@
               [2 :resource :id] := "2"))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_sort=_lastUpdated&_count=50&__t=3&__page-id=0"
+            (is (= (str base-url context-path "/Patient?_sort=_lastUpdated&_count=50&__t=3&__page-id=0")
                    (link-url body "self"))))))
 
       (testing "descending"
@@ -1079,7 +1081,7 @@
               [2 :resource :id] := "0"))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_sort=-_lastUpdated&_count=50&__t=3&__page-id=2"
+            (is (= (str base-url context-path "/Patient?_sort=-_lastUpdated&_count=50&__t=3&__page-id=2")
                    (link-url body "self"))))))))
 
   (testing "_profile search"
@@ -1111,7 +1113,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Patient/1"
+          (is (= (str base-url context-path "/Patient/1")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1151,7 +1153,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Patient/0"
+          (is (= (str base-url context-path "/Patient/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1201,7 +1203,7 @@
             (is (= 2 (count (:entry body)))))
 
           (testing "the entry has the right fullUrl"
-            (is (= "base-url-113047/Observation/1"
+            (is (= (str base-url context-path "/Observation/1")
                    (-> body :entry first :fullUrl))))
 
           (testing "the entry has the right resources"
@@ -1282,7 +1284,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Patient/0"
+          (is (= (str base-url context-path "/Patient/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1317,7 +1319,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Patient/0"
+          (is (= (str base-url context-path "/Patient/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1372,7 +1374,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Patient/0"
+          (is (= (str base-url context-path "/Patient/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1400,7 +1402,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Library/0"
+          (is (= (str base-url context-path "/Library/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1435,7 +1437,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/MeasureReport/0"
+          (is (= (str base-url context-path "/MeasureReport/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1483,7 +1485,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/List/id-143814"
+          (is (= (str base-url context-path "/List/id-143814")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1566,7 +1568,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "has a next link with search params"
-          (is (= "base-url-113047/Observation/__page?combo-code-value-quantity=http%3A%2F%2Floinc.org%7C8480-6%24ge140%7Cmm%5BHg%5D&combo-code-value-quantity=http%3A%2F%2Floinc.org%7C8462-4%24ge90%7Cmm%5BHg%5D&_count=1&__t=2&__page-id=id-123130"
+          (is (= (str base-url context-path "/Observation/__page?combo-code-value-quantity=http%3A%2F%2Floinc.org%7C8480-6%24ge140%7Cmm%5BHg%5D&combo-code-value-quantity=http%3A%2F%2Floinc.org%7C8462-4%24ge90%7Cmm%5BHg%5D&_count=1&__t=2&__page-id=id-123130")
                  (link-url body "next")))))))
 
   (testing "Duplicate OR Search Parameters have no Effect (#293)"
@@ -1599,7 +1601,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Condition/0"
+          (is (= (str base-url context-path "/Condition/0")
                  (-> body :entry first :fullUrl))))
 
         (testing "the entry has the right resource"
@@ -1645,7 +1647,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Condition/1"
+          (is (= (str base-url context-path "/Condition/1")
                  (-> body :entry first :fullUrl)))))))
 
   (testing "forward chaining"
@@ -1702,7 +1704,7 @@
             (is (= 1 (count (:entry body)))))
 
           (testing "the entry has the right fullUrl"
-            (is (= "base-url-113047/Encounter/0"
+            (is (= (str base-url context-path "/Encounter/0")
                    (-> body :entry first :fullUrl))))))
 
       (testing "ambiguous type"
@@ -1744,7 +1746,7 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Observation?_include=Observation%3Asubject&_count=50&__t=1&__page-id=0"
+            (is (= (str base-url context-path "/Observation?_include=Observation%3Asubject&_count=50&__t=1&__page-id=0")
                    (link-url body "self"))))
 
           (testing "the bundle contains two entries"
@@ -1752,13 +1754,13 @@
 
           (testing "the first entry is the matched Observation"
             (given (-> body :entry first)
-              :fullUrl := "base-url-113047/Observation/0"
+              :fullUrl := (str base-url context-path "/Observation/0")
               [:resource :fhir/type] := :fhir/Observation
               [:search :mode] := #fhir/code"match"))
 
           (testing "the second entry is the included Patient"
             (given (-> body :entry second)
-              :fullUrl := "base-url-113047/Patient/0"
+              :fullUrl := (str base-url context-path "/Patient/0")
               [:resource :fhir/type] := :fhir/Patient
               [:search :mode] := #fhir/code"include"))))
 
@@ -1789,7 +1791,7 @@
 
             (testing "the first entry is the matched Observation"
               (given (-> body :entry first)
-                :fullUrl := "base-url-113047/Observation/0"
+                :fullUrl := (str base-url context-path "/Observation/0")
                 [:resource :fhir/type] := :fhir/Observation
                 [:search :mode] := #fhir/code"match")))))
 
@@ -1822,19 +1824,19 @@
 
             (testing "the first entry is the first matched Observation"
               (given (-> body :entry first)
-                :fullUrl := "base-url-113047/Observation/1"
+                :fullUrl := (str base-url context-path "/Observation/1")
                 [:resource :fhir/type] := :fhir/Observation
                 [:search :mode] := #fhir/code"match"))
 
             (testing "the second entry is the second matched Observation"
               (given (-> body :entry second)
-                :fullUrl := "base-url-113047/Observation/2"
+                :fullUrl := (str base-url context-path "/Observation/2")
                 [:resource :fhir/type] := :fhir/Observation
                 [:search :mode] := #fhir/code"match"))
 
             (testing "the third entry is the included Patient"
               (given (-> body :entry (nth 2))
-                :fullUrl := "base-url-113047/Patient/0"
+                :fullUrl := (str base-url context-path "/Patient/0")
                 [:resource :fhir/type] := :fhir/Patient
                 [:search :mode] := #fhir/code"include")))))
 
@@ -1869,19 +1871,19 @@
 
             (testing "the first entry is the matched Observation"
               (given (-> body :entry first)
-                :fullUrl := "base-url-113047/Observation/2"
+                :fullUrl := (str base-url context-path "/Observation/2")
                 [:resource :fhir/type] := :fhir/Observation
                 [:search :mode] := #fhir/code"match"))
 
             (testing "the second entry is the included Encounter"
               (given (-> body :entry (nth 2))
-                :fullUrl := "base-url-113047/Encounter/1"
+                :fullUrl := (str base-url context-path "/Encounter/1")
                 [:resource :fhir/type] := :fhir/Encounter
                 [:search :mode] := #fhir/code"include"))
 
             (testing "the third entry is the included Patient"
               (given (-> body :entry second)
-                :fullUrl := "base-url-113047/Patient/0"
+                :fullUrl := (str base-url context-path "/Patient/0")
                 [:resource :fhir/type] := :fhir/Patient
                 [:search :mode] := #fhir/code"include")))))
 
@@ -1915,7 +1917,7 @@
               (is (= #fhir/unsignedInt 2 (:total body))))
 
             (testing "has a next link"
-              (is (= "base-url-113047/Observation/__page?_include=Observation%3Asubject&_count=1&__t=1&__page-id=3"
+              (is (= (str base-url context-path "/Observation/__page?_include=Observation%3Asubject&_count=1&__t=1&__page-id=3")
                      (link-url body "next"))))
 
             (testing "the bundle contains two entries"
@@ -1923,13 +1925,13 @@
 
             (testing "the first entry is the matched Observation"
               (given (-> body :entry first)
-                :fullUrl := "base-url-113047/Observation/1"
+                :fullUrl := (str base-url context-path "/Observation/1")
                 [:resource :fhir/type] := :fhir/Observation
                 [:search :mode] := #fhir/code"match"))
 
             (testing "the second entry is the included Patient"
               (given (-> body :entry second)
-                :fullUrl := "base-url-113047/Patient/0"
+                :fullUrl := (str base-url context-path "/Patient/0")
                 [:resource :fhir/type] := :fhir/Patient
                 [:search :mode] := #fhir/code"include"))
 
@@ -1952,7 +1954,7 @@
                   (is (= #fhir/unsignedInt 2 (:total body))))
 
                 (testing "has a self link"
-                  (is (= "base-url-113047/Observation?_include=Observation%3Asubject&_count=2&__t=1&__page-id=3"
+                  (is (= (str base-url context-path "/Observation?_include=Observation%3Asubject&_count=2&__t=1&__page-id=3")
                          (link-url body "self"))))
 
                 (testing "the bundle contains two entries"
@@ -1960,13 +1962,13 @@
 
                 (testing "the first entry is the matched Observation"
                   (given (-> body :entry first)
-                    :fullUrl := "base-url-113047/Observation/3"
+                    :fullUrl := (str base-url context-path "/Observation/3")
                     [:resource :fhir/type] := :fhir/Observation
                     [:search :mode] := #fhir/code"match"))
 
                 (testing "the second entry is the included Patient"
                   (given (-> body :entry second)
-                    :fullUrl := "base-url-113047/Patient/2"
+                    :fullUrl := (str base-url context-path "/Patient/2")
                     [:resource :fhir/type] := :fhir/Patient
                     [:search :mode] := #fhir/code"include"))))))))
 
@@ -2005,19 +2007,19 @@
 
           (testing "the first entry is the matched MedicationStatement"
             (given (-> body :entry first)
-              :fullUrl := "base-url-113047/MedicationStatement/0"
+              :fullUrl := (str base-url context-path "/MedicationStatement/0")
               [:resource :fhir/type] := :fhir/MedicationStatement
               [:search :mode] := #fhir/code"match"))
 
           (testing "the second entry is the included Organization"
             (given (-> body :entry second)
-              :fullUrl := "base-url-113047/Organization/0"
+              :fullUrl := (str base-url context-path "/Organization/0")
               [:resource :fhir/type] := :fhir/Organization
               [:search :mode] := #fhir/code"include"))
 
           (testing "the third entry is the included Medication"
             (given (-> body :entry (nth 2))
-              :fullUrl := "base-url-113047/Medication/0"
+              :fullUrl := (str base-url context-path "/Medication/0")
               [:resource :fhir/type] := :fhir/Medication
               [:search :mode] := #fhir/code"include")))))
 
@@ -2057,13 +2059,13 @@
 
           (testing "the first entry is the matched MedicationStatement"
             (given (-> body :entry first)
-              :fullUrl := "base-url-113047/MedicationStatement/0"
+              :fullUrl := (str base-url context-path "/MedicationStatement/0")
               [:resource :fhir/type] := :fhir/MedicationStatement
               [:search :mode] := #fhir/code"match"))
 
           (testing "the second entry is the included Medication"
             (given (-> body :entry second)
-              :fullUrl := "base-url-113047/Medication/0"
+              :fullUrl := (str base-url context-path "/Medication/0")
               [:resource :fhir/type] := :fhir/Medication
               [:search :mode] := #fhir/code"include")))))
 
@@ -2092,7 +2094,7 @@
             (is (= #fhir/unsignedInt 1 (:total body))))
 
           (testing "has a self link"
-            (is (= "base-url-113047/Patient?_revinclude=Observation%3Asubject&_count=50&__t=1&__page-id=0"
+            (is (= (str base-url context-path "/Patient?_revinclude=Observation%3Asubject&_count=50&__t=1&__page-id=0")
                    (link-url body "self"))))
 
           (testing "the bundle contains two entries"
@@ -2100,13 +2102,13 @@
 
           (testing "the first entry is the matched Patient"
             (given (-> body :entry first)
-              :fullUrl := "base-url-113047/Patient/0"
+              :fullUrl := (str base-url context-path "/Patient/0")
               [:resource :fhir/type] := :fhir/Patient
               [:search :mode] := #fhir/code"match"))
 
           (testing "the second entry is the included Observation"
             (given (-> body :entry second)
-              :fullUrl := "base-url-113047/Observation/1"
+              :fullUrl := (str base-url context-path "/Observation/1")
               [:resource :fhir/type] := :fhir/Observation
               [:search :mode] := #fhir/code"include"))))
 
@@ -2140,7 +2142,7 @@
               (is (= #fhir/unsignedInt 1 (:total body))))
 
             (testing "has a self link"
-              (is (= "base-url-113047/Patient?_revinclude=Observation%3Asubject&_revinclude=Condition%3Asubject&_count=50&__t=1&__page-id=0"
+              (is (= (str base-url context-path "/Patient?_revinclude=Observation%3Asubject&_revinclude=Condition%3Asubject&_count=50&__t=1&__page-id=0")
                      (link-url body "self"))))
 
             (testing "the bundle contains two entries"
@@ -2148,19 +2150,19 @@
 
             (testing "the first entry is the matched Patient"
               (given (-> body :entry first)
-                :fullUrl := "base-url-113047/Patient/0"
+                :fullUrl := (str base-url context-path "/Patient/0")
                 [:resource :fhir/type] := :fhir/Patient
                 [:search :mode] := #fhir/code"match"))
 
             (testing "the second entry is the included Condition"
               (given (-> body :entry second)
-                :fullUrl := "base-url-113047/Condition/2"
+                :fullUrl := (str base-url context-path "/Condition/2")
                 [:resource :fhir/type] := :fhir/Condition
                 [:search :mode] := #fhir/code"include"))
 
             (testing "the third entry is the included Observation"
               (given (-> body :entry (nth 2))
-                :fullUrl := "base-url-113047/Observation/1"
+                :fullUrl := (str base-url context-path "/Observation/1")
                 [:resource :fhir/type] := :fhir/Observation
                 [:search :mode] := #fhir/code"include"))))))
 
@@ -2214,7 +2216,7 @@
           (is (= 1 (count (:entry body)))))
 
         (testing "the entry has the right fullUrl"
-          (is (= "base-url-113047/Observation/0" (:fullUrl entry))))
+          (is (= (str base-url context-path "/Observation/0") (:fullUrl entry))))
 
         (testing "the resource is subsetted"
           (given (-> resource :meta :tag first)

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -287,7 +287,7 @@
                   (testing "entry response"
                     (given response
                       :status := "201"
-                      :location := "base-url-115515/Patient/0/_history/1"
+                      :location := (str base-url "/Patient/0/_history/1")
                       :etag := "W/\"1\""
                       :lastModified := Instant/EPOCH)))))
 
@@ -321,7 +321,7 @@
                   (testing "entry response"
                     (given response
                       :status := "201"
-                      :location := "base-url-115515/Patient/0/_history/1"
+                      :location := (str base-url "/Patient/0/_history/1")
                       :etag := "W/\"1\""
                       :lastModified := Instant/EPOCH)))))))
 
@@ -439,7 +439,7 @@
                 (testing "entry response"
                   (given response
                     :status := "201"
-                    :location := "base-url-115515/Patient/AAAAAAAAAAAAAAAA/_history/1"
+                    :location := (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/1")
                     :etag := "W/\"1\""
                     :lastModified := Instant/EPOCH)))))
 
@@ -473,7 +473,7 @@
                 (testing "entry response"
                   (given response
                     :status := "201"
-                    :location := "base-url-115515/Patient/AAAAAAAAAAAAAAAA/_history/1"
+                    :location := (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/1")
                     :etag := "W/\"1\""
                     :lastModified := Instant/EPOCH)))))))
 
@@ -557,7 +557,7 @@
                   (testing "entry response"
                     (given response
                       :status := "201"
-                      :location := "base-url-115515/Patient/AAAAAAAAAAAAAAAA/_history/2"
+                      :location := (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/2")
                       :etag := "W/\"2\""
                       :lastModified := Instant/EPOCH))))))
 
@@ -604,7 +604,7 @@
                   (testing "entry response"
                     (given response
                       :status := "201"
-                      :location := "base-url-115515/Patient/AAAAAAAAAAAAAAAA/_history/2"
+                      :location := (str base-url "/Patient/AAAAAAAAAAAAAAAA/_history/2")
                       :etag := "W/\"2\""
                       :lastModified := Instant/EPOCH)))))))
 
@@ -1680,7 +1680,7 @@
             (testing "entry response"
               (given response
                 :status := "201"
-                :location := "base-url-115515/Patient/0/_history/1"
+                :location := (str base-url "/Patient/0/_history/1")
                 :etag := "W/\"1\""
                 :lastModified := Instant/EPOCH))))
 
@@ -1709,7 +1709,7 @@
               (testing "entry response"
                 (given response
                   :status := "201"
-                  :location := "base-url-115515/Patient/0/_history/1"
+                  :location := (str base-url "/Patient/0/_history/1")
                   :etag := "W/\"1\""
                   :lastModified := Instant/EPOCH))))))
 
@@ -1743,7 +1743,7 @@
             (testing "entry response"
               (given response
                 :status := "201"
-                :location := "base-url-115515/Patient/0/_history/1"
+                :location := (str base-url "/Patient/0/_history/1")
                 :etag := "W/\"1\""
                 :lastModified := Instant/EPOCH))))))
 

--- a/modules/interaction/test/blaze/interaction/update_test.clj
+++ b/modules/interaction/test/blaze/interaction/update_test.clj
@@ -255,7 +255,7 @@
             (is (= 201 status)))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/1" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/1") (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
             (is (= "Thu, 1 Jan 1970 00:00:00 GMT" (get headers "Last-Modified"))))
@@ -264,7 +264,7 @@
             (is (= "W/\"1\"" (get headers "ETag"))))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/1" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/1") (get headers "Location"))))
 
           (testing "Contains the resource as body"
             (given body
@@ -286,7 +286,7 @@
             (is (= 201 status)))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/1" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/1") (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
             (is (= "Thu, 1 Jan 1970 00:00:00 GMT" (get headers "Last-Modified"))))
@@ -295,7 +295,7 @@
             (is (= "W/\"1\"" (get headers "ETag"))))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/1" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/1") (get headers "Location"))))
 
           (testing "Contains no body"
             (is (nil? body))))))
@@ -313,7 +313,7 @@
             (is (= 201 status)))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/1" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/1") (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
             (is (= "Thu, 1 Jan 1970 00:00:00 GMT" (get headers "Last-Modified"))))
@@ -322,7 +322,7 @@
             (is (= "W/\"1\"" (get headers "ETag"))))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/1" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/1") (get headers "Location"))))
 
           (testing "Contains body"
             (given body
@@ -345,7 +345,7 @@
             (is (= 201 status)))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/3" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/3") (get headers "Location"))))
 
           (testing "Transaction time in Last-Modified header"
             (is (= "Thu, 1 Jan 1970 00:00:00 GMT" (get headers "Last-Modified"))))
@@ -354,7 +354,7 @@
             (is (= "W/\"3\"" (get headers "ETag"))))
 
           (testing "Location header"
-            (is (= "base-url-134013/Patient/0/_history/3" (get headers "Location"))))
+            (is (= (str base-url "/Patient/0/_history/3") (get headers "Location"))))
 
           (testing "Contains the resource as body"
             (given body
@@ -406,7 +406,7 @@
           (is (= 201 status)))
 
         (testing "Location header"
-          (is (= "base-url-134013/Observation/0/_history/1" (get headers "Location"))))
+          (is (= (str base-url "/Observation/0/_history/1") (get headers "Location"))))
 
         (testing "Transaction time in Last-Modified header"
           (is (= "Thu, 1 Jan 1970 00:00:00 GMT" (get headers "Last-Modified"))))
@@ -415,7 +415,7 @@
           (is (= "W/\"1\"" (get headers "ETag"))))
 
         (testing "Location header"
-          (is (= "base-url-134013/Observation/0/_history/1" (get headers "Location"))))
+          (is (= (str base-url "/Observation/0/_history/1") (get headers "Location"))))
 
         (testing "Contains the resource as body"
           (given body

--- a/modules/rest-util/test/blaze/handler/fhir/util_test.clj
+++ b/modules/rest-util/test/blaze/handler/fhir/util_test.clj
@@ -3,7 +3,8 @@
     [blaze.handler.fhir.util :as fhir-util]
     [blaze.test-util :as tu]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [are deftest is testing]]))
+    [clojure.test :as test :refer [are deftest is testing]]
+    [reitit.core :as reitit]))
 
 
 (st/instrument)
@@ -120,20 +121,32 @@
       ["A" "b"] "A")))
 
 
+(def router
+  (reitit/router
+    [[""
+      {}
+      ["/Patient" {:name :Patient/type}]
+      ["/Patient/{id}" {:name :Patient/instance}]
+      ["/Patient/{id}/_history/{vid}" {:name :Patient/versioned-instance}]]]
+    {:syntax :bracket
+     :path "/fhir"}))
+
+
 (def context
-  {:blaze/base-url "http://localhost:8080"})
+  {:blaze/base-url "http://localhost:8080"
+   ::reitit/router router})
 
 
 (deftest type-url-test
-  (is (= "http://localhost:8080/Patient"
+  (is (= "http://localhost:8080/fhir/Patient"
          (fhir-util/type-url context "Patient"))))
 
 
 (deftest instance-url-test
-  (is (= "http://localhost:8080/Patient/0"
+  (is (= "http://localhost:8080/fhir/Patient/0"
          (fhir-util/instance-url context "Patient" "0"))))
 
 
 (deftest versioned-instance-url-test
-  (is (= "http://localhost:8080/Patient/0/_history/1"
+  (is (= "http://localhost:8080/fhir/Patient/0/_history/1"
          (fhir-util/versioned-instance-url context "Patient" "0" "1"))))

--- a/modules/spec/src/blaze/spec.clj
+++ b/modules/spec/src/blaze/spec.clj
@@ -7,6 +7,7 @@
     [java.util Random]))
 
 
+;; The base URL of Blaze without :blaze/context-path
 (s/def :blaze/base-url
   (s/and string? (complement #(str/ends-with? % "/"))))
 
@@ -15,6 +16,7 @@
   string?)
 
 
+;; The context path of Blaze that is appended to the :blaze/base-url
 (s/def :blaze/context-path
   (s/and
     string?


### PR DESCRIPTION
In #925, I changed the implementation of blaze.handler.fhir.util/type-url, instance-url and versioned-instance-url so that I no longer payed attention to the context path. So URL's generated by that functions missed the context-path.

Also fixed the Bundle.entry.request.url in history bundles.