### PR TITLE
Improve Composite Search Param Errors

### DIFF
--- a/modules/db/src/blaze/db/impl/search_param/composite/common.clj
+++ b/modules/db/src/blaze/db/impl/search_param/composite/common.clj
@@ -13,8 +13,14 @@
 (set! *warn-on-reflection* true)
 
 
-(defn split-value [value]
-  (str/split value #"\$" 2))
+(defn split-value
+  "Returns the first and second value part in a vector or an anomaly if the
+  second part is missing."
+  [value]
+  (let [res (str/split value #"\$" 2)]
+    (if (< (count res) 2)
+      (ba/incorrect (format "Miss the second part is composite search value `%s`." value))
+      res)))
 
 
 (defn compile-component-value [{:keys [search-param]} value]

--- a/modules/db/src/blaze/db/impl/search_param/composite/token_quantity.clj
+++ b/modules/db/src/blaze/db/impl/search_param/composite/token_quantity.clj
@@ -36,20 +36,20 @@
   [name url type base code c-hash main-expression c1 c2]
   p/SearchParam
   (-compile-value [_ _ value]
-    (let [[v1 v2] (cc/split-value value)
-          token-value (cc/compile-component-value c1 v1)]
-      (if-ok [quantity-value (cc/compile-component-value c2 v2)]
-        (prefix-with quantity-value token-value)
-        #(case (::spq/category %)
-          ::spq/invalid-decimal-value
-          (assoc %
-            ::anom/message (u/invalid-decimal-value-msg code v2))
-          ::spq/unsupported-prefix
-          (assoc %
-            ::anom/message
-            (u/unsupported-prefix-msg
-              code (::spq/unsupported-prefix %)))
-          %))))
+    (when-ok [[v1 v2] (cc/split-value value)]
+      (let [token-value (cc/compile-component-value c1 v1)]
+        (if-ok [quantity-value (cc/compile-component-value c2 v2)]
+          (prefix-with quantity-value token-value)
+          #(case (::spq/category %)
+             ::spq/invalid-decimal-value
+             (assoc %
+               ::anom/message (u/invalid-decimal-value-msg code v2))
+             ::spq/unsupported-prefix
+             (assoc %
+               ::anom/message
+               (u/unsupported-prefix-msg
+                 code (::spq/unsupported-prefix %)))
+             %)))))
 
   (-resource-handles [_ context tid _ value]
     (coll/eduction

--- a/modules/db/src/blaze/db/impl/search_param/composite/token_token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/composite/token_token.clj
@@ -14,10 +14,10 @@
   [name url type base code c-hash main-expression c1 c2]
   p/SearchParam
   (-compile-value [_ _ value]
-    (let [[v1 v2] (cc/split-value value)
-          v1 (cc/compile-component-value c1 v1)
-          v2 (cc/compile-component-value c1 v2)]
-      (bs/concat v1 v2)))
+    (when-ok [[v1 v2] (cc/split-value value)]
+      (let [v1 (cc/compile-component-value c1 v1)
+            v2 (cc/compile-component-value c1 v2)]
+        (bs/concat v1 v2))))
 
   (-resource-handles [_ context tid _ value]
     (coll/eduction

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -2541,6 +2541,11 @@
                         :code #fhir/code"mm[Hg]"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]]]
 
+      (testing "missing second value part"
+        (given (d/type-query (d/db node) "Observation" [["code-value-quantity" "8480-6"]])
+          ::anom/category := ::anom/incorrect
+          ::anom/message := "Miss the second part is composite search value `8480-6`."))
+
       (testing "as first clause"
         (let [clauses [["code-value-quantity" "8480-6$ge140"]]]
           (given (pull-type-query node "Observation" clauses)
@@ -2725,6 +2730,11 @@
                                 {:system #fhir/uri"http://snomed.info/sct"
                                  :code #fhir/code"260373001"
                                  :display "Detected (qualifier value)"}]}}]]]
+
+      (testing "missing second value part"
+        (given (d/type-query (d/db node) "Observation" [["code-value-concept" "http://loinc.org|94564-2"]])
+          ::anom/category := ::anom/incorrect
+          ::anom/message := "Miss the second part is composite search value `http://loinc.org|94564-2`."))
 
       (testing "as first clause"
         (testing "code as system|code"

--- a/modules/db/test/blaze/db/impl/search_param/composite/common_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite/common_spec.clj
@@ -1,0 +1,13 @@
+(ns blaze.db.impl.search-param.composite.common-spec
+  (:require
+    [blaze.anomaly-spec]
+    [blaze.byte-string-spec]
+    [blaze.coll.core-spec]
+    [blaze.db.impl.search-param.composite.common :as cc]
+    [blaze.fhir-path-spec]
+    [clojure.spec.alpha :as s]))
+
+
+(s/fdef cc/split-value
+  :args (s/cat :value string?)
+  :ret vector?)

--- a/modules/db/test/blaze/db/impl/search_param/composite/token_quantity_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite/token_quantity_spec.clj
@@ -3,6 +3,7 @@
     [blaze.byte-string-spec]
     [blaze.coll.core-spec]
     [blaze.db.impl.codec-spec]
+    [blaze.db.impl.search-param.composite.common-spec]
     [blaze.db.impl.search-param.quantity-spec]
     [blaze.db.impl.search-param.util-spec]
     [blaze.fhir-path-spec]))

--- a/modules/db/test/blaze/db/impl/search_param/composite/token_token_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite/token_token_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.byte-string-spec]
     [blaze.coll.core-spec]
+    [blaze.db.impl.search-param.composite.common-spec]
     [blaze.db.impl.search-param.token-spec]
     [blaze.db.impl.search-param.util-spec]
     [blaze.fhir-path-spec]))


### PR DESCRIPTION
Before we run into a NPE if the second port of a composite search param value were missing.