### PR TITLE
Improve Reverse Chaining Error Handling

### DIFF
--- a/modules/db/src/blaze/db/api_spec.clj
+++ b/modules/db/src/blaze/db/api_spec.clj
@@ -31,6 +31,11 @@
   :ret :blaze.db/node)
 
 
+(s/fdef d/basis-t
+  :args (s/cat :db :blaze.db/db)
+  :ret :blaze.db/t)
+
+
 (s/fdef d/tx
   :args (s/cat :node-or-db (s/or :node :blaze.db/node :db :blaze.db/db)
                :t :blaze.db/t)

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -1133,6 +1133,30 @@
               [0 :id] := "0")))))
 
     (testing "errors"
+      (testing "missing modifier"
+        (with-system [{:blaze.db/keys [node]} system]
+          (given (d/type-query (d/db node) "Patient" [["_has" ""]])
+            ::anom/category := ::anom/incorrect
+            ::anom/message := "Missing modifier of _has search param.")))
+
+      (testing "missing type"
+        (with-system [{:blaze.db/keys [node]} system]
+          (given (d/type-query (d/db node) "Patient" [["_has:" ""]])
+            ::anom/category := ::anom/incorrect
+            ::anom/message := "Missing type in _has search param `_has:`.")))
+
+      (testing "missing chaining search param"
+        (with-system [{:blaze.db/keys [node]} system]
+          (given (d/type-query (d/db node) "Patient" [["_has:foo" ""]])
+            ::anom/category := ::anom/incorrect
+            ::anom/message := "Missing chaining search param in _has search param `_has:foo`.")))
+
+      (testing "missing search param"
+        (with-system [{:blaze.db/keys [node]} system]
+          (given (d/type-query (d/db node) "Patient" [["_has:foo:bar" ""]])
+            ::anom/category := ::anom/incorrect
+            ::anom/message := "Missing search param in _has search param `_has:foo:bar`.")))
+
       (testing "main search param not found"
         (with-system [{:blaze.db/keys [node]} system]
           (given (d/type-query (d/db node) "Patient" [["_has:Observation:patient:foo" ""]])


### PR DESCRIPTION
It was possible to omit parts of the reverse chaining search parameter _has which resulted in a 500 because string splitting on nil. This fix reports the individual missing parts.