### PR TITLE
Improve Performance Evaluating Measures without Stratifier

### DIFF
--- a/docs/performance/cql.md
+++ b/docs/performance/cql.md
@@ -17,20 +17,22 @@ define InInitialPopulation:
   exists [Observation: Code '17861-6' from loinc]
 ```
 
+The `DB_RESOURCE_HANDLE_CACHE_SIZE` was set to zero because CQL doesn't benefit from it. The GC settings were: `-XX:+UseG1GC -XX:MaxGCPauseMillis=50`.
+
 The CQL query is executed with the following `blazectl` command:
 
 ```sh
-blazectl "evaluate-measure docs/performance/cql/observation-$CODE.yml" --server http://localhost:8080/fhir | jq -rf docs/performance/cql/result.jq
+blazectl evaluate-measure "cql/observation-$CODE.yml" --server http://localhost:8080/fhir | jq -rf cql/result.jq
 ```
 
-| CPU        | Heap Mem | Block Cache | # Pat. ¹ | # Obs. ² | Code    | # Hits | Time (s) | T / 1M ³ |
-|------------|---------:|------------:|---------:|---------:|---------|-------:|---------:|---------:|
-| EPYC 7543P |     8 GB |        1 GB |    100 k |     28 M | 17861-6 |   15 k |     0.42 |     4.19 |
-| EPYC 7543P |     8 GB |        1 GB |    100 k |     28 M | 39156-5 |   99 k |     0.55 |     5.51 |
-| EPYC 7543P |     8 GB |        1 GB |    100 k |     28 M | 29463-7 |  100 k |     0.55 |     5.54 |
-| EPYC 7543P |    30 GB |       10 GB |      1 M |    278 M | 17861-6 |  149 k |     4.14 |     4.13 |
-| EPYC 7543P |    30 GB |       10 GB |      1 M |    278 M | 39156-5 |  995 k |     5.72 |     5.71 |
-| EPYC 7543P |    30 GB |       10 GB |      1 M |    278 M | 29463-7 |    1 M |     5.71 |     5.70 |
+| CPU        | Heap Mem | Block Cache | # Pat. ¹ | # Obs. ² | Code    | # Hits | Time (s) | StdDev | T / 1M ³ |
+|------------|---------:|------------:|---------:|---------:|---------|-------:|---------:|-------:|---------:|
+| EPYC 7543P |     1 GB |        4 GB |    100 k |     28 M | 17861-6 |   15 k |     0.23 |  0.037 |      2.3 |
+| EPYC 7543P |     1 GB |        4 GB |    100 k |     28 M | 39156-5 |   99 k |     0.25 |  0.034 |      2.5 |
+| EPYC 7543P |     1 GB |        4 GB |    100 k |     28 M | 29463-7 |  100 k |     0.25 |  0.035 |      2.5 |
+| EPYC 7543P |     1 GB |       32 GB |      1 M |    278 M | 17861-6 |  149 k |     2.37 |  0.096 |      2.4 |
+| EPYC 7543P |     1 GB |       32 GB |      1 M |    278 M | 39156-5 |  995 k |     2.64 |  0.103 |      2.6 |
+| EPYC 7543P |     1 GB |       32 GB |      1 M |    278 M | 29463-7 |    1 M |     2.65 |  0.082 |      2.7 |
 
 ¹ Number of Patients, ² Number of Observations, ³ Time in seconds per 1 million patients, The amount of system memory was 128 GB in all cases.
 
@@ -52,19 +54,54 @@ define InInitialPopulation:
   exists [Observation: "body-weight"] O where O.value < 73.3 'kg'
 ```
 
+The `DB_RESOURCE_HANDLE_CACHE_SIZE` was set to zero because CQL doesn't benefit from it. The GC settings were: `-XX:+UseG1GC -XX:MaxGCPauseMillis=50`.
+
 The CQL query is executed with the following `blazectl` command:
 
 ```sh
-blazectl evaluate-measure "docs/performance/cql/observation-$CODE-$VALUE.yml" --server http://localhost:8080/fhir | jq -rf docs/performance/cql/result.jq
+blazectl evaluate-measure "cql/observation-$CODE-$VALUE.yml" --server http://localhost:8080/fhir | jq -rf cql/result.jq
 ```
 
-| CPU        | Heap Mem | Block Cache | # Pat. ¹ | # Obs. ² | Code    | Value | # Hits | Time (s) |
-|------------|---------:|------------:|---------:|---------:|---------|------:|-------:|---------:|
-| EPYC 7543P |     8 GB |        1 GB |    100 k |     28 M | 29463-7 |  11.1 |   10 k |     1.97 |
-| EPYC 7543P |     8 GB |        1 GB |    100 k |     28 M | 29463-7 |  73.3 |   50 k |     1.20 |
-| EPYC 7543P |     8 GB |        1 GB |    100 k |     28 M | 29463-7 |   185 |  100 k |     0.63 |
-| EPYC 7543P |    30 GB |       10 GB |      1 M |    278 M | 17861-6 |  11.1 |  100 k |    20.10 |
-| EPYC 7543P |    30 GB |       10 GB |      1 M |    278 M | 39156-5 |  73.3 |  500 k |    13.10 |
-| EPYC 7543P |    30 GB |       10 GB |      1 M |    278 M | 29463-7 |   185 |    1 M |     5.92 |
+| CPU        | Heap Mem | Block Cache | # Pat. ¹ | # Obs. ² | Code    | Value | # Hits | Time (s) | StdDev |
+|------------|---------:|------------:|---------:|---------:|---------|------:|-------:|---------:|-------:|
+| EPYC 7543P |     2 GB |        4 GB |    100 k |     28 M | 29463-7 |  11.1 |   10 k |     1.02 |  0.023 |
+| EPYC 7543P |     2 GB |        4 GB |    100 k |     28 M | 29463-7 |  73.3 |   50 k |     0.70 |  0.026 |
+| EPYC 7543P |     2 GB |        4 GB |    100 k |     28 M | 29463-7 |   185 |  100 k |     0.28 |  0.025 |
+| EPYC 7543P |    20 GB |       32 GB |      1 M |    278 M | 17861-6 |  11.1 |  100 k |     ---- |  ----- |
+| EPYC 7543P |    20 GB |       32 GB |      1 M |    278 M | 39156-5 |  73.3 |  500 k |     3.20 |  0.179 |
+| EPYC 7543P |    20 GB |       32 GB |      1 M |    278 M | 29463-7 |   185 |    1 M |     5.92 |  0.082 |
+
+¹ Number of Patients, ² Number of Observations, The amount of system memory was 128 GB in all cases.
+
+## Observation Code Search
+
+In this section, CQL Queries for selecting Patients which have Observation resources with a certain code and value are used.
+
+```text
+library "observation-category-laboratory"
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+codesystem "observation-category": 'http://terminology.hl7.org/CodeSystem/observation-category'
+code "laboratory": 'laboratory' from "observation-category"
+
+context Patient
+
+define InInitialPopulation:
+  [Observation: category in "laboratory"]
+```
+
+The `DB_RESOURCE_HANDLE_CACHE_SIZE` was set to zero because CQL doesn't benefit from it. The GC settings were: `-XX:+UseG1GC -XX:MaxGCPauseMillis=50`.
+
+The CQL query is executed with the following `blazectl` command:
+
+```sh
+blazectl evaluate-measure "cql/observation-category-$CODE.yml" --server http://localhost:8080/fhir | jq -rf cql/result.jq
+```
+
+| CPU        | Heap Mem | Block Cache | # Pat. ¹ | # Obs. ² | Code       | # Hits | Time (s) | StdDev |
+|------------|---------:|------------:|---------:|---------:|------------|-------:|---------:|-------:|
+| EPYC 7543P |     1 GB |        4 GB |    100 k |     28 M | laboratory |   17 M |     10.1 |  0.315 |
+| EPYC 7543P |     1 GB |       40 GB |      1 M |    278 M | laboratory |  170 M |     92.8 |  2.057 |
 
 ¹ Number of Patients, ² Number of Observations, The amount of system memory was 128 GB in all cases.

--- a/docs/performance/cql/code-value-search.sh
+++ b/docs/performance/cql/code-value-search.sh
@@ -1,19 +1,21 @@
 #!/bin/bash -e
 
 BASE="http://localhost:8080/fhir"
+START_EPOCH="$(date +"%s")"
 
 for CODE in "body-weight"
 do
   for VALUE in "10" "50" "100"
   do
     echo "Counting Patients with Observations with code $CODE and value $VALUE..."
-    for i in {1..6}
+    for i in {0..50}
     do
-      blazectl evaluate-measure "docs/performance/cql/observation-$CODE-$VALUE.yml" --server "$BASE" 2> /dev/null |\
-        jq -rf docs/performance/cql/duration.jq >> "$CODE-$VALUE.times"
+      blazectl evaluate-measure "cql/observation-$CODE-$VALUE.yml" --server "$BASE" 2> /dev/null |\
+        jq -rf cql/duration.jq >> "$START_EPOCH-$CODE-$VALUE.times"
     done
 
     # Skip first line because it will not benefit from caching
-    tail -n +2 "$CODE-$VALUE.times" | awk '{t+=$1;n++} END {printf("Avg time: %.2f\n", t/n)}'
+    tail -n +2 "$START_EPOCH-$CODE-$VALUE.times" |\
+      awk '{sum += $1; sumsq += $1^2} END {printf("Avg    : %.3f\nStdDev : %.3f\n", sum/NR, sqrt(sumsq/NR - (sum/NR)^2))}'
   done
 done

--- a/docs/performance/cql/observation-17861-6.yml
+++ b/docs/performance/cql/observation-17861-6.yml
@@ -1,4 +1,4 @@
-library: docs/performance/cql/observation-17861-6.cql
+library: cql/observation-17861-6.cql
 group:
 - type: Patient
   population:

--- a/docs/performance/cql/observation-29463-7.yml
+++ b/docs/performance/cql/observation-29463-7.yml
@@ -1,4 +1,4 @@
-library: docs/performance/cql/observation-29463-7.cql
+library: cql/observation-29463-7.cql
 group:
 - type: Patient
   population:

--- a/docs/performance/cql/observation-39156-5.yml
+++ b/docs/performance/cql/observation-39156-5.yml
@@ -1,4 +1,4 @@
-library: docs/performance/cql/observation-39156-5.cql
+library: cql/observation-39156-5.cql
 group:
 - type: Patient
   population:

--- a/docs/performance/cql/observation-body-weight-10.yml
+++ b/docs/performance/cql/observation-body-weight-10.yml
@@ -1,4 +1,4 @@
-library: docs/performance/cql/observation-body-weight-10.cql
+library: cql/observation-body-weight-10.cql
 group:
 - type: Patient
   population:

--- a/docs/performance/cql/observation-body-weight-100.yml
+++ b/docs/performance/cql/observation-body-weight-100.yml
@@ -1,4 +1,4 @@
-library: docs/performance/cql/observation-body-weight-100.cql
+library: cql/observation-body-weight-100.cql
 group:
 - type: Patient
   population:

--- a/docs/performance/cql/observation-body-weight-50.yml
+++ b/docs/performance/cql/observation-body-weight-50.yml
@@ -1,4 +1,4 @@
-library: docs/performance/cql/observation-body-weight-50.cql
+library: cql/observation-body-weight-50.cql
 group:
 - type: Patient
   population:

--- a/docs/performance/cql/observation-category-laboratory.cql
+++ b/docs/performance/cql/observation-category-laboratory.cql
@@ -1,0 +1,11 @@
+library "observation-category-laboratory"
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+codesystem "observation-category": 'http://terminology.hl7.org/CodeSystem/observation-category'
+code "laboratory": 'laboratory' from "observation-category"
+
+context Patient
+
+define InInitialPopulation:
+  [Observation: category in "laboratory"]

--- a/docs/performance/cql/observation-category-laboratory.yml
+++ b/docs/performance/cql/observation-category-laboratory.yml
@@ -1,0 +1,5 @@
+library: cql/observation-category-laboratory.cql
+group:
+- type: Observation
+  population:
+  - expression: InInitialPopulation

--- a/docs/performance/cql/observation-code-search.sh
+++ b/docs/performance/cql/observation-code-search.sh
@@ -3,12 +3,12 @@
 BASE="http://localhost:8080/fhir"
 START_EPOCH="$(date +"%s")"
 
-for CODE in "17861-6" "39156-5" "29463-7"
+for CODE in "laboratory"
 do
-  echo "Counting Patients with Observations with code $CODE..."
+  echo "Counting Observations with code $CODE..."
   for i in {0..50}
   do
-    blazectl evaluate-measure "cql/observation-$CODE.yml" --server "$BASE" 2> /dev/null |\
+    blazectl evaluate-measure "cql/observation-category-$CODE.yml" --server "$BASE" 2> /dev/null |\
       jq -rf cql/duration.jq >> "$START_EPOCH-$CODE.times"
   done
 

--- a/modules/operation-measure-evaluate-measure/deps.edn
+++ b/modules/operation-measure-evaluate-measure/deps.edn
@@ -43,4 +43,5 @@
    {cloverage/cloverage
     {:mvn/version "1.2.4"}}
 
-   :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"]}}}
+   :main-opts ["-m" "cloverage.coverage" "--codecov" "-p" "src" "-s" "test"
+               "-e" ".+spec$"]}}}

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -189,8 +189,12 @@
 
 (defn- evaluate-group
   {:arglists '([context group])}
-  [context {:keys [code population stratifier] :as group}]
-  (when-ok [context (assoc context :population-basis (population-basis group))
+  [{:keys [report-type] :as context}
+   {:keys [code population stratifier] :as group}]
+  (when-ok [context (assoc context
+                      :population-basis (population-basis group)
+                      :return-handles? (or (= "subject-list" report-type)
+                                           (some? (seq stratifier))))
             {:keys [luids] :as evaluated-populations}
             (evaluate-populations context population)
             evaluated-stratifiers

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/util.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/util.clj
@@ -53,8 +53,8 @@
        handles)}]])
 
 
-(defn population [{:keys [luids] :as context} fhir-type code handles]
-  (case (:report-type context)
+(defn population [{:keys [report-type luids]} fhir-type code handles]
+  (case report-type
     ("population" "subject")
     {:result
      (cond->
@@ -76,13 +76,22 @@
        :tx-ops (population-tx-ops list-id handles)})))
 
 
+(defn population-count [{:keys [luids]} fhir-type code count]
+  {:result
+   (cond->
+     {:fhir/type fhir-type
+      :count count}
+     code
+     (assoc :code code))
+   :luids luids})
+
+
 (defn- merge-result*
   "Merges `result` into the return value of the reduction `ret`."
   {:arglists '([ret result])}
   [ret {:keys [result handles luids tx-ops]}]
-  (cond-> (update ret :result conj result)
-    (seq handles)
-    (update :handles conj handles)
+  (cond-> (-> (update ret :result conj result)
+              (update :handles conj handles))
     luids
     (assoc :luids luids)
     (seq tx-ops)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql/spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql/spec.clj
@@ -23,9 +23,17 @@
                    ::compiler/expression-defs]))
 
 
+(s/def ::cql/return-handles?
+  boolean?)
+
+
+(s/def ::cql/evaluate-expression-context
+  (s/merge ::cql/context (s/keys :opt-un [::cql/return-handles?])))
+
+
 (s/def ::cql/parameters
   (s/map-of string? any?))
 
 
-(s/def ::cql/individual-context
+(s/def ::cql/evaluate-individual-expression-context
   (s/merge ::cql/context (s/keys :opt-un [::cql/parameters])))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_spec.clj
@@ -13,14 +13,16 @@
 
 
 (s/fdef cql/evaluate-expression
-  :args (s/cat :context ::cql/context :name string? :subject-type :fhir.resource/type
-               :population-basis (s/alt :subject-based #{:boolean} :other :fhir.resource/type))
+  :args (s/cat :context ::cql/evaluate-expression-context :name string?
+               :subject-type :fhir.resource/type :population-basis
+               (s/alt :subject-based #{:boolean} :other :fhir.resource/type))
   :ret (s/or :handles ::measure/handles
+             :count int?
              :anomaly ::anom/anomaly))
 
 
 (s/fdef cql/evaluate-individual-expression
-  :args (s/cat :context ::cql/individual-context
+  :args (s/cat :context ::cql/evaluate-individual-expression-context
                :subject-handle :blaze.db/resource-handle
                :name string?)
   :ret (s/or :value any?

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/util_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/util_spec.clj
@@ -9,3 +9,7 @@
 (s/fdef u/population
   :args (s/cat :context map? :fhir-type :fhir/type :code any?
                :handles ::measure/handles))
+
+
+(s/fdef u/population-count
+  :args (s/cat :context map? :fhir-type :fhir/type :code any? :count int?))


### PR DESCRIPTION
Evaluating a Measure with reportType of population and no stratifier doesn't need collect the handles. This change determines that situation and just calculates the population count instead of collecting all handles.

This changes enables Blaze to determine the count of large populations were previously lots of memory was used for no reason.