### PR TITLE
Add Estimated Size to Cache Metrics

### DIFF
--- a/dev/blaze/dev.clj
+++ b/dev/blaze/dev.clj
@@ -3,7 +3,7 @@
     [blaze.byte-string :as bs]
     [blaze.db.api :as d]
     [blaze.db.api-spec]
-    [blaze.db.cache-collector :as cc]
+    [blaze.db.cache-collector.protocols :as ccp]
     [blaze.db.resource-cache :as resource-cache]
     [blaze.db.resource-store :as rs]
     [blaze.db.tx-log :as tx-log]
@@ -58,19 +58,19 @@
 
 ;; Resource Handle Cache
 (comment
-  (str (cc/-stats (:blaze.db/resource-handle-cache system)))
+  (str (ccp/-stats (:blaze.db/resource-handle-cache system)))
   (.invalidateAll ^Cache (:blaze.db/resource-handle-cache system))
   )
 
 ;; Transaction Cache
 (comment
-  (str (cc/-stats (:blaze.db/tx-cache system)))
+  (str (ccp/-stats (:blaze.db/tx-cache system)))
   (resource-cache/invalidate-all! (:blaze.db/tx-cache system))
   )
 
 ;; Resource Cache
 (comment
-  (str (cc/-stats (:blaze.db/resource-cache system)))
+  (str (ccp/-stats (:blaze.db/resource-cache system)))
   (resource-cache/invalidate-all! (:blaze.db/resource-cache system))
   )
 

--- a/modules/db/src/blaze/db/cache_collector.clj
+++ b/modules/db/src/blaze/db/cache_collector.clj
@@ -16,11 +16,13 @@
 (extend-protocol p/StatsCache
   Cache
   (-stats [cache]
-    (.stats cache)))
+    (.stats cache))
+  (-estimated-size [cache]
+    (.estimatedSize cache)))
 
 
 (defn- sample-xf [f]
-  (map (fn [[name stats]] {:label-values [name] :value (f stats)})))
+  (map (fn [[name stats estimated-size]] {:label-values [name] :value (f stats estimated-size)})))
 
 
 (defn- counter-metric [name help f stats]
@@ -28,8 +30,13 @@
     (metrics/counter-metric name help ["name"] samples)))
 
 
+(defn- gauge-metric [name help f stats]
+  (let [samples (into [] (sample-xf f) stats)]
+    (metrics/gauge-metric name help ["name"] samples)))
+
+
 (def ^:private mapper
-  (map (fn [[name cache]] [name (p/-stats cache)])))
+  (map (fn [[name cache]] [name (p/-stats cache) (p/-estimated-size cache)])))
 
 
 (defmethod ig/pre-init-spec :blaze.db/cache-collector [_]
@@ -43,32 +50,37 @@
       [(counter-metric
          "blaze_db_cache_hits_total"
          "Returns the number of times Cache lookup methods have returned a cached value."
-         #(.hitCount ^CacheStats %)
+         (fn [stats _] (.hitCount ^CacheStats stats))
          stats)
        (counter-metric
          "blaze_db_cache_misses_total"
          "Returns the number of times Cache lookup methods have returned an uncached (newly loaded) value, or null."
-         #(.missCount ^CacheStats %)
+         (fn [stats _] (.missCount ^CacheStats stats))
          stats)
        (counter-metric
          "blaze_db_cache_load_successes_total"
          "Returns the number of times Cache lookup methods have successfully loaded a new value."
-         #(.loadSuccessCount ^CacheStats %)
+         (fn [stats _] (.loadSuccessCount ^CacheStats stats))
          stats)
        (counter-metric
          "blaze_db_cache_load_failures_total"
          "Returns the number of times Cache lookup methods failed to load a new value, either because no value was found or an exception was thrown while loading."
-         #(.loadFailureCount ^CacheStats %)
+         (fn [stats _] (.loadFailureCount ^CacheStats stats))
          stats)
        (counter-metric
          "blaze_db_cache_load_seconds_total"
          "Returns the total number of seconds the cache has spent loading new values."
-         #(/ (double (.totalLoadTime ^CacheStats %)) 1e9)
+         (fn [stats _] (/ (double (.totalLoadTime ^CacheStats stats)) 1e9))
          stats)
        (counter-metric
          "blaze_db_cache_evictions_total"
          "Returns the number of times an entry has been evicted."
-         #(.evictionCount ^CacheStats %)
+         (fn [stats _] (.evictionCount ^CacheStats stats))
+         stats)
+       (gauge-metric
+         "blaze_db_cache_estimated_size"
+         "Returns the approximate number of entries in this cache."
+         (fn [_ estimated-size] estimated-size)
          stats)])))
 
 

--- a/modules/db/src/blaze/db/cache_collector/protocols.clj
+++ b/modules/db/src/blaze/db/cache_collector/protocols.clj
@@ -2,4 +2,5 @@
 
 
 (defprotocol StatsCache
-  (-stats [_]))
+  (-stats [_])
+  (-estimated-size [_]))

--- a/modules/db/src/blaze/db/resource_cache.clj
+++ b/modules/db/src/blaze/db/resource_cache.clj
@@ -33,7 +33,9 @@
 
   ccp/StatsCache
   (-stats [_]
-    (.stats (.synchronous cache))))
+    (.stats (.synchronous cache)))
+  (-estimated-size [_]
+    (.estimatedSize (.synchronous cache))))
 
 
 (defn invalidate-all! [resource-cache]

--- a/modules/db/test/blaze/db/cache_collector_test.clj
+++ b/modules/db/test/blaze/db/cache_collector_test.clj
@@ -70,8 +70,11 @@
         [4 :type] := :counter
         [4 :samples 0 :value] := 0.0
         [5 :name] := "blaze_db_cache_evictions"
+        [5 :type] := :counter
         [5 :samples 0 :value] := 0.0
-        [5 :type] := :counter))
+        [6 :name] := "blaze_db_cache_estimated_size"
+        [6 :type] := :gauge
+        [6 :samples 0 :value] := 0.0))
 
     (testing "one load"
       (.get cache 1 (reify Function (apply [_ key] key)))
@@ -83,7 +86,13 @@
         [1 :name] := "blaze_db_cache_misses"
         [1 :samples 0 :value] := 1.0
         [2 :name] := "blaze_db_cache_load_successes"
-        [2 :samples 0 :value] := 1.0))
+        [2 :samples 0 :value] := 1.0
+        [3 :name] := "blaze_db_cache_load_failures"
+        [3 :samples 0 :value] := 0.0
+        [5 :name] := "blaze_db_cache_evictions"
+        [5 :samples 0 :value] := 0.0
+        [6 :name] := "blaze_db_cache_estimated_size"
+        [6 :samples 0 :value] := 1.0))
 
     (testing "one loads and one hit"
       (.get cache 1 (reify Function (apply [_ key] key)))
@@ -95,4 +104,10 @@
         [1 :name] := "blaze_db_cache_misses"
         [1 :samples 0 :value] := 1.0
         [2 :name] := "blaze_db_cache_load_successes"
-        [2 :samples 0 :value] := 1.0))))
+        [2 :samples 0 :value] := 1.0
+        [3 :name] := "blaze_db_cache_load_failures"
+        [3 :samples 0 :value] := 0.0
+        [5 :name] := "blaze_db_cache_evictions"
+        [5 :samples 0 :value] := 0.0
+        [6 :name] := "blaze_db_cache_estimated_size"
+        [6 :samples 0 :value] := 1.0))))


### PR DESCRIPTION
The new metric is called `blaze_db_cache_estimated_size`.