### PR TITLE
Fix Null Resource in Transactions Result in a 500

### DIFF
--- a/.github/scripts/transaction-null-resource.sh
+++ b/.github/scripts/transaction-null-resource.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+#
+# This script posts an invalid transaction bundle with a null resource.
+#
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+
+bundle() {
+cat <<END
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": null
+    }
+  ]
+}
+END
+}
+RESULT=$(curl -sH "Content-Type: application/fhir+json" -d "$(bundle)" "$BASE")
+
+test "resource type" "$(echo "$RESULT" | jq -r .resourceType)" "OperationOutcome"
+test "severity" "$(echo "$RESULT" | jq -r '.issue[0].severity')" "error"
+test "code" "$(echo "$RESULT" | jq -r '.issue[0].code')" "invariant"
+test "diagnostics" "$(echo "$RESULT" | jq -r '.issue[0].diagnostics')" 'Error on value `null`. Expected type is `Resource`.'
+test "expression" "$(echo "$RESULT" | jq -r '.issue[0].expression[0]')" "entry[0].resource"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -507,6 +507,9 @@ jobs:
     - name: Transaction Read/Write
       run: .github/scripts/transaction-rw.sh
 
+    - name: Transaction with Invalid (Null) Resource
+      run: .github/scripts/transaction-null-resource.sh
+
     - name: OPTIONS
       run: curl -f -XOPTIONS http://localhost:8080/fhir/metadata
 
@@ -1210,6 +1213,9 @@ jobs:
 
     - name: Transaction Read/Write
       run: .github/scripts/transaction-rw.sh
+
+    - name: Transaction with Invalid (Null) Resource
+      run: .github/scripts/transaction-null-resource.sh
 
     - name: OPTIONS
       run: curl -f -XOPTIONS http://localhost:8080/fhir/metadata

--- a/modules/fhir-structure/src/blaze/fhir/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec.clj
@@ -230,7 +230,7 @@
       [{:fhir.issues/severity "error"
         :fhir.issues/code "value"
         :fhir.issues/diagnostics
-        "Given resource does not contain a :resourceType key."}]})))
+        "Given resource does not contain a `resourceType` property."}]})))
 
 
 (defn explain-data-xml
@@ -256,8 +256,7 @@
      {:fhir/issues
       [{:fhir.issues/severity "error"
         :fhir.issues/code "value"
-        :fhir.issues/diagnostics
-        "Given resource does not contain a :tag key."}]})))
+        :fhir.issues/diagnostics (format "Invalid resource element `%s`." resource)}]})))
 
 
 (defn primitive?
@@ -303,7 +302,7 @@
   {:arglists '([x])}
   [{:keys [tag] :as x}]
   (or
-    (when type
+    (when tag
       (when-let [spec (s2/get-spec (keyword "fhir.xml" (name tag)))]
         (let [resource (s2/conform spec x)]
           (when-not (s2/invalid? resource)

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -830,7 +830,8 @@
 
 
 (defmethod json-resource :default [{json-type :resourceType :fhir/keys [type]}]
-  (keyword "fhir.json" (or json-type (name type))))
+  (when-let [type (or json-type (some-> type name))]
+    (keyword "fhir.json" type)))
 
 
 (s/def :fhir.json/Resource
@@ -857,7 +858,7 @@
 
 
 (defn conform-xml-resource [{:keys [content]}]
-  (some #(when (xml/element? %) %) content))
+  (or (some #(when (xml/element? %) %) content) ::s/invalid))
 
 
 (defn unform-xml-resource [resource]

--- a/modules/rest-api/test/blaze/rest_api/middleware/resource_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/middleware/resource_test.clj
@@ -87,6 +87,17 @@
       [:body :issue 0 :diagnostics] := "Error on value `{}`. Expected type is `code`, regex `[^\\s]+(\\s[^\\s]+)*`."
       [:body :issue 0 :expression] := ["gender"]))
 
+  (testing "body with bundle with null resource"
+    (given @(resource-handler
+              {:headers {"content-type" "application/fhir+json"}
+               :body (input-stream "{\"resourceType\": \"Bundle\", \"entry\": [{\"resource\": null}]}")})
+      :status := 400
+      [:body fhir-spec/fhir-type] := :fhir/OperationOutcome
+      [:body :issue 0 :severity] := #fhir/code"error"
+      [:body :issue 0 :code] := #fhir/code"invariant"
+      [:body :issue 0 :diagnostics] := "Error on value `null`. Expected type is `Resource`."
+      [:body :issue 0 :expression] := ["entry[0].resource"]))
+
   (testing "body with bundle with invalid resource"
     (given @(resource-handler
               {:headers {"content-type" "application/fhir+json"}
@@ -135,6 +146,16 @@
       [:body :issue 0 :severity] := #fhir/code"error"
       [:body :issue 0 :code] := #fhir/code"invariant"
       [:body :issue 0 :diagnostics] := "Error on value `a_b`. Expected type is `id`, regex `[A-Za-z0-9\\-\\.]{1,64}`."))
+
+  (testing "body with bundle with empty resource"
+    (given @(resource-handler
+              {:headers {"content-type" "application/fhir+xml"}
+               :body (input-stream "<Bundle xmlns=\"http://hl7.org/fhir\"><entry><resource></resource></entry></Bundle>")})
+      :status := 400
+      [:body fhir-spec/fhir-type] := :fhir/OperationOutcome
+      [:body :issue 0 :severity] := #fhir/code"error"
+      [:body :issue 0 :code] := #fhir/code"invariant"
+      [:body :issue 0 :diagnostics] := "Error on value `<:resource/>`. Expected type is `Resource`."))
 
   (testing "body with bundle with invalid resource"
     (given @(resource-handler


### PR DESCRIPTION
The root cause was that if resources in bundles have no resourceType, the conversion from JSON/XML to the internal representation will fail with a NPE. Not an appropriate error is generated.