### PR TITLE
Temporarily Support Bundle Entries with Typeless Resources

### DIFF
--- a/modules/interaction/src/blaze/interaction/search/util.clj
+++ b/modules/interaction/src/blaze/interaction/search/util.clj
@@ -15,7 +15,10 @@
   ([context resource]
    (entry context resource match))
   ([context {:fhir/keys [type] :keys [id] :as resource} mode]
-   {:fhir/type :fhir.Bundle/entry
-    :fullUrl (fhir-util/instance-url context (name type) id)
-    :resource resource
-    :search mode}))
+   ;; TODO: revert after discovery why the resource type can be nil
+   (cond->
+     {:fhir/type :fhir.Bundle/entry
+      :resource resource
+      :search mode}
+     type
+     (assoc :fullUrl (fhir-util/instance-url context (name type) id)))))


### PR DESCRIPTION
This should be reverted after it is clear why there are resources without a type.