### PR TITLE
Handle Case of Missing Resource Contents

### DIFF
--- a/.github/scripts/create-patient-0.sh
+++ b/.github/scripts/create-patient-0.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+curl -s -f -XPUT -H 'Content-Type: application/fhir+json' -d "{\"resourceType\": \"Patient\", \"id\": \"0\"}" -o /dev/null "$BASE/Patient/0"

--- a/.github/scripts/fetch-resource-0-with-missing-resource-content.sh
+++ b/.github/scripts/fetch-resource-0-with-missing-resource-content.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+#
+# This script fetches the Patient/0 expecting that the resource content is missing.
+#
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+
+RESULT=$(curl -sH "Accept: application/fhir+json" "$BASE/Patient/0")
+
+test "resource type" "$(echo "$RESULT" | jq -r .resourceType)" "OperationOutcome"
+test "severity" "$(echo "$RESULT" | jq -r '.issue[0].severity')" "error"
+test "code" "$(echo "$RESULT" | jq -r '.issue[0].code')" "incomplete"
+test "diagnostics" "$(echo "$RESULT" | jq -r '.issue[0].diagnostics')" 'The resource content of `Patient/0` with hash `C9ADE22457D5AD750735B6B166E3CE8D6878D09B64C2C2868DCB6DE4C9EFBD4F` was not found.'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -942,6 +942,50 @@ jobs:
     - name: Post Large Binary Resource
       run:  curl -f -H Content-Type:application/fhir+xml -H Prefer:return=minimal -d @large-binary.xml http://localhost:8080/fhir/Binary
 
+  missing-resource-content-test:
+    needs: build
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+
+    - name: Download Blaze Image
+      uses: actions/download-artifact@v3
+      with:
+        name: blaze-image
+        path: /tmp
+
+    - name: Load Blaze Image
+      run: docker load --input /tmp/blaze.tar
+
+    - name: Create a Data Dir
+      run: mkdir data
+
+    - name: Run Blaze
+      run: docker run --name blaze -d -e JAVA_TOOL_OPTIONS=-Xmx2g -p 8080:8080 -v "$(pwd)/data:/app/data" blaze:latest
+
+    - name: Wait for Blaze
+      run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
+
+    - name: Create Patient
+      run: .github/scripts/create-patient-0.sh
+
+    - name: Stop Blaze
+      run: docker stop blaze
+
+    - name: Remove Resource Database
+      run: rm -r data/resource
+
+    - name: Start Blaze Again
+      run: docker start blaze
+
+    - name: Wait for Blaze
+      run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
+
+    - name: Fetch Patient Expecting an Error
+      run: .github/scripts/fetch-resource-0-with-missing-resource-content.sh
+
   distributed-test:
     needs: build
     runs-on: ubuntu-22.04
@@ -1346,6 +1390,7 @@ jobs:
     - openid-auth-test
     - doc-copy-data-test
     - big-binary-test
+    - missing-resource-content-test
     - distributed-test
     - jepsen-distributed-test
     runs-on: ubuntu-22.04

--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -469,14 +469,14 @@
 
 (defn pull
   "Returns a CompletableFuture that will complete with the resource of
-  `resource-handle`."
+  `resource-handle` or an anomaly in case of errors."
   [node-or-db resource-handle]
   (p/-pull node-or-db resource-handle))
 
 
 (defn pull-content
   "Returns a CompletableFuture that will complete with the resource content of
-  `resource-handle`.
+  `resource-handle` or an anomaly in case of errors.
 
   Compared to `pull`, the resource content doesn't contain :versionId and
   :lastUpdated in :meta and also not :blaze.db/t, :blaze.db/num-changes,
@@ -487,7 +487,7 @@
 
 (defn pull-many
   "Returns a CompletableFuture that will complete with a vector of all resources
-  of all `resource-handles`.
+  of all `resource-handles` in the same order.
 
   Optional, `elements` can be given which is a list of top-level keys to return
   instead of all keys. Certain mandatory and modifier elements are returned

--- a/modules/db/test/blaze/db/node_test.clj
+++ b/modules/db/test/blaze/db/node_test.clj
@@ -37,7 +37,8 @@
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log])
   (:import
-    [java.time Instant]))
+    [java.time Instant]
+    [java.util.concurrent TimeUnit]))
 
 
 (set! *warn-on-reflection* true)
@@ -59,10 +60,19 @@
       (ac/completed-future nil))))
 
 
-(def resource-store-failing-on-get-system
-  (-> (assoc-in system [:blaze.db/node :resource-store]
-                (ig/ref ::resource-store-failing-on-get))
-      (assoc ::resource-store-failing-on-get {})))
+(def ^:private resource-store-failing-on-get-system
+  (merge-with
+    merge
+    system
+    {:blaze.db/node
+     {:resource-store (ig/ref ::resource-store-failing-on-get)}
+     :blaze.db.node/resource-indexer
+     {:resource-store (ig/ref ::resource-store-failing-on-get)}
+     ::resource-store-failing-on-get {}}))
+
+
+(def ^:private delayed-executor
+  (ac/delayed-executor 100 TimeUnit/MILLISECONDS))
 
 
 (defmethod ig/init-key ::resource-store-slow-on-put [_ {:keys [resource-store]}]
@@ -74,14 +84,19 @@
       (rs/multi-get resource-store hashes))
     (-put [_ entries]
       (-> (rs/put! resource-store entries)
-          (ac/then-apply-async (fn [_] (Thread/sleep 100)))))))
+          (ac/then-apply-async identity delayed-executor)))))
 
 
-(def resource-store-slow-on-put
-  (-> (assoc-in system [:blaze.db/node :resource-store]
-                (ig/ref ::resource-store-slow-on-put))
-      (assoc ::resource-store-slow-on-put
-             {:resource-store (ig/ref ::rs/kv)})))
+(def ^:private resource-store-slow-on-put-system
+  (merge-with
+    merge
+    system
+    {:blaze.db/node
+     {:resource-store (ig/ref ::resource-store-slow-on-put)}
+     :blaze.db.node/resource-indexer
+     {:resource-store (ig/ref ::resource-store-slow-on-put)}
+     ::resource-store-slow-on-put
+     {:resource-store (ig/ref ::rs/kv)}}))
 
 
 (defn- with-index-store-version [system version]
@@ -233,7 +248,7 @@
            (ac/failed-future (ex-info "" (ba/fault "" ::x ::y))))]
 
         (testing "fetching the result immediately"
-          (with-system [{:blaze.db/keys [node]} resource-store-slow-on-put]
+          (with-system [{:blaze.db/keys [node]} resource-store-slow-on-put-system]
             (given-failed-future
               (-> (node/submit-tx node [[:put {:fhir/type :fhir/Patient :id "0"}]])
                   (ac/then-compose (partial node/tx-result node)))

--- a/modules/db/test/blaze/db/resource_cache_test.clj
+++ b/modules/db/test/blaze/db/resource_cache_test.clj
@@ -77,29 +77,43 @@
 
 
 (deftest get-test
-  (with-system [{cache :blaze.db/resource-cache store ::rs/kv} system]
-    @(rs/put! store {patient-0-hash patient-0
-                     patient-1-hash patient-1})
+  (testing "success"
+    (with-system [{cache :blaze.db/resource-cache store ::rs/kv} system]
+      @(rs/put! store {patient-0-hash patient-0
+                       patient-1-hash patient-1})
 
-    (are [patient patient-hash] (= patient @(rs/get cache patient-hash))
-      patient-0 patient-0-hash
-      patient-1 patient-1-hash)))
+      (are [patient patient-hash] (= patient @(rs/get cache patient-hash))
+        patient-0 patient-0-hash
+        patient-1 patient-1-hash)))
+
+  (testing "not-found"
+    (with-system [{cache :blaze.db/resource-cache} system]
+
+      (is (nil? @(rs/get cache patient-0-hash))))))
 
 
 (deftest multi-get-test
-  (with-system [{cache :blaze.db/resource-cache store ::rs/kv} system]
-    @(rs/put! store {patient-0-hash patient-0
-                     patient-1-hash patient-1})
+  (testing "found both"
+    (with-system [{cache :blaze.db/resource-cache store ::rs/kv} system]
+      @(rs/put! store {patient-0-hash patient-0
+                       patient-1-hash patient-1})
 
-    (is (= {patient-0-hash patient-0
-            patient-1-hash patient-1}
-           @(rs/multi-get cache [patient-0-hash patient-1-hash])))))
+      (is (= {patient-0-hash patient-0
+              patient-1-hash patient-1}
+             @(rs/multi-get cache [patient-0-hash patient-1-hash])))))
+
+  (testing "found one"
+    (with-system [{cache :blaze.db/resource-cache store ::rs/kv} system]
+      @(rs/put! store {patient-0-hash patient-0})
+
+      (is (= {patient-0-hash patient-0}
+             @(rs/multi-get cache [patient-0-hash patient-1-hash]))))))
 
 
 (deftest put-test
   (with-system [{cache :blaze.db/resource-cache store ::rs/kv} system]
     (is (nil? @(rs/put! cache {patient-0-hash patient-0
-                                        patient-1-hash patient-1})))
+                               patient-1-hash patient-1})))
     (is (= {patient-0-hash patient-0
             patient-1-hash patient-1}
            @(rs/multi-get store [patient-0-hash patient-1-hash])))))

--- a/modules/interaction/src/blaze/interaction/history/type.clj
+++ b/modules/interaction/src/blaze/interaction/history/type.clj
@@ -3,7 +3,7 @@
 
   https://www.hl7.org/fhir/http.html#history"
   (:require
-    [blaze.async.comp :refer [do-sync]]
+    [blaze.async.comp :as ac]
     [blaze.db.api :as d]
     [blaze.db.spec]
     [blaze.fhir.spec.type :as type]
@@ -14,6 +14,7 @@
     [blaze.spec]
     [blaze.util :refer [conj-vec]]
     [clojure.spec.alpha :as s]
+    [cognitect.anomalies :as anom]
     [integrant.core :as ig]
     [reitit.core :as reitit]
     [ring.util.response :as ring]
@@ -35,21 +36,27 @@
         self-link (partial link context query-params "self")
         next-link (partial link context query-params "next")]
     ;; we need take here again because we take page-size + 1 above
-    (-> (do-sync [paged-versions (d/pull-many db (take page-size paged-version-handles))]
-          (ring/response
-            (cond->
-              {:fhir/type :fhir/Bundle
-               :id (iu/luid context)
-               :type #fhir/code"history"
-               :total (type/->UnsignedInt total)
-               :entry
-               (mapv (partial history-util/build-entry context) paged-versions)}
+    (-> (d/pull-many db (take page-size paged-version-handles))
+        (ac/exceptionally
+          #(assoc %
+             ::anom/category ::anom/fault
+             :fhir/issue "incomplete"))
+        (ac/then-apply
+          (fn [paged-versions]
+            (ring/response
+              (cond->
+                {:fhir/type :fhir/Bundle
+                 :id (iu/luid context)
+                 :type #fhir/code"history"
+                 :total (type/->UnsignedInt total)
+                 :entry
+                 (mapv (partial history-util/build-entry context) paged-versions)}
 
-              (seq paged-version-handles)
-              (update :link conj-vec (self-link (first paged-version-handles)))
+                (seq paged-version-handles)
+                (update :link conj-vec (self-link (first paged-version-handles)))
 
-              (< page-size (count paged-version-handles))
-              (update :link conj-vec (next-link (peek paged-version-handles)))))))))
+                (< page-size (count paged-version-handles))
+                (update :link conj-vec (next-link (peek paged-version-handles))))))))))
 
 
 (defn- handler [context]

--- a/modules/interaction/src/blaze/interaction/search_compartment.clj
+++ b/modules/interaction/src/blaze/interaction/search_compartment.clj
@@ -14,6 +14,7 @@
     [blaze.page-store.spec]
     [blaze.spec]
     [clojure.spec.alpha :as s]
+    [cognitect.anomalies :as anom]
     [integrant.core :as ig]
     [reitit.core :as reitit]
     [ring.util.response :as ring]
@@ -94,6 +95,10 @@
 (defn- search-normal [{:blaze/keys [db] :as context}]
   (if-ok [{:keys [handles clauses]} (handles-and-clauses context)]
     (-> (d/pull-many db handles)
+        (ac/exceptionally
+          #(assoc %
+             ::anom/category ::anom/fault
+             :fhir/issue "incomplete"))
         (ac/then-apply (partial entries context))
         (ac/then-compose (partial bundle context handles clauses)))
     ac/completed-future))

--- a/modules/interaction/test/blaze/interaction/history/type_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/type_test.clj
@@ -5,9 +5,12 @@
   https://www.hl7.org/fhir/operationoutcome.html
   https://www.hl7.org/fhir/http.html#ops"
   (:require
+    [blaze.async.comp :as ac]
     [blaze.db.api-stub :refer [mem-node-system with-system-data]]
+    [blaze.db.resource-store :as rs]
     [blaze.interaction.history.type]
     [blaze.interaction.history.util-spec]
+    [blaze.interaction.test-util :refer [wrap-error]]
     [blaze.middleware.fhir.db :refer [wrap-db]]
     [blaze.middleware.fhir.db-spec]
     [blaze.test-util :as tu :refer [given-thrown]]
@@ -99,7 +102,8 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# :blaze.interaction.history/type} system]
        ~txs
-       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#))]
+       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#)
+                                  wrap-error)]
          ~@body))))
 
 
@@ -158,4 +162,20 @@
           [:resource :meta :versionId] := #fhir/id"1"
           [:response :status] := "201"
           [:response :etag] := "W/\"1\""
-          [:response :lastModified] := Instant/EPOCH)))))
+          [:response :lastModified] := Instant/EPOCH))))
+
+  (testing "missing resource contents"
+    (with-redefs [rs/multi-get (fn [_ _] (ac/completed-future {}))]
+      (with-handler [handler]
+        [[[:put {:fhir/type :fhir/Patient :id "0"}]]]
+
+        (let [{:keys [status body]}
+              @(handler {})]
+
+          (is (= 500 status))
+
+          (given body
+            :fhir/type := :fhir/OperationOutcome
+            [:issue 0 :severity] := #fhir/code"error"
+            [:issue 0 :code] := #fhir/code"incomplete"
+            [:issue 0 :diagnostics] := "The resource content of `Patient/0` with hash `C9ADE22457D5AD750735B6B166E3CE8D6878D09B64C2C2868DCB6DE4C9EFBD4F` was not found."))))))

--- a/modules/operation-graphql/src/blaze/fhir/operation/graphql.clj
+++ b/modules/operation-graphql/src/blaze/fhir/operation/graphql.clj
@@ -55,11 +55,17 @@
     (d/type-list db type)))
 
 
+(defn- to-error [e]
+  {:message (ex-message e)})
+
+
 (defn- resolve-type-list [type {:blaze/keys [db]} args _]
   (log/trace (format "execute %sList query" type))
   (let [result (resolve/resolve-promise)]
     (-> (d/pull-many db (type-query db type args))
-        (ac/when-complete (partial resolve/deliver! result)))
+        (ac/when-complete
+          (fn [r e]
+            (resolve/deliver! result r (some-> e ac/-completion-cause to-error)))))
     result))
 
 

--- a/modules/rest-util/src/blaze/fhir/response/create.clj
+++ b/modules/rest-util/src/blaze/fhir/response/create.clj
@@ -7,7 +7,7 @@
     [ring.util.response :as ring]
     [taoensso.timbre :as log])
   (:import
-    [java.time ZonedDateTime ZoneId]
+    [java.time ZoneId ZonedDateTime]
     [java.time.format DateTimeFormatter]))
 
 


### PR DESCRIPTION
Before non-found resource contents would not handled correctly. The nil content would just enhanced with some meta information and the so incomplete resource without type would case all sorts of other problems.

Now pull d/pull, d/pull-content and d/pull-many will return not-found anomalies what will be translated into faults in the REST layer.