### PR TITLE
Fix Date Equal Search and Add Missing Prefixes

### DIFF
--- a/.github/scripts/check-date-search.sh
+++ b/.github/scripts/check-date-search.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+TYPE=$1
+
+download() {
+  blazectl --no-progress --server "$BASE" download "$TYPE" -q "date=$1" 2>/dev/null | wc -l | xargs
+}
+
+count() {
+  curl -sH 'Prefer: handling=strict' -H 'Accept: application/fhir+json' "$BASE/$TYPE?date=$1&_summary=count" | jq .total
+}
+
+size() {
+  DOWNLOAD_SIZE=$(download $1)
+  COUNT_SIZE=$(count $1)
+  if [ "$DOWNLOAD_SIZE" = "$COUNT_SIZE" ]; then
+    echo "$DOWNLOAD_SIZE"
+  else
+    echo "Fail: the download size is $DOWNLOAD_SIZE, expected $COUNT_SIZE"
+    exit 1
+  fi
+}
+
+for YEAR in {1990..2020}; do
+  YEAR_SIZE=$(size "$YEAR")
+  MONTH_SIZE=0
+
+  for MONTH in {1..12}; do
+    SIZE=$(size "$YEAR-$(printf "%02d" "$MONTH")")
+    MONTH_SIZE=$((MONTH_SIZE + SIZE))
+  done
+
+  test-le "$YEAR months sum" "$MONTH_SIZE" "$YEAR_SIZE"
+  test "[$YEAR-01-01, $YEAR-12-31] size" "$(size "sa$((YEAR - 1))-12-31&date=eb$((YEAR + 1))-01-01")" "$YEAR_SIZE"
+
+done

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -8,3 +8,12 @@ test() {
     exit 1
   fi
 }
+
+test-le() {
+  if [ "$2" -le "$3" ]; then
+    echo "OK: the $1 of $2 is <= $3"
+  else
+    echo "Fail: the $1 is $2, expected <= $3"
+    exit 1
+  fi
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,6 +336,36 @@ jobs:
     - name: Download Observation Resources of female Patients
       run: .github/scripts/download-resources-query.sh Observation "_count=500&patient.gender=female" 22463
 
+    - name: Download Observation Resources of the year 1970
+      run: .github/scripts/download-resources-query.sh Observation "date=1970" 59
+
+    - name: Download Observation Resources of the year 1980
+      run: .github/scripts/download-resources-query.sh Observation "date=1980" 0
+
+    - name: Download Observation Resources of the year 1990
+      run: .github/scripts/download-resources-query.sh Observation "date=1990" 19
+
+    - name: Download Observation Resources of the year 2000
+      run: .github/scripts/download-resources-query.sh Observation "date=2000" 101
+
+    - name: Download Observation Resources of the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=2010" 995
+
+    - name: Download Observation Resources of the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=2020" 17419
+
+    - name: Download Observation Resources of not the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=ne2020" 25510
+
+    - name: Check Observation Date Search
+      run: .github/scripts/check-date-search.sh "Observation"
+
+    - name: Check Encounter Date Search
+      run: .github/scripts/check-date-search.sh "Encounter"
+
+    - name: Check DiagnosticReport Date Search
+      run: .github/scripts/check-date-search.sh "DiagnosticReport"
+
     - name: Download Observation Resources of female Patients Sorted Ascending
       run: .github/scripts/download-resources-query-sort.sh Observation "patient.gender=female" "_lastUpdated" 22463
 
@@ -1086,6 +1116,36 @@ jobs:
 
     - name: Download Observation Resources of female Patients
       run: .github/scripts/download-resources-query.sh Observation "_count=500&patient.gender=female" 22463
+
+    - name: Download Observation Resources of the year 1970
+      run: .github/scripts/download-resources-query.sh Observation "date=1970" 59
+
+    - name: Download Observation Resources of the year 1980
+      run: .github/scripts/download-resources-query.sh Observation "date=1980" 0
+
+    - name: Download Observation Resources of the year 1990
+      run: .github/scripts/download-resources-query.sh Observation "date=1990" 19
+
+    - name: Download Observation Resources of the year 2000
+      run: .github/scripts/download-resources-query.sh Observation "date=2000" 101
+
+    - name: Download Observation Resources of the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=2010" 995
+
+    - name: Download Observation Resources of the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=2020" 17419
+
+    - name: Download Observation Resources of not the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=ne2020" 25510
+
+    - name: Check Observation Date Search
+      run: .github/scripts/check-date-search.sh "Observation"
+
+    - name: Check Encounter Date Search
+      run: .github/scripts/check-date-search.sh "Encounter"
+
+    - name: Check DiagnosticReport Date Search
+      run: .github/scripts/check-date-search.sh "DiagnosticReport"
 
     - name: Download Observation Resources of female Patients Sorted Ascending
       run: .github/scripts/download-resources-query-sort.sh Observation "patient.gender=female" "_lastUpdated" 22463

--- a/modules/anomaly/src/blaze/anomaly.clj
+++ b/modules/anomaly/src/blaze/anomaly.clj
@@ -1,7 +1,8 @@
 (ns blaze.anomaly
   (:refer-clojure :exclude [map])
   (:require
-    [cognitect.anomalies :as anom])
+    [cognitect.anomalies :as anom]
+    [io.aviso.exception :as aviso])
   (:import
     [clojure.lang ExceptionInfo]
     [java.util Map]
@@ -65,6 +66,15 @@
   (anomaly* ::anom/busy msg kvs))
 
 
+(defn- format-exception
+  "Formats `e` without any ANSI formatting.
+
+  Used to output stack traces in OperationOutcome's."
+  [e]
+  (binding [aviso/*fonts* nil]
+    (aviso/format-exception e)))
+
+
 (defprotocol ToAnomaly
   (-anomaly [x]))
 
@@ -88,7 +98,7 @@
       (assoc :blaze.anomaly/cause (-anomaly (.getCause e)))))
   Throwable
   (-anomaly [e]
-    (fault (.getMessage e)))
+    (fault (.getMessage e) :stacktrace (format-exception e)))
   Map
   (-anomaly [m]
     (when (anomaly? m)

--- a/modules/db-stub/src/blaze/db/api_stub.clj
+++ b/modules/db-stub/src/blaze/db/api_stub.clj
@@ -14,8 +14,7 @@
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log-spec]
     [blaze.db.tx-log.local]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :refer [with-system]]
+    [blaze.test-util :refer [structure-definition-repo with-system]]
     [integrant.core :as ig]
     [java-time.api :as time]))
 
@@ -80,9 +79,7 @@
    :blaze.db.node.resource-indexer/executor {}
 
    :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-
-   :blaze.fhir/structure-definition-repo {}})
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (def mem-node-system

--- a/modules/db/src/blaze/db/impl/search_param/token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/token.clj
@@ -188,7 +188,7 @@
         (keep
           (fn [value]
             (when (identical? :fhir/Reference (fhir-spec/fhir-type value))
-              (when-let [reference (:reference value)]
+              (when-let [reference (type/value (:reference value))]
                 (some-> (u/split-literal-ref reference) (coll/nth 1))))))
         values)))
 

--- a/modules/db/test-perf/blaze/db/api_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/api_test_perf.clj
@@ -12,9 +12,8 @@
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log.local]
     [blaze.fhir.spec.type :as type]
-    [blaze.fhir.structure-definition-repo]
     [blaze.log]
-    [blaze.test-util :refer [with-system]]
+    [blaze.test-util :refer [structure-definition-repo with-system]]
     [clojure.test :refer [deftest]]
     [criterium.core :as criterium]
     [integrant.core :as ig]
@@ -83,9 +82,7 @@
    :blaze.db.node.resource-indexer/executor {}
 
    :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-
-   :blaze.fhir/structure-definition-repo {}})
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (defmacro with-system-data [[binding-form system] txs & body]

--- a/modules/db/test-perf/blaze/db/search_param_registry_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/search_param_registry_test_perf.clj
@@ -1,11 +1,9 @@
 (ns blaze.db.search-param-registry-test-perf
   (:require
     [blaze.db.search-param-registry :as sr]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :refer [with-system]]
+    [blaze.test-util :refer [structure-definition-repo with-system]]
     [clojure.test :refer [deftest testing]]
     [criterium.core :as criterium]
-    [integrant.core :as ig]
     [taoensso.timbre :as log]))
 
 
@@ -13,9 +11,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest linked-compartments-test

--- a/modules/db/test/blaze/db/impl/codec/date_spec.clj
+++ b/modules/db/test/blaze/db/impl/codec/date_spec.clj
@@ -13,12 +13,12 @@
 
 
 (s/fdef codec-date/encode-lower-bound
-  :args (s/cat :date-time :system/date-or-date-time)
+  :args (s/cat :date-time (s/nilable :system/date-or-date-time))
   :ret byte-string?)
 
 
 (s/fdef codec-date/encode-upper-bound
-  :args (s/cat :date-time :system/date-or-date-time)
+  :args (s/cat :date-time (s/nilable :system/date-or-date-time))
   :ret byte-string?)
 
 

--- a/modules/db/test/blaze/db/impl/codec/date_test.clj
+++ b/modules/db/test/blaze/db/impl/codec/date_test.clj
@@ -7,7 +7,7 @@
     [blaze.test-util :as tu :refer [satisfies-prop]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [are deftest testing]]
+    [clojure.test :as test :refer [are deftest is testing]]
     [clojure.test.check.properties :as prop])
   (:import
     [java.time OffsetDateTime ZoneOffset]))
@@ -46,7 +46,11 @@
       (OffsetDateTime/of 1970 1 1 0 0 0 0 (ZoneOffset/ofHours 2)) "6FE3E0"
       (OffsetDateTime/of 1970 1 1 0 0 0 0 (ZoneOffset/ofHours 1)) "6FF1F0"
       (OffsetDateTime/of 1970 1 1 0 0 0 0 (ZoneOffset/ofHours -1)) "900E10"
-      (OffsetDateTime/of 1970 1 1 0 0 0 0 (ZoneOffset/ofHours -2)) "901C20")))
+      (OffsetDateTime/of 1970 1 1 0 0 0 0 (ZoneOffset/ofHours -2)) "901C20"))
+
+  (testing "nil"
+    (is (= (codec-date/encode-lower-bound #system/date"0001")
+           (codec-date/encode-lower-bound nil)))))
 
 
 (deftest encode-upper-bound-test
@@ -75,7 +79,11 @@
       (OffsetDateTime/of 1969 12 31 23 59 59 0 (ZoneOffset/ofHours 2)) "6FE3DF"
       (OffsetDateTime/of 1969 12 31 23 59 59 0 (ZoneOffset/ofHours 1)) "6FF1EF"
       (OffsetDateTime/of 1969 12 31 23 59 59 0 (ZoneOffset/ofHours -1)) "900E0F"
-      (OffsetDateTime/of 1969 12 31 23 59 59 0 (ZoneOffset/ofHours -2)) "901C1F")))
+      (OffsetDateTime/of 1969 12 31 23 59 59 0 (ZoneOffset/ofHours -2)) "901C1F"))
+
+  (testing "nil"
+    (is (= (codec-date/encode-upper-bound #system/date"9999")
+           (codec-date/encode-upper-bound nil)))))
 
 
 (deftest encode-range-test

--- a/modules/db/test/blaze/db/impl/search_param/composite_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite_test.clj
@@ -15,12 +15,10 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest testing]]
     [cognitect.anomalies :as anom]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log])
   (:import
@@ -43,9 +41,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest code-value-quantity-param-test

--- a/modules/db/test/blaze/db/impl/search_param/date_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/date_test.clj
@@ -14,12 +14,10 @@
     [blaze.fhir-path :as fhir-path]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log])
   (:import
@@ -39,9 +37,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest birth-date-param-test
@@ -59,12 +56,6 @@
                (birth-date-param search-param-registry) nil ["a"])
         ::anom/category := ::anom/incorrect
         ::anom/message := "Invalid date-time value `a` in search parameter `birthdate`."))
-
-    (testing "unsupported prefix"
-      (given (search-param/compile-values
-               (birth-date-param search-param-registry) nil ["ne2020"])
-        ::anom/category := ::anom/unsupported
-        ::anom/message := "Unsupported prefix `ne` in search parameter `birthdate`."))
 
     (testing "less than"
       (given (search-param/compile-values

--- a/modules/db/test/blaze/db/impl/search_param/list_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/list_test.clj
@@ -3,11 +3,9 @@
     [blaze.byte-string-spec]
     [blaze.db.impl.search-param-spec]
     [blaze.db.search-param-registry :as sr]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest]]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log]))
 
@@ -24,9 +22,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest list-param-test

--- a/modules/db/test/blaze/db/impl/search_param/number_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/number_test.clj
@@ -14,12 +14,10 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest is testing]]
     [cognitect.anomalies :as anom]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log]))
 
@@ -42,9 +40,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest compile-value-test

--- a/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
@@ -14,12 +14,10 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest is testing]]
     [cognitect.anomalies :as anom]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log]))
 
@@ -32,9 +30,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest resource-keys-test

--- a/modules/db/test/blaze/db/impl/search_param/string_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/string_test.clj
@@ -14,12 +14,10 @@
     [blaze.fhir-path :as fhir-path]
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log]))
 
@@ -36,9 +34,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest phonetic-param-test

--- a/modules/db/test/blaze/db/impl/search_param/token_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/token_test.clj
@@ -14,12 +14,10 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log]))
 
@@ -36,9 +34,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest code-param-test

--- a/modules/db/test/blaze/db/impl/search_param_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param_test.clj
@@ -12,11 +12,9 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest is testing]]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]))
 
 
@@ -36,9 +34,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest compile-value-test

--- a/modules/db/test/blaze/db/node/resource_indexer_test.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_test.clj
@@ -24,9 +24,8 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
     [blaze.metrics.spec]
-    [blaze.test-util :as tu :refer [given-failed-future given-thrown with-system]]
+    [blaze.test-util :as tu :refer [given-failed-future given-thrown structure-definition-repo with-system]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]
@@ -146,9 +145,7 @@
    ::rs-kv/executor {}
 
    :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-
-   :blaze.fhir/structure-definition-repo {}
+   {:structure-definition-repo structure-definition-repo}
 
    :blaze.db.node/resource-indexer
    {:kv-store (ig/ref :blaze.db/index-kv-store)

--- a/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
+++ b/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
@@ -20,7 +20,6 @@
     [blaze.fhir.hash :as hash]
     [blaze.fhir.hash-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
     [blaze.log]
     [blaze.test-util :as tu :refer [with-system]]
     [clojure.spec.test.alpha :as st]

--- a/modules/db/test/blaze/db/node_test.clj
+++ b/modules/db/test/blaze/db/node_test.clj
@@ -25,7 +25,6 @@
     [blaze.db.tx-log.local-spec]
     [blaze.db.tx-log.spec :refer [tx-log?]]
     [blaze.executors :as ex]
-    [blaze.fhir.structure-definition-repo]
     [blaze.log]
     [blaze.metrics.spec]
     [blaze.test-util :as tu :refer [given-failed-future given-thrown with-system]]

--- a/modules/db/test/blaze/db/search_param_registry_test.clj
+++ b/modules/db/test/blaze/db/search_param_registry_test.clj
@@ -4,9 +4,8 @@
     [blaze.db.search-param-registry-spec]
     [blaze.fhir-path :as fhir-path]
     [blaze.fhir.spec.type]
-    [blaze.fhir.structure-definition-repo]
     [blaze.fhir.structure-definition-repo.spec :refer [structure-definition-repo?]]
-    [blaze.test-util :as tu :refer [given-thrown with-system]]
+    [blaze.test-util :as tu :refer [given-thrown structure-definition-repo with-system]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest is testing]]
@@ -45,9 +44,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest get-test

--- a/modules/db/test/blaze/db/test_util.clj
+++ b/modules/db/test/blaze/db/test_util.clj
@@ -10,10 +10,15 @@
     [blaze.db.tx-cache]
     [blaze.db.tx-log :as tx-log]
     [blaze.db.tx-log.local]
-    [blaze.fhir.structure-definition-repo]
-    [blaze.test-util :refer [with-system]]
+    [blaze.test-util :refer [structure-definition-repo with-system]]
     [integrant.core :as ig]
     [java-time.api :as time]))
+
+
+(defonce search-param-registry
+         (-> (ig/init {:blaze.db/search-param-registry
+                       {:structure-definition-repo structure-definition-repo}})
+             :blaze.db/search-param-registry))
 
 
 (def system
@@ -25,7 +30,7 @@
     :resource-store (ig/ref ::rs/kv)
     :kv-store (ig/ref :blaze.db/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node/resource-indexer)
-    :search-param-registry (ig/ref :blaze.db/search-param-registry)
+    :search-param-registry search-param-registry
     :poll-timeout (time/millis 10)}
 
    ::tx-log/local
@@ -73,15 +78,10 @@
    :blaze.db.node/resource-indexer
    {:kv-store (ig/ref :blaze.db/index-kv-store)
     :resource-store (ig/ref ::rs/kv)
-    :search-param-registry (ig/ref :blaze.db/search-param-registry)
+    :search-param-registry search-param-registry
     :executor (ig/ref :blaze.db.node.resource-indexer/executor)}
 
-   :blaze.db.node.resource-indexer/executor {}
-
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-
-   :blaze.fhir/structure-definition-repo {}})
+   :blaze.db.node.resource-indexer/executor {}})
 
 
 (defmacro with-system-data [[binding-form system] txs & body]

--- a/modules/fhir-path/src/blaze/fhir_path.clj
+++ b/modules/fhir-path/src/blaze/fhir_path.clj
@@ -316,11 +316,11 @@
 
 
 (defmethod resolve :fhir/string [{:keys [resolver]} uri]
-  (resolve* resolver uri))
+  (resolve* resolver (type/value uri)))
 
 
 (defmethod resolve :fhir/Reference [{:keys [resolver]} {:keys [reference]}]
-  (resolve* resolver reference))
+  (resolve* resolver (type/value reference)))
 
 
 (defmethod resolve :default [_ item]

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/system_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/system_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly-spec]
     [blaze.fhir.spec.type.system :as system]
+    [blaze.fhir.spec.type.system.spec]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]))
 
@@ -52,3 +53,13 @@
   :args (s/cat :s string?)
   :ret (s/or :date-time system/date-time?
              :anomaly ::anom/anomaly))
+
+
+(s/fdef system/date-time-lower-bound
+  :args (s/cat :date-time (s/nilable :system/date-or-date-time))
+  :ret int?)
+
+
+(s/fdef system/date-time-upper-bound
+  :args (s/cat :date-time (s/nilable :system/date-or-date-time))
+  :ret int?)

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
@@ -7,8 +7,8 @@
     [blaze.fhir.spec.impl.xml :as xml]
     [blaze.fhir.spec.impl.xml-spec]
     [blaze.fhir.spec.type :as type]
-    [blaze.fhir.structure-definition-repo :as u]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.fhir.structure-definition-repo :as sdr]
+    [blaze.test-util :as tu :refer [structure-definition-repo]]
     [clojure.alpha.spec :as s2]
     [clojure.data.xml.name :as xml-name]
     [clojure.data.xml.node :as xml-node]
@@ -38,453 +38,447 @@
   (walk/postwalk #(if (instance? Pattern %) (str %) %) form))
 
 
-(defn- primitive-type [structure-definition-repo name]
+(defn- primitive-type [name]
   (some #(when (= name (:name %)) %)
-        (u/primitive-types structure-definition-repo)))
-
-
-(def system
-  {:blaze.fhir/structure-definition-repo {}})
+        (sdr/primitive-types structure-definition-repo)))
 
 
 (deftest primitive-type->spec-defs-test
-  (with-system [{:blaze.fhir/keys [structure-definition-repo]} system]
-    (testing "boolean"
-      (is (= (-> (primitive-type structure-definition-repo "boolean")
-                 impl/primitive-type->spec-defs
-                 regexes->str)
-             [{:key :fhir/boolean
-               :spec-form `type/boolean?}
-              {:key :fhir.json/boolean
-               :spec-form `(specs/json-pred-primitive boolean? type/boolean)}
-              {:key :fhir.xml/boolean
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "true|false" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Boolean type/to-xml))}
-              {:key :fhir.cbor/boolean
-               :spec-form `(specs/cbor-primitive type/boolean)}])))
+  (testing "boolean"
+    (is (= (-> (primitive-type "boolean")
+               impl/primitive-type->spec-defs
+               regexes->str)
+           [{:key :fhir/boolean
+             :spec-form `type/boolean?}
+            {:key :fhir.json/boolean
+             :spec-form `(specs/json-pred-primitive boolean? type/boolean)}
+            {:key :fhir.xml/boolean
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "true|false" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Boolean type/to-xml))}
+            {:key :fhir.cbor/boolean
+             :spec-form `(specs/cbor-primitive type/boolean)}])))
 
-    (testing "integer"
-      (is (= (-> (primitive-type structure-definition-repo "integer")
-                 impl/primitive-type->spec-defs
-                 regexes->str)
-             [{:key :fhir/integer
-               :spec-form `type/integer?}
-              {:key :fhir.json/integer
-               :spec-form `(specs/json-pred-primitive int? type/integer)}
-              {:key :fhir.xml/integer
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "-?([0]|([1-9][0-9]*))" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Integer type/to-xml))}
-              {:key :fhir.cbor/integer
-               :spec-form `(specs/cbor-primitive type/integer)}])))
+  (testing "integer"
+    (is (= (-> (primitive-type "integer")
+               impl/primitive-type->spec-defs
+               regexes->str)
+           [{:key :fhir/integer
+             :spec-form `type/integer?}
+            {:key :fhir.json/integer
+             :spec-form `(specs/json-pred-primitive int? type/integer)}
+            {:key :fhir.xml/integer
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "-?([0]|([1-9][0-9]*))" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Integer type/to-xml))}
+            {:key :fhir.cbor/integer
+             :spec-form `(specs/cbor-primitive type/integer)}])))
 
-    (testing "string"
-      (is (= (-> (primitive-type structure-definition-repo "string")
-                 impl/primitive-type->spec-defs
-                 regexes->str)
-             [{:key :fhir/string
-               :spec-form `type/string?}
-              {:key :fhir.json/string
-               :spec-form `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/string)}
-              {:key :fhir.xml/string
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->String type/to-xml))}
-              {:key :fhir.cbor/string
-               :spec-form `(specs/cbor-primitive type/string)}])))
+  (testing "string"
+    (is (= (-> (primitive-type "string")
+               impl/primitive-type->spec-defs
+               regexes->str)
+           [{:key :fhir/string
+             :spec-form `type/string?}
+            {:key :fhir.json/string
+             :spec-form `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/string)}
+            {:key :fhir.xml/string
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->String type/to-xml))}
+            {:key :fhir.cbor/string
+             :spec-form `(specs/cbor-primitive type/string)}])))
 
-    (testing "decimal"
-      (is (= (-> (primitive-type structure-definition-repo "decimal")
-                 impl/primitive-type->spec-defs
-                 regexes->str)
-             [{:key :fhir/decimal
-               :spec-form `type/decimal?}
-              {:key :fhir.json/decimal
-               :spec-form `(specs/json-pred-primitive impl/decimal-or-int? type/decimal)}
-              {:key :fhir.xml/decimal
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Decimal type/to-xml))}
-              {:key :fhir.cbor/decimal
-               :spec-form `(specs/cbor-primitive type/decimal)}])))
+  (testing "decimal"
+    (is (= (-> (primitive-type "decimal")
+               impl/primitive-type->spec-defs
+               regexes->str)
+           [{:key :fhir/decimal
+             :spec-form `type/decimal?}
+            {:key :fhir.json/decimal
+             :spec-form `(specs/json-pred-primitive impl/decimal-or-int? type/decimal)}
+            {:key :fhir.xml/decimal
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Decimal type/to-xml))}
+            {:key :fhir.cbor/decimal
+             :spec-form `(specs/cbor-primitive type/decimal)}])))
 
-    (testing "uri"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "uri"))
-                 regexes->str)
-             [{:key :fhir/uri
-               :spec-form `type/uri?}
-              {:key :fhir.json/uri
-               :spec-form `(specs/json-regex-primitive "\\S*" type/uri)}
-              {:key :fhir.xml/uri
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "\\S*" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Uri type/to-xml))}
-              {:key :fhir.cbor/uri
-               :spec-form `(specs/cbor-primitive type/uri)}])))
+  (testing "uri"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "uri"))
+               regexes->str)
+           [{:key :fhir/uri
+             :spec-form `type/uri?}
+            {:key :fhir.json/uri
+             :spec-form `(specs/json-regex-primitive "\\S*" type/uri)}
+            {:key :fhir.xml/uri
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "\\S*" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Uri type/to-xml))}
+            {:key :fhir.cbor/uri
+             :spec-form `(specs/cbor-primitive type/uri)}])))
 
-    (testing "canonical"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "canonical"))
-                 regexes->str)
-             [{:key :fhir/canonical
-               :spec-form `type/canonical?}
-              {:key :fhir.json/canonical
-               :spec-form `(specs/json-regex-primitive "\\S*" type/canonical)}
-              {:key :fhir.xml/canonical
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "\\S*" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Canonical type/to-xml))}
-              {:key :fhir.cbor/canonical
-               :spec-form `(specs/cbor-primitive type/canonical)}])))
+  (testing "canonical"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "canonical"))
+               regexes->str)
+           [{:key :fhir/canonical
+             :spec-form `type/canonical?}
+            {:key :fhir.json/canonical
+             :spec-form `(specs/json-regex-primitive "\\S*" type/canonical)}
+            {:key :fhir.xml/canonical
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "\\S*" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Canonical type/to-xml))}
+            {:key :fhir.cbor/canonical
+             :spec-form `(specs/cbor-primitive type/canonical)}])))
 
-    (testing "base64Binary"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "base64Binary"))
-                 regexes->str)
-             [{:key :fhir/base64Binary
-               :spec-form `type/base64Binary?}
-              {:key :fhir.json/base64Binary
-               :spec-form `(specs/json-regex-primitive "([0-9a-zA-Z\\\\+/=]{4})+" type/base64Binary)}
-              {:key :fhir.xml/base64Binary
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "([0-9a-zA-Z\\\\+/=]{4})+" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Base64Binary type/to-xml))}
-              {:key :fhir.cbor/base64Binary
-               :spec-form `(specs/cbor-primitive type/base64Binary)}])))
+  (testing "base64Binary"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "base64Binary"))
+               regexes->str)
+           [{:key :fhir/base64Binary
+             :spec-form `type/base64Binary?}
+            {:key :fhir.json/base64Binary
+             :spec-form `(specs/json-regex-primitive "([0-9a-zA-Z\\\\+/=]{4})+" type/base64Binary)}
+            {:key :fhir.xml/base64Binary
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "([0-9a-zA-Z\\\\+/=]{4})+" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Base64Binary type/to-xml))}
+            {:key :fhir.cbor/base64Binary
+             :spec-form `(specs/cbor-primitive type/base64Binary)}])))
 
-    (testing "code"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "code"))
-                 regexes->str)
-             [{:key :fhir/code
-               :spec-form `type/code?}
-              {:key :fhir.json/code
-               :spec-form `(specs/json-regex-primitive "[^\\s]+(\\s[^\\s]+)*" type/code)}
-              {:key :fhir.xml/code
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "[^\\s]+(\\s[^\\s]+)*" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Code type/to-xml))}
-              {:key :fhir.cbor/code
-               :spec-form `(specs/cbor-primitive type/code)}])))
+  (testing "code"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "code"))
+               regexes->str)
+           [{:key :fhir/code
+             :spec-form `type/code?}
+            {:key :fhir.json/code
+             :spec-form `(specs/json-regex-primitive "[^\\s]+(\\s[^\\s]+)*" type/code)}
+            {:key :fhir.xml/code
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "[^\\s]+(\\s[^\\s]+)*" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Code type/to-xml))}
+            {:key :fhir.cbor/code
+             :spec-form `(specs/cbor-primitive type/code)}])))
 
-    (testing "unsignedInt"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "unsignedInt"))
-                 regexes->str)
-             [{:key :fhir/unsignedInt
-               :spec-form `type/unsignedInt?}
-              {:key :fhir.json/unsignedInt
-               :spec-form `(specs/json-pred-primitive int? type/unsignedInt)}
-              {:key :fhir.xml/unsignedInt
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "[0]|([1-9][0-9]*)" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->UnsignedInt type/to-xml))}
-              {:key :fhir.cbor/unsignedInt
-               :spec-form `(specs/cbor-primitive type/unsignedInt)}])))
+  (testing "unsignedInt"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "unsignedInt"))
+               regexes->str)
+           [{:key :fhir/unsignedInt
+             :spec-form `type/unsignedInt?}
+            {:key :fhir.json/unsignedInt
+             :spec-form `(specs/json-pred-primitive int? type/unsignedInt)}
+            {:key :fhir.xml/unsignedInt
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "[0]|([1-9][0-9]*)" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->UnsignedInt type/to-xml))}
+            {:key :fhir.cbor/unsignedInt
+             :spec-form `(specs/cbor-primitive type/unsignedInt)}])))
 
-    (testing "positiveInt"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "positiveInt"))
-                 regexes->str)
-             [{:key :fhir/positiveInt
-               :spec-form `type/positiveInt?}
-              {:key :fhir.json/positiveInt
-               :spec-form `(specs/json-pred-primitive int? type/positiveInt)}
-              {:key :fhir.xml/positiveInt
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "[1-9][0-9]*" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->PositiveInt type/to-xml))}
-              {:key :fhir.cbor/positiveInt
-               :spec-form `(specs/cbor-primitive type/positiveInt)}])))
+  (testing "positiveInt"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "positiveInt"))
+               regexes->str)
+           [{:key :fhir/positiveInt
+             :spec-form `type/positiveInt?}
+            {:key :fhir.json/positiveInt
+             :spec-form `(specs/json-pred-primitive int? type/positiveInt)}
+            {:key :fhir.xml/positiveInt
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "[1-9][0-9]*" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->PositiveInt type/to-xml))}
+            {:key :fhir.cbor/positiveInt
+             :spec-form `(specs/cbor-primitive type/positiveInt)}])))
 
-    (testing "uuid"
-      (is (= (-> (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "uuid"))
-                 regexes->str)
-             [{:key :fhir/uuid
-               :spec-form `type/uuid?}
-              {:key :fhir.json/uuid
-               :spec-form `(specs/json-regex-primitive "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" type/uuid)}
-              {:key :fhir.xml/uuid
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (fn [~'e] (xml/value-matches? "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" ~'e))
-                  (s2/conformer xml/remove-character-content xml/set-extension-tag)
-                  (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-                  (s2/conformer type/xml->Uuid type/to-xml))}
-              {:key :fhir.cbor/uuid
-               :spec-form `(specs/cbor-primitive type/uuid)}])))
+  (testing "uuid"
+    (is (= (-> (impl/primitive-type->spec-defs (primitive-type "uuid"))
+               regexes->str)
+           [{:key :fhir/uuid
+             :spec-form `type/uuid?}
+            {:key :fhir.json/uuid
+             :spec-form `(specs/json-regex-primitive "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" type/uuid)}
+            {:key :fhir.xml/uuid
+             :spec-form
+             `(s2/and
+                xml/element?
+                (fn [~'e] (xml/value-matches? "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" ~'e))
+                (s2/conformer xml/remove-character-content xml/set-extension-tag)
+                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+                (s2/conformer type/xml->Uuid type/to-xml))}
+            {:key :fhir.cbor/uuid
+             :spec-form `(specs/cbor-primitive type/uuid)}])))
 
-    (testing "xhtml"
-      (is (= (impl/primitive-type->spec-defs (primitive-type structure-definition-repo "xhtml"))
-             [{:key :fhir/xhtml
-               :spec-form `type/xhtml?}
-              {:key :fhir.json/xhtml
-               :spec-form
-               `(s2/and
-                  string?
-                  (s2/conformer type/->Xhtml identity))}
-              {:key :fhir.xml/xhtml
-               :spec-form
-               `(s2/and
-                  xml/element?
-                  (s2/conformer type/xml->Xhtml type/to-xml))}
-              {:key :fhir.cbor/xhtml
-               :spec-form `(s2/conformer type/->Xhtml identity)}])))))
+  (testing "xhtml"
+    (is (= (impl/primitive-type->spec-defs (primitive-type "xhtml"))
+           [{:key :fhir/xhtml
+             :spec-form `type/xhtml?}
+            {:key :fhir.json/xhtml
+             :spec-form
+             `(s2/and
+                string?
+                (s2/conformer type/->Xhtml identity))}
+            {:key :fhir.xml/xhtml
+             :spec-form
+             `(s2/and
+                xml/element?
+                (s2/conformer type/xml->Xhtml type/to-xml))}
+            {:key :fhir.cbor/xhtml
+             :spec-form `(s2/conformer type/->Xhtml identity)}]))))
 
 
-(defn- complex-type [structure-definition-repo name]
-  (some #(when (= name (:name %)) %) (u/complex-types structure-definition-repo)))
+(defn- complex-type [name]
+  (some #(when (= name (:name %)) %) (sdr/complex-types structure-definition-repo)))
 
 
 (defn- resource [structure-definition-repo name]
-  (some #(when (= name (:name %)) %) (u/resources structure-definition-repo)))
+  (some #(when (= name (:name %)) %) (sdr/resources structure-definition-repo)))
 
 
 (deftest struct-def->spec-def-test
-  (with-system [{:blaze.fhir/keys [structure-definition-repo]} system]
-    (testing "internal representation of choice typed data element"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "UsageContext")))
-        [:fhir.UsageContext/value 0 :spec-form]
-        := `(s2/or :valueCodeableConcept :fhir/CodeableConcept
-                   :valueQuantity :fhir/Quantity
-                   :valueRange :fhir/Range
-                   :valueReference :fhir/Reference)))
+  (testing "internal representation of choice typed data element"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
+      [:fhir.UsageContext/value 0 :spec-form]
+      := `(s2/or :valueCodeableConcept :fhir/CodeableConcept
+                 :valueQuantity :fhir/Quantity
+                 :valueRange :fhir/Range
+                 :valueReference :fhir/Reference)))
 
-    (testing "internal representation of complex type"
-      (testing "has a type checker"
-        (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "UsageContext")))
-          [:fhir/UsageContext 0 :spec-form 1]
-          := `(fn [~'m] (identical? :fhir/UsageContext (type/type ~'m)))))
-      (testing "has a schema form"
-        (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "UsageContext")))
-          [:fhir/UsageContext 0 :spec-form 2]
-          := `(s2/schema
-                {:id :fhir.UsageContext/id
-                 :extension (s2/coll-of :fhir.UsageContext/extension)
-                 :code :fhir.UsageContext/code
-                 :value :fhir.UsageContext/value}))))
-
-    (testing "JSON representation of choice typed data element"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "UsageContext")))
-        [:fhir.json.UsageContext/valueCodeableConcept 0 :choice-group] := :value))
-
-    (testing "JSON representation of complex type with choice typed data element"
-      (testing "has a type annotating conformer"
-        (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "UsageContext")))
-          [:fhir.json/UsageContext 0 :spec-form 3]
-          := `(s2/conformer
-                (fn [~'m] (assoc ~'m :fhir/type :fhir/UsageContext))
-                (fn [~'m] (dissoc ~'m :fhir/type)))))
-      (testing "has a choice group merging conformer"
-        (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "UsageContext")))
-          [:fhir.json/UsageContext 0 :spec-form 4]
-          := `(s2/conformer
-                (fn [~'m]
-                  (impl/remove-choice-type ~'m [:valueCodeableConcept :valueQuantity :valueRange :valueReference] :value))
-                (fn [~'m]
-                  (impl/add-choice-type ~'m :value))))))
-
-    (testing "JSON representation of Patient"
-      (testing "has a type annotating conformer"
-        (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Patient")))
-          [:fhir.json/Patient 0 :spec-form 3]
-          := `(s2/conformer
-                (fn [~'m] (-> (assoc ~'m :fhir/type :fhir/Patient) (dissoc :resourceType)))
-                (fn [~'m] (-> (dissoc ~'m :fhir/type) (assoc :resourceType "Patient")))))))
-
-    (testing "JSON representation of Bundle"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.json/Bundle 0 :spec-form 2]
+  (testing "internal representation of complex type"
+    (testing "has a type checker"
+      (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
+        [:fhir/UsageContext 0 :spec-form 1]
+        := `(fn [~'m] (identical? :fhir/UsageContext (type/type ~'m)))))
+    (testing "has a schema form"
+      (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
+        [:fhir/UsageContext 0 :spec-form 2]
         := `(s2/schema
-              {:id :fhir.json.Bundle/id
-               :meta :fhir.json.Bundle/meta
-               :implicitRules :fhir.json.Bundle/implicitRules
-               :language :fhir.json.Bundle/language
-               :identifier :fhir.json.Bundle/identifier
-               :type :fhir.json.Bundle/type
-               :timestamp :fhir.json.Bundle/timestamp
-               :total :fhir.json.Bundle/total
-               :link (s2/and (s2/conformer impl/ensure-coll identity)
-                             (s2/coll-of :fhir.json.Bundle/link))
-               :entry (s2/and (s2/conformer impl/ensure-coll identity)
-                              (s2/coll-of :fhir.json.Bundle/entry))
-               :signature :fhir.json.Bundle/signature})))
+              {:id :fhir.UsageContext/id
+               :extension (s2/coll-of :fhir.UsageContext/extension)
+               :code :fhir.UsageContext/code
+               :value :fhir.UsageContext/value}))))
 
-    (testing "JSON representation of Bundle.id"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.json.Bundle/id 0 :spec-form regexes->str]
-        := `(s2/and string? (fn [~'s] (.matches (re-matcher "[A-Za-z0-9\\-\\.]{1,64}" ~'s))))))
+  (testing "JSON representation of choice typed data element"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
+      [:fhir.json.UsageContext/valueCodeableConcept 0 :choice-group] := :value))
 
-    (testing "XML representation of Bundle.id"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.xml.Bundle/id 0 :spec-form regexes->str]
-        := `(s2/and
-              xml/element?
-              (s2/conformer impl/conform-xml-value impl/unform-xml-value)
-              (fn [~'s] (.matches (re-matcher "[A-Za-z0-9\\-\\.]{1,64}" ~'s))))))
+  (testing "JSON representation of complex type with choice typed data element"
+    (testing "has a type annotating conformer"
+      (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
+        [:fhir.json/UsageContext 0 :spec-form 3]
+        := `(s2/conformer
+              (fn [~'m] (assoc ~'m :fhir/type :fhir/UsageContext))
+              (fn [~'m] (dissoc ~'m :fhir/type)))))
+    (testing "has a choice group merging conformer"
+      (given (group-by :key (impl/struct-def->spec-def (complex-type "UsageContext")))
+        [:fhir.json/UsageContext 0 :spec-form 4]
+        := `(s2/conformer
+              (fn [~'m]
+                (impl/remove-choice-type ~'m [:valueCodeableConcept :valueQuantity :valueRange :valueReference] :value))
+              (fn [~'m]
+                (impl/add-choice-type ~'m :value))))))
 
-    (testing "JSON representation of Bundle.entry"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.json.Bundle/entry 0 :spec-form 2]
-        := `(s2/schema
-              {:id :fhir.json.Bundle.entry/id
-               :extension (s2/and (s2/conformer impl/ensure-coll identity)
-                                  (s2/coll-of :fhir.json.Bundle.entry/extension))
-               :modifierExtension (s2/and (s2/conformer impl/ensure-coll identity)
-                                          (s2/coll-of :fhir.json.Bundle.entry/modifierExtension))
-               :link (s2/and (s2/conformer impl/ensure-coll identity)
-                             (s2/coll-of :fhir.json.Bundle.entry/link))
-               :fullUrl :fhir.json.Bundle.entry/fullUrl
-               :resource :fhir.json.Bundle.entry/resource
-               :search :fhir.json.Bundle.entry/search
-               :request :fhir.json.Bundle.entry/request
-               :response :fhir.json.Bundle.entry/response})))
+  (testing "JSON representation of Patient"
+    (testing "has a type annotating conformer"
+      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Patient")))
+        [:fhir.json/Patient 0 :spec-form 3]
+        := `(s2/conformer
+              (fn [~'m] (-> (assoc ~'m :fhir/type :fhir/Patient) (dissoc :resourceType)))
+              (fn [~'m] (-> (dissoc ~'m :fhir/type) (assoc :resourceType "Patient")))))))
 
-    (testing "XML representation of Bundle entry"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.xml.Bundle/entry 0 :spec-form]
-        := `(s2/and
-              (s2/conformer
-                blaze.fhir.spec.impl/conform-xml
-                (fn [~'m]
-                  (when ~'m
-                    (xml-node/element*
-                      nil
-                      (blaze.fhir.spec.impl/select-non-nil-keys ~'m [:id])
-                      (-> []
-                          (impl/conj-all ::f/extension (:extension ~'m))
-                          (impl/conj-all ::f/modifierExtension (:modifierExtension ~'m))
-                          (impl/conj-all ::f/link (:link ~'m))
-                          (impl/conj-when (some-> ~'m :fullUrl (assoc :tag ::f/fullUrl)))
-                          (impl/conj-when (:resource ~'m))
-                          (impl/conj-when (some-> ~'m :search (assoc :tag ::f/search)))
-                          (impl/conj-when (some-> ~'m :request (assoc :tag ::f/request)))
-                          (impl/conj-when (some-> ~'m :response (assoc :tag ::f/response))))))))
-              (s2/schema
-                {:id :fhir.xml.Bundle.entry/id
-                 :extension (s2/and
-                              (s2/conformer impl/ensure-coll identity)
-                              (s2/coll-of :fhir.xml.Bundle.entry/extension))
-                 :modifierExtension (s2/and
-                                      (s2/conformer impl/ensure-coll identity)
-                                      (s2/coll-of :fhir.xml.Bundle.entry/modifierExtension))
-                 :link (s2/and
-                         (s2/conformer impl/ensure-coll identity)
-                         (s2/coll-of :fhir.xml.Bundle.entry/link))
-                 :fullUrl :fhir.xml.Bundle.entry/fullUrl
-                 :resource :fhir.xml.Bundle.entry/resource
-                 :search :fhir.xml.Bundle.entry/search
-                 :request :fhir.xml.Bundle.entry/request
-                 :response :fhir.xml.Bundle.entry/response})
-              (s2/conformer
-                (fn [~'m] (assoc ~'m :fhir/type :fhir.Bundle/entry))
-                identity))))
+  (testing "JSON representation of Bundle"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.json/Bundle 0 :spec-form 2]
+      := `(s2/schema
+            {:id :fhir.json.Bundle/id
+             :meta :fhir.json.Bundle/meta
+             :implicitRules :fhir.json.Bundle/implicitRules
+             :language :fhir.json.Bundle/language
+             :identifier :fhir.json.Bundle/identifier
+             :type :fhir.json.Bundle/type
+             :timestamp :fhir.json.Bundle/timestamp
+             :total :fhir.json.Bundle/total
+             :link (s2/and (s2/conformer impl/ensure-coll identity)
+                           (s2/coll-of :fhir.json.Bundle/link))
+             :entry (s2/and (s2/conformer impl/ensure-coll identity)
+                            (s2/coll-of :fhir.json.Bundle/entry))
+             :signature :fhir.json.Bundle/signature})))
 
-    (testing "JSON representation of Bundle.entry.resource"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.json.Bundle.entry/resource 0 :spec-form] := :fhir.json/Resource))
+  (testing "JSON representation of Bundle.id"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.json.Bundle/id 0 :spec-form regexes->str]
+      := `(s2/and string? (fn [~'s] (.matches (re-matcher "[A-Za-z0-9\\-\\.]{1,64}" ~'s))))))
 
-    (testing "XML representation of Bundle.entry.resource"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
-        [:fhir.xml.Bundle.entry/resource 0 :spec-form] := :fhir.xml/Resource))
+  (testing "XML representation of Bundle.id"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.xml.Bundle/id 0 :spec-form regexes->str]
+      := `(s2/and
+            xml/element?
+            (s2/conformer impl/conform-xml-value impl/unform-xml-value)
+            (fn [~'s] (.matches (re-matcher "[A-Za-z0-9\\-\\.]{1,64}" ~'s))))))
 
-    (testing "XML representation of Extension"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Extension")))
-        [:fhir.Extension/url 0 :spec-form regexes->str]
-        := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
-        [:fhir.json.Extension/url 0 :spec-form regexes->str]
-        := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
-        [:fhir.xml.Extension/url 0 :spec-form regexes->str]
-        := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
-        [:fhir.xml.Extension/url 0 :representation] := :xmlAttr))
+  (testing "JSON representation of Bundle.entry"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.json.Bundle/entry 0 :spec-form 2]
+      := `(s2/schema
+            {:id :fhir.json.Bundle.entry/id
+             :extension (s2/and (s2/conformer impl/ensure-coll identity)
+                                (s2/coll-of :fhir.json.Bundle.entry/extension))
+             :modifierExtension (s2/and (s2/conformer impl/ensure-coll identity)
+                                        (s2/coll-of :fhir.json.Bundle.entry/modifierExtension))
+             :link (s2/and (s2/conformer impl/ensure-coll identity)
+                           (s2/coll-of :fhir.json.Bundle.entry/link))
+             :fullUrl :fhir.json.Bundle.entry/fullUrl
+             :resource :fhir.json.Bundle.entry/resource
+             :search :fhir.json.Bundle.entry/search
+             :request :fhir.json.Bundle.entry/request
+             :response :fhir.json.Bundle.entry/response})))
 
-    (testing "XML representation of Coding"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Coding")))
-        [:fhir.xml/Coding 0 :spec-form 1 2 2 2]
-        := `(xml-node/element*
-              nil
-              (blaze.fhir.spec.impl/select-non-nil-keys ~'m [:id])
-              (->
-                []
-                (impl/conj-all ::f/extension (:extension ~'m))
-                (impl/conj-when (some-> ~'m :system (assoc :tag ::f/system)))
-                (impl/conj-when (some-> ~'m :version (assoc :tag ::f/version)))
-                (impl/conj-when (some-> ~'m :code (assoc :tag ::f/code)))
-                (impl/conj-when (some-> ~'m :display (assoc :tag ::f/display)))
-                (impl/conj-when (some-> ~'m :userSelected (assoc :tag ::f/userSelected)))))))
+  (testing "XML representation of Bundle entry"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.xml.Bundle/entry 0 :spec-form]
+      := `(s2/and
+            (s2/conformer
+              blaze.fhir.spec.impl/conform-xml
+              (fn [~'m]
+                (when ~'m
+                  (xml-node/element*
+                    nil
+                    (blaze.fhir.spec.impl/select-non-nil-keys ~'m [:id])
+                    (-> []
+                        (impl/conj-all ::f/extension (:extension ~'m))
+                        (impl/conj-all ::f/modifierExtension (:modifierExtension ~'m))
+                        (impl/conj-all ::f/link (:link ~'m))
+                        (impl/conj-when (some-> ~'m :fullUrl (assoc :tag ::f/fullUrl)))
+                        (impl/conj-when (:resource ~'m))
+                        (impl/conj-when (some-> ~'m :search (assoc :tag ::f/search)))
+                        (impl/conj-when (some-> ~'m :request (assoc :tag ::f/request)))
+                        (impl/conj-when (some-> ~'m :response (assoc :tag ::f/response))))))))
+            (s2/schema
+              {:id :fhir.xml.Bundle.entry/id
+               :extension (s2/and
+                            (s2/conformer impl/ensure-coll identity)
+                            (s2/coll-of :fhir.xml.Bundle.entry/extension))
+               :modifierExtension (s2/and
+                                    (s2/conformer impl/ensure-coll identity)
+                                    (s2/coll-of :fhir.xml.Bundle.entry/modifierExtension))
+               :link (s2/and
+                       (s2/conformer impl/ensure-coll identity)
+                       (s2/coll-of :fhir.xml.Bundle.entry/link))
+               :fullUrl :fhir.xml.Bundle.entry/fullUrl
+               :resource :fhir.xml.Bundle.entry/resource
+               :search :fhir.xml.Bundle.entry/search
+               :request :fhir.xml.Bundle.entry/request
+               :response :fhir.xml.Bundle.entry/response})
+            (s2/conformer
+              (fn [~'m] (assoc ~'m :fhir/type :fhir.Bundle/entry))
+              identity))))
 
-    (testing "XML representation of Measure unformer XML attributes"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Measure")))
-        [:fhir.xml/Measure 0 :spec-form 1 2 2 2 2] :=
-        `(assoc (blaze.fhir.spec.impl/select-non-nil-keys ~'m []) :xmlns "http://hl7.org/fhir")))
+  (testing "JSON representation of Bundle.entry.resource"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.json.Bundle.entry/resource 0 :spec-form] := :fhir.json/Resource))
 
-    (testing "XML representation of Measure.url"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Measure")))
-        [:fhir.xml.Measure/url 0 :spec-form] := :fhir.xml/uri))
+  (testing "XML representation of Bundle.entry.resource"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Bundle")))
+      [:fhir.xml.Bundle.entry/resource 0 :spec-form] := :fhir.xml/Resource))
 
-    (testing "XML representation of Questionnaire.item contains recursive spec to itself"
-      (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Questionnaire")))
-        [:fhir.xml.Questionnaire/item 0 :spec-form 2 1 :item]
-        := `(s2/and
-              (s2/conformer impl/ensure-coll clojure.core/identity)
-              (s2/coll-of :fhir.xml.Questionnaire.item/item))))
+  (testing "XML representation of Extension"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "Extension")))
+      [:fhir.Extension/url 0 :spec-form regexes->str]
+      := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
+      [:fhir.json.Extension/url 0 :spec-form regexes->str]
+      := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
+      [:fhir.xml.Extension/url 0 :spec-form regexes->str]
+      := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
+      [:fhir.xml.Extension/url 0 :representation] := :xmlAttr))
 
-    (testing "JSON representation of Quantity.unit"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Quantity")))
-        [:fhir.json.Quantity/unit 0 :spec-form regexes->str]
-        := `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/intern-string)))
+  (testing "XML representation of Coding"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "Coding")))
+      [:fhir.xml/Coding 0 :spec-form 1 2 2 2]
+      := `(xml-node/element*
+            nil
+            (blaze.fhir.spec.impl/select-non-nil-keys ~'m [:id])
+            (->
+              []
+              (impl/conj-all ::f/extension (:extension ~'m))
+              (impl/conj-when (some-> ~'m :system (assoc :tag ::f/system)))
+              (impl/conj-when (some-> ~'m :version (assoc :tag ::f/version)))
+              (impl/conj-when (some-> ~'m :code (assoc :tag ::f/code)))
+              (impl/conj-when (some-> ~'m :display (assoc :tag ::f/display)))
+              (impl/conj-when (some-> ~'m :userSelected (assoc :tag ::f/userSelected)))))))
 
-    (testing "XML representation of Quantity.unit"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Quantity")))
-        [:fhir.xml.Quantity/unit 0 :spec-form regexes->str]
-        := `(s2/and
-              xml/element?
-              (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
-              (s2/conformer xml/remove-character-content xml/set-extension-tag)
-              (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
-              (s2/conformer type/xml->InternedString type/to-xml))))
+  (testing "XML representation of Measure unformer XML attributes"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Measure")))
+      [:fhir.xml/Measure 0 :spec-form 1 2 2 2 2] :=
+      `(assoc (blaze.fhir.spec.impl/select-non-nil-keys ~'m []) :xmlns "http://hl7.org/fhir")))
 
-    (testing "CBOR representation of Quantity.unit"
-      (given (group-by :key (impl/struct-def->spec-def (complex-type structure-definition-repo "Quantity")))
-        [:fhir.cbor.Quantity/unit 0 :spec-form regexes->str]
-        := `(specs/cbor-primitive type/intern-string)))))
+  (testing "XML representation of Measure.url"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Measure")))
+      [:fhir.xml.Measure/url 0 :spec-form] := :fhir.xml/uri))
+
+  (testing "XML representation of Questionnaire.item contains recursive spec to itself"
+    (given (group-by :key (impl/struct-def->spec-def (resource structure-definition-repo "Questionnaire")))
+      [:fhir.xml.Questionnaire/item 0 :spec-form 2 1 :item]
+      := `(s2/and
+            (s2/conformer impl/ensure-coll clojure.core/identity)
+            (s2/coll-of :fhir.xml.Questionnaire.item/item))))
+
+  (testing "JSON representation of Quantity.unit"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "Quantity")))
+      [:fhir.json.Quantity/unit 0 :spec-form regexes->str]
+      := `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/intern-string)))
+
+  (testing "XML representation of Quantity.unit"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "Quantity")))
+      [:fhir.xml.Quantity/unit 0 :spec-form regexes->str]
+      := `(s2/and
+            xml/element?
+            (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
+            (s2/conformer xml/remove-character-content xml/set-extension-tag)
+            (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
+            (s2/conformer type/xml->InternedString type/to-xml))))
+
+  (testing "CBOR representation of Quantity.unit"
+    (given (group-by :key (impl/struct-def->spec-def (complex-type "Quantity")))
+      [:fhir.cbor.Quantity/unit 0 :spec-form regexes->str]
+      := `(specs/cbor-primitive type/intern-string))))
 
 
 (deftest elem-def->spec-def-test

--- a/modules/fhir-structure/test/blaze/fhir/spec/type/system_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type/system_test.clj
@@ -504,6 +504,44 @@
       "2019-02-29")))
 
 
+(deftest date-time-lower-bound-test
+  (testing "date-times with increasing precision have the same lower bound"
+    (are [dt] (= 1577836800 (system/date-time-lower-bound dt))
+      #system/date"2020"
+      #system/date"2020-01"
+      #system/date"2020-01-01"
+      #system/date-time"2020"
+      #system/date-time"2020-01"
+      #system/date-time"2020-01-01"
+      #system/date-time"2020-01-01T00:00:00"
+      #system/date-time"2020-01-01T00:00:00Z"
+      #system/date-time"2020-01-01T00:00:00.000"
+      #system/date-time"2020-01-01T00:00:00.000Z")
+
+    (testing "nil has the same lower bound as year 1"
+      (is (= (system/date-time-lower-bound #system/date"0001")
+             (system/date-time-lower-bound nil))))))
+
+
+(deftest date-time-upper-bound-test
+  (testing "date-times with increasing precision have the same upper bound"
+    (are [dt] (= 1609459199 (system/date-time-upper-bound dt))
+      #system/date"2020"
+      #system/date"2020-12"
+      #system/date"2020-12-31"
+      #system/date-time"2020"
+      #system/date-time"2020-12"
+      #system/date-time"2020-12-31"
+      #system/date-time"2020-12-31T23:59:59"
+      #system/date-time"2020-12-31T23:59:59Z"
+      #system/date-time"2020-12-31T23:59:59.000"
+      #system/date-time"2020-12-31T23:59:59.000Z"))
+
+  (testing "nil has the same upper bound as year 9999"
+    (is (= (system/date-time-upper-bound #system/date"9999")
+           (system/date-time-upper-bound nil)))))
+
+
 (deftest time-test
   (testing "type"
     (is (= :system/time (system/type (LocalTime/of 0 0 0)))))

--- a/modules/rest-api/test/blaze/rest_api/capabilities_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/capabilities_test.clj
@@ -1,13 +1,11 @@
 (ns blaze.rest-api.capabilities-test
   (:require
     [blaze.db.impl.search-param]
-    [blaze.fhir.structure-definition-repo]
     [blaze.rest-api.capabilities :as capabilities]
     [blaze.rest-api.capabilities-spec]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest testing]]
-    [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [reitit.ring]))
 
@@ -27,9 +25,8 @@
 
 
 (def system
-  {:blaze.fhir/structure-definition-repo {}
-   :blaze.db/search-param-registry
-   {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}})
+  {:blaze.db/search-param-registry
+   {:structure-definition-repo structure-definition-repo}})
 
 
 (deftest capabilities-handler-test

--- a/modules/rest-api/test/blaze/rest_api_test.clj
+++ b/modules/rest-api/test/blaze/rest_api_test.clj
@@ -4,12 +4,11 @@
     [blaze.db.api-stub :refer [mem-node-system]]
     [blaze.db.impl.search-param]
     [blaze.fhir.spec :as fhir-spec]
-    [blaze.fhir.structure-definition-repo]
     [blaze.fhir.structure-definition-repo.protocols :as sdrp]
     [blaze.handler.util :as handler-util]
     [blaze.metrics.spec]
     [blaze.rest-api :as rest-api]
-    [blaze.test-util :as tu :refer [given-thrown with-system]]
+    [blaze.test-util :as tu :refer [given-thrown structure-definition-repo with-system]]
     [blaze.test-util.ring :refer [call]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
@@ -309,7 +308,7 @@
     :blaze/rest-api
     {:base-url "http://localhost:8080"
      :version "0.1.0"
-     :structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)
+     :structure-definition-repo structure-definition-repo
      :node (ig/ref :blaze.db/node)
      :search-param-registry (ig/ref :blaze.db/search-param-registry)
      :db-sync-timeout 10000
@@ -330,8 +329,7 @@
                #:blaze.rest-api.interaction
                        {:handler success-handler}}}]}
     :blaze.db/search-param-registry
-    {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-    :blaze.fhir/structure-definition-repo {}))
+    {:structure-definition-repo structure-definition-repo}))
 
 
 (defmethod ig/init-key ::empty-structure-definition-repo

--- a/modules/test-util/src/blaze/test_util.clj
+++ b/modules/test-util/src/blaze/test_util.clj
@@ -97,7 +97,9 @@
   (Arrays/equals a b))
 
 
-(ig/init {:blaze.fhir/structure-definition-repo {}})
+(defonce structure-definition-repo
+         (:blaze.fhir/structure-definition-repo
+           (ig/init {:blaze.fhir/structure-definition-repo {}})))
 
 
 (defn fixture [f]

--- a/test/blaze/system_test.clj
+++ b/test/blaze/system_test.clj
@@ -11,7 +11,7 @@
     [blaze.rest-api]
     [blaze.system :as system]
     [blaze.system-spec]
-    [blaze.test-util :as tu :refer [with-system]]
+    [blaze.test-util :as tu :refer [structure-definition-repo with-system]]
     [blaze.test-util.ring :refer [call]]
     [buddy.auth.protocols :as ap]
     [clojure.spec.alpha :as s]
@@ -69,7 +69,7 @@
     :blaze/rest-api
     {:base-url "http://localhost:8080"
      :version "0.1.0"
-     :structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)
+     :structure-definition-repo structure-definition-repo
      :node (ig/ref :blaze.db/node)
      :search-param-registry (ig/ref :blaze.db/search-param-registry)
      :db-sync-timeout 10000
@@ -90,8 +90,7 @@
                #:blaze.rest-api.interaction
                        {:handler (ig/ref :blaze.interaction/search-type)}}}]}
     :blaze.db/search-param-registry
-    {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-    :blaze.fhir/structure-definition-repo {}
+    {:structure-definition-repo structure-definition-repo}
     ::auth-backend {}
     :blaze.interaction/transaction
     {:node (ig/ref :blaze.db/node)


### PR DESCRIPTION
The equal search worked like approximately (ap) search. Now it tests for fully contains instead of overlapping. The Prefixes sa (starts-after), eb (ends-before) and ap (approximately) were also added.

Closes: #666