### PR TITLE
Improve Date Search Performance

### DIFF
--- a/.github/scripts/check-total-number-of-resources.sh
+++ b/.github/scripts/check-total-number-of-resources.sh
@@ -3,4 +3,4 @@
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 . "$SCRIPT_DIR/util.sh"
 
-test "total number of resources" "$(curl -s http://localhost:8080/fhir | jq -r .total)" "$1"
+test "total number of resources" "$(curl -sH 'Accept: application/fhir+json' http://localhost:8080/fhir | jq -r .total)" "$1"

--- a/.github/scripts/download-resources-query.sh
+++ b/.github/scripts/download-resources-query.sh
@@ -1,10 +1,19 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
 BASE="http://localhost:8080/fhir"
 TYPE=$1
 QUERY=$2
 EXPECTED_SIZE=$3
 FILE_NAME_PREFIX="$(uuidgen)"
+
+count() {
+  curl -sH 'Prefer: handling=strict' -H 'Accept: application/fhir+json' "$BASE/$TYPE?$QUERY&_summary=count" | jq .total
+}
+
+test "count size" "$(count)" "$EXPECTED_SIZE"
 
 blazectl --no-progress --server "$BASE" download "$TYPE" -q "$QUERY" -o "$FILE_NAME_PREFIX-get".ndjson
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,8 +356,44 @@ jobs:
     - name: Download Observation Resources of the year 2020
       run: .github/scripts/download-resources-query.sh Observation "date=2020" 17419
 
-    - name: Download Observation Resources of not the year 2020
+    - name: Download Observation Resources not of the year 2020
       run: .github/scripts/download-resources-query.sh Observation "date=ne2020" 25510
+
+    - name: Download Observation Resources greater than the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=gt2010" 38486
+
+    - name: Download Observation Resources greater than the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=gt2020" 983
+
+    - name: Download Observation Resources less than the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=lt2010" 3448
+
+    - name: Download Observation Resources less than the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=lt2020" 24527
+
+    - name: Download Observation Resources greater equal the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=ge2010" 39481
+
+    - name: Download Observation Resources greater equal the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=ge2020" 18402
+
+    - name: Download Observation Resources less equal the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=le2010" 4443
+
+    - name: Download Observation Resources less equal the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=le2020" 41946
+
+    - name: Download Observation Resources that start after the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=sa2010" 38486
+
+    - name: Download Observation Resources that start after the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=sa2020" 983
+
+    - name: Download Observation Resources that end before the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=eb2010" 3448
+
+    - name: Download Observation Resources that end before the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=eb2020" 24527
 
     - name: Check Observation Date Search
       run: .github/scripts/check-date-search.sh "Observation"
@@ -1137,8 +1173,44 @@ jobs:
     - name: Download Observation Resources of the year 2020
       run: .github/scripts/download-resources-query.sh Observation "date=2020" 17419
 
-    - name: Download Observation Resources of not the year 2020
+    - name: Download Observation Resources not of the year 2020
       run: .github/scripts/download-resources-query.sh Observation "date=ne2020" 25510
+
+    - name: Download Observation Resources greater than the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=gt2010" 38486
+
+    - name: Download Observation Resources greater than the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=gt2020" 983
+
+    - name: Download Observation Resources less than the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=lt2010" 3448
+
+    - name: Download Observation Resources less than the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=lt2020" 24527
+
+    - name: Download Observation Resources greater equal the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=ge2010" 39481
+
+    - name: Download Observation Resources greater equal the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=ge2020" 18402
+
+    - name: Download Observation Resources less equal the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=le2010" 4443
+
+    - name: Download Observation Resources less equal the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=le2020" 41946
+
+    - name: Download Observation Resources that start after the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=sa2010" 38486
+
+    - name: Download Observation Resources that start after the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=sa2020" 983
+
+    - name: Download Observation Resources that end before the year 2010
+      run: .github/scripts/download-resources-query.sh Observation "date=eb2010" 3448
+
+    - name: Download Observation Resources that end before the year 2020
+      run: .github/scripts/download-resources-query.sh Observation "date=eb2020" 24527
 
     - name: Check Observation Date Search
       run: .github/scripts/check-date-search.sh "Observation"

--- a/docs/performance/fhir-search.md
+++ b/docs/performance/fhir-search.md
@@ -177,6 +177,29 @@ blazectl download --server http://localhost:8080/fhir Observation -q "code=http:
 
 ¹ Number of Resources, ² Number of Observations, ³ Time in seconds per 1 million resources, The amount of system memory was 128 GB in all cases.
 
+
+## Date Search
+
+In this section, FHIR Search for selecting Observation resources with a certain effective year is used.
+
+### Counting
+
+All measurements are done after Blaze is in a steady state with all resource handles to hit in it's resource handle cache in order to cancel out additional seeks necessary to determine the current version of each resource. A resource handle doesn't contain the actual resource content which is not necessary for counting.
+
+Counting is done using the following `curl` command:
+
+```sh
+curl -s "http://localhost:8080/fhir/Observation?date=$YEAR&_summary=count"
+```
+
+| CPU        | Heap Mem | Block Cache | # Res. ¹ | # Obs. ² | Year | # Hits | Time (s) | StdDev | T / 1M ³ |
+|------------|---------:|------------:|---------:|---------:|------|-------:|---------:|-------:|---------:|
+| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 2012 |      0 |     0.11 |  0.007 |      N/A |
+| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 2019 |    2 M |     2.10 |  0.034 |     1.06 |
+| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 2020 | 11.3 M |    11.45 |  0.112 |     1.01 |
+
+¹ Number of Resources, ² Number of Observations, ³ Time in seconds per 1 million resources, The amount of system memory was 128 GB in all cases.
+
 ## Used Dataset
 
 The dataset used is Synthea v2.7.0. The resource generation was done with the following settings:

--- a/docs/performance/fhir-search/date-search.sh
+++ b/docs/performance/fhir-search/date-search.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+BASE="http://localhost:8080/fhir"
+START_EPOCH="$(date +"%s")"
+
+for YEAR in "2012" "2019" "2020"
+do
+  echo "Counting Observations with effective date in $YEAR..."
+  echo "The number is : $(curl -s "$BASE/Observation?date=$YEAR&_summary=count" | jq .total)"
+  for i in {0..10}
+  do
+    curl -s "$BASE/Observation?date=$YEAR&_summary=count" -o /dev/null -w '%{time_starttransfer}\n' >> "$START_EPOCH-$YEAR.times"
+  done
+
+  # Skip first line because it will not benefit from caching
+  tail -n +2 "$START_EPOCH-$YEAR.times" |\
+    awk '{sum += $1; sumsq += $1^2} END {printf("Avg    : %.3f\nStdDev : %.3f\n", sum/NR, sqrt(sumsq/NR - (sum/NR)^2))}'
+done

--- a/modules/db/src/blaze/db/impl/index/search_param_value_resource.clj
+++ b/modules/db/src/blaze/db/impl/index/search_param_value_resource.clj
@@ -146,6 +146,18 @@
      (i/prefix-keys-prev! iter prefix decode-value-id-hash-prefix start-key))))
 
 
+(defn prefix-keys-value! [iter c-hash tid value-prefix]
+  (let [prefix (encode-seek-key c-hash tid)
+        start-key (encode-seek-key c-hash tid value-prefix)]
+    (i/prefix-keys! iter prefix decode-value-id-hash-prefix start-key)))
+
+
+(defn prefix-keys-value-prev! [iter c-hash tid value-prefix]
+  (let [prefix (encode-seek-key c-hash tid)
+        start-key (encode-seek-key c-hash tid value-prefix)]
+    (i/prefix-keys-prev! iter prefix decode-value-id-hash-prefix start-key)))
+
+
 (defn decode-id-hash-prefix
   "Returns a tuple of `[id hash-prefix]`."
   ([] (bb/allocate-direct key-buffer-capacity))


### PR DESCRIPTION
Used indexes for equal, less than and starts after. That operators all have a predicate on the lower bound of the resource value that comes first in the index. The other operators can't use the existing index, because they either look at the upper bound or on both bounds.

We have to add indexes in order to speed up the other operators. The issue is: #976.