### PR TITLE
Add Java 20 To Test Matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
         java-version:
         - '11'
         - '17'
+        - '20'
 
     runs-on: ubuntu-22.04
 
@@ -145,6 +146,7 @@ jobs:
         java-version:
         - '11'
         - '17'
+        - '20'
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
In order to prepare for the next Java LTS Version 21 in september, we start testing under Java 20.