### PR TITLE
Fix Extended Birth Date in CQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+classes
 .cpcache
 .cache
 blaze-load-tests/node_modules

--- a/modules/anomaly/Makefile
+++ b/modules/anomaly/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/anomaly/deps.edn
+++ b/modules/anomaly/deps.edn
@@ -1,5 +1,10 @@
 {:deps
- {blaze/spec
+ {
+  ;; TODO: only needed for prepping
+  blaze/fhir-structure
+  {:local/root "../fhir-structure"}
+
+  blaze/spec
   {:local/root "../spec"}
 
   com.cognitect/anomalies

--- a/modules/anomaly/src/blaze/anomaly.clj
+++ b/modules/anomaly/src/blaze/anomaly.clj
@@ -16,6 +16,10 @@
   (some? (::anom/category x)))
 
 
+(defn incorrect? [x]
+  (identical? ::anom/incorrect (::anom/category x)))
+
+
 (defn unsupported? [x]
   (identical? ::anom/unsupported (::anom/category x)))
 
@@ -201,3 +205,9 @@
 
 (defn exceptionally [x f]
   (if (::anom/category x) (f x) x))
+
+
+(defn ignore
+  "Ignores a possible anomaly, returning nil instead."
+  [x]
+  (when-not (::anom/category x) x))

--- a/modules/anomaly/src/blaze/anomaly_spec.clj
+++ b/modules/anomaly/src/blaze/anomaly_spec.clj
@@ -11,6 +11,11 @@
   :ret boolean?)
 
 
+(s/fdef ba/incorrect?
+  :args (s/cat :x any?)
+  :ret boolean?)
+
+
 (s/fdef ba/unsupported?
   :args (s/cat :x any?)
   :ret boolean?)
@@ -104,3 +109,7 @@
 
 (s/fdef ba/exceptionally
   :args (s/cat :x any? :f ifn?))
+
+
+(s/fdef ba/ignore
+  :args (s/cat :x any?))

--- a/modules/anomaly/test/blaze/anomaly_test.clj
+++ b/modules/anomaly/test/blaze/anomaly_test.clj
@@ -29,6 +29,17 @@
     (is (not (ba/anomaly? nil)))))
 
 
+(deftest incorrect?-test
+  (testing "a incorrect anomaly has to have the right category"
+    (is (ba/incorrect? {::anom/category ::anom/incorrect})))
+
+  (testing "anomalies with other categories are no incorrect anomalies"
+    (is (not (ba/incorrect? {::anom/category ::anom/fault}))))
+
+  (testing "nil is no incorrect anomaly"
+    (is (not (ba/anomaly? nil)))))
+
+
 (deftest unsupported?-test
   (testing "a unsupported anomaly has to have the right category"
     (is (ba/unsupported? {::anom/category ::anom/unsupported})))
@@ -342,3 +353,11 @@
     (given (ba/exceptionally (ba/fault) #(assoc % ::foo ::bar))
       ::anom/category := ::anom/fault
       ::foo := ::bar)))
+
+
+(deftest ignore-test
+  (testing "no anomaly"
+    (is (= 1 (ba/ignore 1))))
+
+  (testing "with anomaly"
+    (is (nil? (ba/ignore (ba/fault))))))

--- a/modules/async/Makefile
+++ b/modules/async/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/async/deps.edn
+++ b/modules/async/deps.edn
@@ -5,6 +5,10 @@
   blaze/executor
   {:local/root "../executor"}
 
+  ;; TODO: only needed for prepping
+  blaze/fhir-structure
+  {:local/root "../fhir-structure"}
+
   com.taoensso/timbre
   {:mvn/version "5.2.1"}}
 

--- a/modules/byte-buffer/Makefile
+++ b/modules/byte-buffer/Makefile
@@ -1,7 +1,10 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
@@ -10,4 +13,4 @@ test-coverage:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/byte-buffer/deps.edn
+++ b/modules/byte-buffer/deps.edn
@@ -1,5 +1,10 @@
 {:deps
- {com.google.protobuf/protobuf-java
+ {
+  ;; TODO: only needed for prepping
+  blaze/fhir-structure
+  {:local/root "../fhir-structure"}
+
+  com.google.protobuf/protobuf-java
   {:mvn/version "3.22.3"}}
 
  :aliases

--- a/modules/cassandra/Makefile
+++ b/modules/cassandra/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/coll/Makefile
+++ b/modules/coll/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/coll/deps.edn
+++ b/modules/coll/deps.edn
@@ -1,5 +1,8 @@
 {:deps
- {}
+ {
+  ;; TODO: only needed for prepping
+  blaze/fhir-structure
+  {:local/root "../fhir-structure"}}
 
  :aliases
  {:test

--- a/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
@@ -20,9 +20,9 @@
     (when-let [date (core/compile* context date)]
       (let [chrono-precision (some-> precision core/to-chrono-unit)]
         (reify core/Expression
-          (-eval [_ {:keys [now] :as context} resource scope]
+          (-eval [_ context resource scope]
             (p/duration-between
-              (p/to-date (core/-eval birth-date context resource scope) now)
+              (core/-eval birth-date context resource scope)
               (core/-eval date context resource scope)
               chrono-precision))
           (-form [_]

--- a/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
+++ b/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
@@ -119,14 +119,16 @@
 
 (defrecord ToDateFunctionExpression [operand]
   core/Expression
-  (-eval [_ {:keys [now] :as context} resource scope]
-    (p/to-date (core/-eval operand context resource scope) now)))
+  (-eval [_ context resource scope]
+    (type/value (core/-eval operand context resource scope)))
+  (-form [_]
+    `(~'call "ToDate" ~(core/-form operand))))
 
 
 (defrecord ToDateTimeFunctionExpression [operand]
   core/Expression
   (-eval [_ {:keys [now] :as context} resource scope]
-    (p/to-date-time (core/-eval operand context resource scope) now))
+    (p/to-date-time (type/value (core/-eval operand context resource scope)) now))
   (-form [_]
     `(~'call "ToDateTime" ~(core/-form operand))))
 

--- a/modules/cql/src/blaze/elm/date_time.clj
+++ b/modules/cql/src/blaze/elm/date_time.clj
@@ -4,36 +4,22 @@
   Section numbers are according to
   https://cql.hl7.org/04-logicalspecification.html."
   (:require
-    [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.protocols :as p]
     [blaze.fhir.spec.type]
     [blaze.fhir.spec.type.system :as system]
     [java-time.api :as time])
   (:import
-    [blaze.fhir.spec.type OffsetInstant]
-    [blaze.fhir.spec.type.system DateTimeYear DateTimeYearMonth DateTimeYearMonthDay]
-    [java.time LocalDate LocalDateTime LocalTime OffsetDateTime Year YearMonth Instant]
+    [blaze.fhir.spec.type.system Date DateDate DateTime DateTimeDate DateTimeYear DateTimeYearMonth DateYear DateYearMonth]
+    [java.time DateTimeException LocalDateTime LocalTime OffsetDateTime]
     [java.time.temporal ChronoField ChronoUnit Temporal TemporalAccessor]))
 
 
 (set! *warn-on-reflection* true)
 
 
-(def min-year (system/date 1))
-(def date-time-min-year (system/date-time 1))
-(def min-year-month (system/date 1 1))
-(def date-time-min-year-month (system/date-time 1 1))
 (def min-date (system/date 1 1 1))
-(def date-time-min-date (system/date-time 1 1 1))
 (def min-date-time (system/date-time 1 1 1 0 0 0 0))
-
-
-(def max-year (system/date 9999))
-(def date-time-max-year (system/date-time 9999))
-(def max-year-month (system/date 9999 12))
-(def date-time-max-year-month (system/date-time 9999 12))
 (def max-date (system/date 9999 12 31))
-(def date-time-max-date (system/date-time 9999 12 31))
 (def max-date-time (system/date-time 9999 12 31 23 59 59 999))
 
 
@@ -172,17 +158,17 @@
 
 
 (extend-protocol PrecisionNum
-  Year
+  DateYear
   (precision-num [_] 0)
   DateTimeYear
   (precision-num [_] 0)
-  YearMonth
+  DateYearMonth
   (precision-num [_] 1)
   DateTimeYearMonth
   (precision-num [_] 1)
-  LocalDate
+  DateDate
   (precision-num [_] 2)
-  DateTimeYearMonthDay
+  DateTimeDate
   (precision-num [_] 2)
   LocalDateTime
   (precision-num [_] 6))
@@ -203,7 +189,7 @@
 
 ;; 12.3. Greater
 (extend-protocol p/Greater
-  Year
+  DateYear
   (greater [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
@@ -215,7 +201,7 @@
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
         (> cmp 0))))
 
-  YearMonth
+  DateYearMonth
   (greater [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
@@ -227,13 +213,13 @@
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
         (> cmp 0))))
 
-  LocalDate
+  DateDate
   (greater [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
         (> cmp 0))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (greater [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
@@ -255,7 +241,7 @@
 
 ;; 12.4. GreaterOrEqual
 (extend-protocol p/GreaterOrEqual
-  Year
+  DateYear
   (greater-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
@@ -267,7 +253,7 @@
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
         (>= cmp 0))))
 
-  YearMonth
+  DateYearMonth
   (greater-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
@@ -279,13 +265,13 @@
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
         (>= cmp 0))))
 
-  LocalDate
+  DateDate
   (greater-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
         (>= cmp 0))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (greater-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
@@ -307,7 +293,7 @@
 
 ;; 12.5. Less
 (extend-protocol p/Less
-  Year
+  DateYear
   (less [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
@@ -319,7 +305,7 @@
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
         (< cmp 0))))
 
-  YearMonth
+  DateYearMonth
   (less [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
@@ -331,13 +317,13 @@
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
         (< cmp 0))))
 
-  LocalDate
+  DateDate
   (less [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
         (< cmp 0))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (less [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
@@ -359,7 +345,7 @@
 
 ;; 12.6. LessOrEqual
 (extend-protocol p/LessOrEqual
-  Year
+  DateYear
   (less-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
@@ -371,7 +357,7 @@
       (when-let [cmp (compare-to-precision this other 0 (precision-num other))]
         (<= cmp 0))))
 
-  YearMonth
+  DateYearMonth
   (less-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
@@ -383,13 +369,13 @@
       (when-let [cmp (compare-to-precision this other 1 (precision-num other))]
         (<= cmp 0))))
 
-  LocalDate
+  DateDate
   (less-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
         (<= cmp 0))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (less-or-equal [this other]
     (when other
       (when-let [cmp (compare-to-precision this other 2 (precision-num other))]
@@ -412,48 +398,54 @@
 
 ;; 16. Arithmetic Operators
 
+(defmacro catch-date-time-error [& body]
+  `(try
+     ~@body
+     (catch DateTimeException ~'_)))
+
+
 ;; 16.2. Add
 (extend-protocol p/Add
-  Year
+  DateYear
   (add [this other]
     (if (instance? Period other)
-      (time/plus this (time/years (quot (:months other) 12)))
-      (throw (ex-info (str "Invalid RHS adding to Year. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusYears this (quot (:months other) 12)))
+      (throw (ex-info (str "Invalid RHS adding to DateYear. Expected Period but was `" (type other) "`.")
                       {:op :add :this this :other other}))))
 
   DateTimeYear
   (add [this other]
     (if (instance? Period other)
-      (time/plus this (time/years (quot (:months other) 12)))
-      (throw (ex-info (str "Invalid RHS adding to Year. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusYears this (quot (:months other) 12)))
+      (throw (ex-info (str "Invalid RHS adding to DateYear. Expected Period but was `" (type other) "`.")
                       {:op :add :this this :other other}))))
 
-  YearMonth
+  DateYearMonth
   (add [this other]
     (if (instance? Period other)
-      (time/plus this (time/months (:months other)))
-      (throw (ex-info (str "Invalid RHS adding to YearMonth. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusMonths this (:months other)))
+      (throw (ex-info (str "Invalid RHS adding to DateYearMonth. Expected Period but was `" (type other) "`.")
                       {:op :add :this this :other other}))))
 
   DateTimeYearMonth
   (add [this other]
     (if (instance? Period other)
-      (time/plus this (time/months (:months other)))
-      (throw (ex-info (str "Invalid RHS adding to YearMonth. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusMonths this (:months other)))
+      (throw (ex-info (str "Invalid RHS adding to DateYearMonth. Expected Period but was `" (type other) "`.")
                       {:op :add :this this :other other}))))
 
-  LocalDate
+  DateDate
   (add [this other]
     (if (instance? Period other)
-      (time/plus this (time/months (:months other)) (time/days (quot (:millis other) 86400000)))
-      (throw (ex-info (str "Invalid RHS adding to LocalDate. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (time/plus this (time/months (:months other)) (time/days (quot (:millis other) 86400000))))
+      (throw (ex-info (str "Invalid RHS adding to DateDate. Expected Period but was `" (type other) "`.")
                       {:op :add :this this :other other}))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (add [this other]
     (if (instance? Period other)
-      (time/plus this (time/months (:months other)) (time/days (quot (:millis other) 86400000)))
-      (throw (ex-info (str "Invalid RHS adding to LocalDate. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (time/plus this (time/months (:months other)) (time/days (quot (:millis other) 86400000))))
+      (throw (ex-info (str "Invalid RHS adding to DateDate. Expected Period but was `" (type other) "`.")
                       {:op :add :this this :other other}))))
 
   LocalDateTime
@@ -471,161 +463,93 @@
                       {:op :add :this this :other other})))))
 
 
-(defn- minimum-value-msg [x]
-  (format "Predecessor: argument `%s` is already the minimum value." x))
-
-
-(defn- minimum-value-anom [x]
-  (ba/incorrect (minimum-value-msg x)))
-
-
 ;; 16.18. Predecessor
 (extend-protocol p/Predecessor
-  Year
+  DateYear
   (predecessor [x]
-    (if (time/after? x min-year)
-      (.minusYears x 1)
-      (throw-anom (minimum-value-anom x))))
+    (catch-date-time-error (.plusYears x -1)))
 
   DateTimeYear
   (predecessor [x]
-    (if (time/after? x date-time-min-year)
-      (time/minus x (time/years 1))
-      (throw-anom (minimum-value-anom x))))
+    (catch-date-time-error (.plusYears x -1)))
 
-  YearMonth
+  DateYearMonth
   (predecessor [x]
-    (if (time/after? x min-year-month)
-      (.minusMonths x 1)
-      (throw-anom (minimum-value-anom x))))
+    (catch-date-time-error (.plusMonths x -1)))
 
   DateTimeYearMonth
   (predecessor [x]
-    (if (time/after? x date-time-min-year-month)
-      (time/minus x (time/months 1))
-      (throw-anom (minimum-value-anom x))))
+    (catch-date-time-error (.plusMonths x -1)))
 
-  LocalDate
+  DateDate
   (predecessor [x]
-    (if (time/after? x min-date)
-      (.minusDays x 1)
-      (throw-anom (minimum-value-anom x))))
+    (catch-date-time-error (.plusDays x -1)))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (predecessor [x]
-    (if (time/after? x date-time-min-date)
-      (time/minus x (time/days 1))
-      (throw-anom (minimum-value-anom x))))
+    (catch-date-time-error (.plusDays x -1)))
 
   LocalDateTime
   (predecessor [x]
-    (if (time/after? x min-date-time)
-      (.minusNanos x 1000000)
-      (throw-anom (minimum-value-anom x))))
+    (when (time/after? x min-date-time)
+      (.minusNanos x 1000000)))
 
   PrecisionLocalTime
   (predecessor [{:keys [local-time p-num] :as x}]
-    (if (p/greater x min-time)
-      (->PrecisionLocalTime (.minus ^LocalTime local-time 1 ^ChronoUnit (p-num->precision p-num)) p-num)
-      (throw-anom (minimum-value-anom x)))))
+    (when (p/greater x min-time)
+      (->PrecisionLocalTime (.minus ^LocalTime local-time 1 ^ChronoUnit (p-num->precision p-num)) p-num))))
 
 
 ;; 16.20. Subtract
-(defn- year-out-of-range-msg [result period year]
-  (format "Year %s out of range while subtracting the period %s from the year %s."
-          result period year))
-
-
-(defn year-out-of-range-ex-info [year period result]
-  (ex-info (year-out-of-range-msg result period year)
-           {:op :subtract :year year :period period}))
-
-
-(defn- year-month-out-of-range-msg [result period year-month]
-  (format "Year-month %s out of range while subtracting the period %s from the year-month %s."
-          result period year-month))
-
-
-(defn year-month-out-of-range-ex-info [year-month period result]
-  (ex-info (year-month-out-of-range-msg result period year-month)
-           {:op :subtract :year-month year-month :period period}))
-
-
-(defn- date-out-of-range-msg [result period date]
-  (format "Date %s out of range while subtracting the period %s from the date %s."
-          result period date))
-
-
-(defn date-out-of-range-ex-info [date period result]
-  (ex-info (date-out-of-range-msg result period date)
-           {:op :subtract :date date :period period}))
-
-
 (extend-protocol p/Subtract
-  Year
+  DateYear
   (subtract [this other]
     (if (instance? Period other)
-      (let [result (time/minus this (time/years (quot (:months other) 12)))]
-        (if (time/before? result min-year)
-          (throw (year-out-of-range-ex-info this other result))
-          result))
-      (throw (ex-info (str "Invalid RHS adding to Year. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusYears this (- (quot (:months other) 12))))
+      (throw (ex-info (str "Invalid RHS adding to DateYear. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
   DateTimeYear
   (subtract [this other]
     (if (instance? Period other)
-      (let [result (time/minus this (time/years (quot (:months other) 12)))]
-        (if (time/before? result date-time-min-year)
-          (throw (year-out-of-range-ex-info this other result))
-          result))
-      (throw (ex-info (str "Invalid RHS adding to Year. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusYears this (- (quot (:months other) 12))))
+      (throw (ex-info (str "Invalid RHS adding to DateYear. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
-  YearMonth
+  DateYearMonth
   (subtract [this other]
     (if (instance? Period other)
-      (let [result (time/minus this (time/months (:months other)))]
-        (if (time/before? result min-year-month)
-          (throw (year-month-out-of-range-ex-info this other result))
-          result))
-      (throw (ex-info (str "Invalid RHS adding to YearMonth. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusMonths this (- (:months other))))
+      (throw (ex-info (str "Invalid RHS adding to DateYearMonth. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
   DateTimeYearMonth
   (subtract [this other]
     (if (instance? Period other)
-      (let [result (time/minus this (time/months (:months other)))]
-        (if (time/before? result date-time-min-year-month)
-          (throw (year-month-out-of-range-ex-info this other result))
-          result))
-      (throw (ex-info (str "Invalid RHS adding to YearMonth. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error (.plusMonths this (- (:months other))))
+      (throw (ex-info (str "Invalid RHS adding to DateYearMonth. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
-  LocalDate
+  DateDate
   (subtract [this other]
     (if (instance? Period other)
-      (let [result (time/minus
-                     this
-                     (time/months (:months other))
-                     (time/days (quot (:millis other) 86400000)))]
-        (if (time/before? result min-date)
-          (throw (date-out-of-range-ex-info this other result))
-          result))
-      (throw (ex-info (str "Invalid RHS adding to LocalDate. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error
+        (time/minus
+          this
+          (time/months (:months other))
+          (time/days (quot (:millis other) 86400000))))
+      (throw (ex-info (str "Invalid RHS adding to DateDate. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (subtract [this other]
     (if (instance? Period other)
-      (let [result (time/minus
-                     this
-                     (time/months (:months other))
-                     (time/days (quot (:millis other) 86400000)))]
-        (if (time/before? result date-time-min-date)
-          (throw (date-out-of-range-ex-info this other result))
-          result))
-      (throw (ex-info (str "Invalid RHS adding to LocalDate. Expected Period but was `" (type other) "`.")
+      (catch-date-time-error
+        (time/minus
+          this
+          (time/months (:months other))
+          (time/days (quot (:millis other) 86400000))))
+      (throw (ex-info (str "Invalid RHS adding to DateDate. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
   LocalDateTime
@@ -634,9 +558,8 @@
       (let [result (-> this
                        (.minusMonths (:months other))
                        (.minusNanos (* (:millis other) 1000000)))]
-        (if (>= (.compareTo result min-date-time) 0)
-          result
-          (throw (ex-info "Out of range." {:op :subtract :this this :other other}))))
+        (when (>= (.compareTo result min-date-time) 0)
+          result))
       (throw (ex-info (str "Invalid RHS adding to LocalDateTime. Expected Period but was `" (type other) "`.")
                       {:op :subtract :this this :other other}))))
 
@@ -651,61 +574,39 @@
 
 ;; 16.15. Successor
 (extend-protocol p/Successor
-  Year
+  DateYear
   (successor [x]
-    (if (time/before? x max-year)
-      (.plusYears x 1)
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (catch-date-time-error (.plusYears x 1)))
 
   DateTimeYear
   (successor [x]
-    (if (time/before? x date-time-max-year)
-      (time/plus x (time/years 1))
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (catch-date-time-error (.plusYears x 1)))
 
-  YearMonth
+  DateYearMonth
   (successor [x]
-    (if (time/before? x max-year-month)
-      (.plusMonths x 1)
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (catch-date-time-error (.plusMonths x 1)))
 
   DateTimeYearMonth
   (successor [x]
-    (if (time/before? x date-time-max-year-month)
-      (time/plus x (time/months 1))
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (catch-date-time-error (.plusMonths x 1)))
 
-  LocalDate
+  DateDate
   (successor [x]
-    (if (time/before? x max-date)
-      (.plusDays x 1)
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (catch-date-time-error (.plusDays x 1)))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (successor [x]
-    (if (time/before? x date-time-max-date)
-      (time/plus x (time/days 1))
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (catch-date-time-error (.plusDays x 1)))
 
   LocalDateTime
   (successor [x]
-    (if (time/before? x max-date-time)
-      (.plusNanos x 1000000)
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x}))))
+    (when (time/before? x max-date-time)
+      (.plusNanos x 1000000)))
 
   PrecisionLocalTime
   (successor [{:keys [local-time p-num] :as x}]
-    (if (p/less x max-time)
-      (->PrecisionLocalTime (.plus ^LocalTime local-time 1 ^ChronoUnit (p-num->precision p-num)) p-num)
-      (throw (ex-info "Successor: argument is already the maximum value."
-                      {:x x})))))
+    (when (p/less x max-time)
+      (->PrecisionLocalTime (.plus ^LocalTime local-time 1 ^ChronoUnit (p-num->precision p-num)) p-num))))
 
 
 
@@ -713,18 +614,22 @@
 
 ;; 18.7. DateFrom
 (extend-protocol p/DateFrom
-  LocalDate
+  Date
   (date-from [x]
     x)
 
+  DateTime
+  (date-from [x]
+    (.toDate x))
+
   LocalDateTime
   (date-from [x]
-    (.toLocalDate x)))
+    (DateDate/fromLocalDate (.toLocalDate x))))
 
 
 ;; 18.9. DateTimeComponentFrom
 (extend-protocol p/DateTimeComponentFrom
-  Year
+  DateYear
   (date-time-component-from [x precision]
     (let [req-p-num (precision->p-num precision)]
       (when (<= req-p-num 0)
@@ -736,7 +641,7 @@
       (when (<= req-p-num 0)
         (get-chrono-field x req-p-num))))
 
-  YearMonth
+  DateYearMonth
   (date-time-component-from [x precision]
     (let [req-p-num (precision->p-num precision)]
       (when (<= req-p-num 1)
@@ -748,13 +653,13 @@
       (when (<= req-p-num 1)
         (get-chrono-field x req-p-num))))
 
-  LocalDate
+  DateDate
   (date-time-component-from [x precision]
     (let [req-p-num (precision->p-num precision)]
       (when (<= req-p-num 2)
         (get-chrono-field x req-p-num))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (date-time-component-from [x precision]
     (let [req-p-num (precision->p-num precision)]
       (when (<= req-p-num 2)
@@ -775,7 +680,7 @@
 
 ;; 18.10. DifferenceBetween
 (extend-protocol p/DifferenceBetween
-  Year
+  DateYear
   (difference-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 0 (precision-num other)))
@@ -787,7 +692,7 @@
       (when (<= (precision->p-num precision) (min 0 (precision-num other)))
         (.until this other precision))))
 
-  YearMonth
+  DateYearMonth
   (difference-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 1 (precision-num other)))
@@ -799,13 +704,13 @@
       (when (<= (precision->p-num precision) (min 1 (precision-num other)))
         (.until this other precision))))
 
-  LocalDate
+  DateDate
   (difference-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 2 (precision-num other)))
         (.until this other precision))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (difference-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 2 (precision-num other)))
@@ -833,7 +738,7 @@
 
 ;; 18.11. DurationBetween
 (extend-protocol p/DurationBetween
-  Year
+  DateYear
   (duration-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 0 (precision-num other)))
@@ -845,7 +750,7 @@
       (when (<= (precision->p-num precision) (min 0 (precision-num other)))
         (.until this other precision))))
 
-  YearMonth
+  DateYearMonth
   (duration-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 1 (precision-num other)))
@@ -857,13 +762,13 @@
       (when (<= (precision->p-num precision) (min 1 (precision-num other)))
         (.until this other precision))))
 
-  LocalDate
+  DateDate
   (duration-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 2 (precision-num other)))
         (.until this other precision))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (duration-between [this other precision]
     (when other
       (when (<= (precision->p-num precision) (min 2 (precision-num other)))
@@ -884,7 +789,7 @@
 
 ;; 18.14. SameAs
 (extend-protocol p/SameAs
-  Year
+  DateYear
   (same-as [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -902,7 +807,7 @@
             (= cmp 0)))
         (p/equal this other))))
 
-  YearMonth
+  DateYearMonth
   (same-as [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -920,7 +825,7 @@
             (= cmp 0)))
         (p/equal this other))))
 
-  LocalDate
+  DateDate
   (same-as [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -929,7 +834,7 @@
             (= cmp 0)))
         (p/equal this other))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (same-as [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -960,7 +865,7 @@
 
 ;; 18.15. SameOrBefore
 (extend-protocol p/SameOrBefore
-  Year
+  DateYear
   (same-or-before [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -978,7 +883,7 @@
             (<= cmp 0)))
         (p/less-or-equal this other))))
 
-  YearMonth
+  DateYearMonth
   (same-or-before [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -996,7 +901,7 @@
             (<= cmp 0)))
         (p/less-or-equal this other))))
 
-  LocalDate
+  DateDate
   (same-or-before [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -1005,7 +910,7 @@
             (<= cmp 0)))
         (p/less-or-equal this other))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (same-or-before [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -1036,7 +941,7 @@
 
 ;; 18.16. SameOrAfter
 (extend-protocol p/SameOrAfter
-  Year
+  DateYear
   (same-or-after [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -1054,7 +959,7 @@
             (>= cmp 0)))
         (p/greater-or-equal this other))))
 
-  YearMonth
+  DateYearMonth
   (same-or-after [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -1072,7 +977,7 @@
             (>= cmp 0)))
         (p/greater-or-equal this other))))
 
-  LocalDate
+  DateDate
   (same-or-after [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -1081,7 +986,7 @@
             (>= cmp 0)))
         (p/greater-or-equal this other))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (same-or-after [this other precision]
     (when other
       (if-let [p-num (some-> precision precision->p-num)]
@@ -1112,7 +1017,7 @@
 
 ;; 19.2. After
 (extend-protocol p/After
-  Year
+  DateYear
   (after [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1130,7 +1035,7 @@
             (> cmp 0))
           (p/greater this other)))))
 
-  YearMonth
+  DateYearMonth
   (after [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1148,7 +1053,7 @@
             (> cmp 0))
           (p/greater this other)))))
 
-  LocalDate
+  DateDate
   (after [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1157,7 +1062,7 @@
             (> cmp 0))
           (p/greater this other)))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (after [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1188,7 +1093,7 @@
 
 ;; 19.3. Before
 (extend-protocol p/Before
-  Year
+  DateYear
   (before [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1206,7 +1111,7 @@
             (< cmp 0))
           (p/less this other)))))
 
-  YearMonth
+  DateYearMonth
   (before [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1224,7 +1129,7 @@
             (< cmp 0))
           (p/less this other)))))
 
-  LocalDate
+  DateDate
   (before [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1233,7 +1138,7 @@
             (< cmp 0))
           (p/less this other)))))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (before [this other precision]
     (when other
       (let [p-num (some-> precision precision->p-num)]
@@ -1267,72 +1172,32 @@
 
 ;; 22.22. ToDate
 (extend-protocol p/ToDate
-  Year
+  Date
   (to-date [this _]
     this)
 
-  DateTimeYear
+  DateTime
   (to-date [this _]
-    (.-year this))
-
-  YearMonth
-  (to-date [this _]
-    this)
-
-  DateTimeYearMonth
-  (to-date [this _]
-    (.-year_month this))
-
-  LocalDate
-  (to-date [this _]
-    this)
-
-  DateTimeYearMonthDay
-  (to-date [this _]
-    (.-date this))
+    (.toDate this))
 
   LocalDateTime
   (to-date [this _]
-    (.toLocalDate this))
+    (DateDate/fromLocalDate (.toLocalDate this)))
 
   OffsetDateTime
   (to-date [this now]
     (-> (.withOffsetSameInstant this (.getOffset ^OffsetDateTime now))
-        (.toLocalDate))))
+        (.toLocalDate)
+        (DateDate/fromLocalDate))))
 
 
 ;; 22.23. ToDateTime
 (extend-protocol p/ToDateTime
-  Instant
-  (to-date-time [this now]
-    (-> (.atOffset this (.getOffset ^OffsetDateTime now))
-        (.toLocalDateTime)))
-
-  OffsetInstant
-  (to-date-time [this now]
-    (p/to-date-time (.value this) now))
-
-  Year
+  Date
   (to-date-time [this _]
-    (DateTimeYear. this))
+    (.toDateTime this))
 
-  DateTimeYear
-  (to-date-time [this _]
-    this)
-
-  YearMonth
-  (to-date-time [this _]
-    (DateTimeYearMonth. this))
-
-  DateTimeYearMonth
-  (to-date-time [this _]
-    this)
-
-  LocalDate
-  (to-date-time [this _]
-    (DateTimeYearMonthDay. this))
-
-  DateTimeYearMonthDay
+  DateTime
   (to-date-time [this _]
     this)
 
@@ -1352,7 +1217,7 @@
   (to-string [{:keys [local-time]}]
     (str local-time))
 
-  Year
+  DateYear
   (to-string [x]
     (str x))
 
@@ -1360,7 +1225,7 @@
   (to-string [x]
     (str x))
 
-  YearMonth
+  DateYearMonth
   (to-string [x]
     (str x))
 
@@ -1368,11 +1233,11 @@
   (to-string [x]
     (str x))
 
-  LocalDate
+  DateDate
   (to-string [x]
     (str x))
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (to-string [x]
     (str x))
 
@@ -1398,4 +1263,4 @@
 
   PrecisionLocalTime
   (to-time [this _]
-   (.-local_time this)))
+    (.-local_time this)))

--- a/modules/cql/src/blaze/elm/decimal.clj
+++ b/modules/cql/src/blaze/elm/decimal.clj
@@ -210,23 +210,13 @@
           check-overflow))))
 
 
-(defn- minimum-value-msg [x]
-  (format "Predecessor: argument `%s` is already the minimum value." x))
-
-
-(defn- minimum-value-anom [x]
-  (ba/incorrect (minimum-value-msg x)))
-
-
 ;; 16.18. Predecessor
 (extend-protocol p/Predecessor
   BigDecimal
   (predecessor [x]
     (let [x (.subtract x min-step-size)]
-      (if (within-bounds? x)
-        x
-        ;; TODO: throwing an exception this is inconsistent with subtract
-        (throw-anom (minimum-value-anom x))))))
+      (when (within-bounds? x)
+        x))))
 
 
 ;; 16.19. Round
@@ -253,11 +243,8 @@
   BigDecimal
   (successor [x]
     (let [x (.add x min-step-size)]
-      (if (within-bounds? x)
-        x
-        ;; TODO: throwing an exception this is inconsistent with add
-        (throw (ex-info "Successor: argument is already the maximum value."
-                        {:x x}))))))
+      (when (within-bounds? x)
+        x))))
 
 
 ;; 16.22. Truncate

--- a/modules/cql/src/blaze/elm/protocols.clj
+++ b/modules/cql/src/blaze/elm/protocols.clj
@@ -274,7 +274,7 @@
 (defprotocol ToDate
   "Converts an object into something usable as Date relative to `now`.
 
-  Converts OffsetDateTime and Instant to LocalDate so that we can compare
+  Converts OffsetDateTime to LocalDate so that we can compare
   temporal fields directly."
   (to-date [x now]))
 
@@ -283,7 +283,7 @@
 (defprotocol ToDateTime
   "Converts an object into something usable as DateTime relative to `now`.
 
-  Converts OffsetDateTime and Instant to LocalDateTime so that we can compare
+  Converts OffsetDateTime to LocalDateTime so that we can compare
   temporal fields directly.
 
   Returns nil if not convertable."

--- a/modules/cql/src/blaze/elm/quantity.clj
+++ b/modules/cql/src/blaze/elm/quantity.clj
@@ -175,8 +175,8 @@
 (extend-protocol p/Predecessor
   Quantity
   (predecessor [x]
-    (Quantities/getQuantity ^Number (p/predecessor (p/to-decimal (.getValue x)))
-                            (.getUnit x))))
+    (when-let [value (p/predecessor (p/to-decimal (.getValue x)))]
+      (Quantities/getQuantity ^Number value (.getUnit x)))))
 
 
 ;; 16.20. Subtract
@@ -190,8 +190,8 @@
 (extend-protocol p/Successor
   Quantity
   (successor [x]
-    (Quantities/getQuantity ^Number (p/successor (p/to-decimal (.getValue x)))
-                            (.getUnit x))))
+    (when-let [value (p/successor (p/to-decimal (.getValue x)))]
+      (Quantities/getQuantity ^Number value (.getUnit x)))))
 
 
 

--- a/modules/cql/src/blaze/elm/string.clj
+++ b/modules/cql/src/blaze/elm/string.clj
@@ -51,15 +51,14 @@
 (extend-protocol p/ToDate
   String
   (to-date [s _]
-    (-> (system/parse-date s)
-        (ba/exceptionally (constantly nil)))))
+    (ba/ignore (system/parse-date s))))
 
 
 ;; 22.23. ToDateTime
 (extend-protocol p/ToDateTime
   String
   (to-date-time [s now]
-    (p/to-date-time (system/parse-date-time s) now)))
+    (p/to-date-time (ba/ignore (system/parse-date-time s)) now)))
 
 
 ;; 22.24. ToDecimal

--- a/modules/cql/test/blaze/cql_test.clj
+++ b/modules/cql/test/blaze/cql_test.clj
@@ -202,6 +202,11 @@
             "HighBoundaryDateTimeMillisecond"               ; TODO: implement
             "HighBoundaryDateMonth"                         ; TODO: implement
             "HighBoundaryDecimal"                           ; TODO: implement
+
+            "PredecessorUnderflowDt"                        ; is nil
+            "PredecessorUnderflowT"                         ; is nil
+            "SuccessorOverflowDt"                           ; is nil
+            "SuccessorOverflowT"                            ; is nil
             })
 
 
@@ -258,6 +263,7 @@
             "DateTimeDurationBetweenMonthUncertain7"        ; TODO: implement uncertainty
 
             "TimeDurationBetweenHourDiffPrecision"          ; new in v1.4.6
+            "DateTimeSubtractInvalidYears"                  ; is nil
             })
 
 

--- a/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
@@ -56,17 +56,26 @@
 ;; For the DateTime overload, the result is the number of whole calendar periods
 ;; that have elapsed between the first datetime and the second datetime.
 (deftest compile-calculate-age-at-test
-  (testing "Year"
+  (testing "Static"
     (are [elm res] (= res (core/-eval (c/compile {} elm) {:now tu/now} nil nil))
-      #elm/calculate-age-at [#elm/date "2018" #elm/date "2019" "year"]
-      1
-      #elm/calculate-age-at [#elm/date "2018" #elm/date "2018" "year"]
-      0
+      #elm/calculate-age-at [#elm/date"2018" #elm/date"2019" "year"] 1
+      #elm/calculate-age-at [#elm/date"2018" #elm/date"2018" "year"] 0
+      #elm/calculate-age-at [#elm/date"2018" #elm/date"2019" "month"] nil
 
-      #elm/calculate-age-at [#elm/date "2018" #elm/date "2018" "month"]
-      nil))
+      #elm/calculate-age-at [#elm/date"2018-01" #elm/date"2019-02" "year"] 1
+      #elm/calculate-age-at [#elm/date"2018-01" #elm/date"2018-12" "year"] 0
+      #elm/calculate-age-at [#elm/date"2018-01" #elm/date"2018-12" "month"] 11
+      #elm/calculate-age-at [#elm/date"2018-01" #elm/date"2018-12" "day"] nil
 
-  (tu/testing-binary-null elm/calculate-age-at #elm/date "2018")
+      #elm/calculate-age-at [#elm/date"2018-01-01" #elm/date"2019-02-02" "year"] 1
+      #elm/calculate-age-at [#elm/date"2018-01" #elm/date"2018-12-15" "year"] 0
+      #elm/calculate-age-at [#elm/date"2018-01-01" #elm/date"2018-12-02" "month"] 11
+      #elm/calculate-age-at [#elm/date"2018-01-01" #elm/date"2018-02-01" "day"] 31
+
+      #elm/calculate-age-at [#elm/date-time"2018-01-01" #elm/date-time"2018-02-01" "day"] 31))
+
+  (tu/testing-binary-null elm/calculate-age-at #elm/date"2018")
+  (tu/testing-binary-null elm/calculate-age-at #elm/date-time"2018-01-01")
 
   (tu/testing-binary-precision-form elm/calculate-age-at "year" "month" "day"))
 

--- a/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
@@ -168,7 +168,7 @@
 
       [#elm/integer "1" {:type "Null"}] [#elm/integer "1" {:type "Null"}] nil
       [{:type "Null"}] [{:type "Null"}] nil
-      [#elm/date "2019"] [#elm/date "2019-01"] nil)
+      [#elm/date"2019"] [#elm/date"2019-01"] nil)
 
     (tu/testing-binary-null elm/equal #elm/list []))
 
@@ -185,7 +185,7 @@
       "2012" "2013" false
       "2013" "2012" false)
 
-    (tu/testing-binary-null elm/equal #elm/date "2013"))
+    (tu/testing-binary-null elm/equal #elm/date"2013"))
 
   (testing "Date with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -193,7 +193,7 @@
       "2013-01" "2013-02" false
       "2013-02" "2013-01" false)
 
-    (tu/testing-binary-null elm/equal #elm/date "2013-01"))
+    (tu/testing-binary-null elm/equal #elm/date"2013-01"))
 
   (testing "Date with full precision"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -201,7 +201,7 @@
       "2013-01-01" "2013-01-02" false
       "2013-01-02" "2013-01-01" false)
 
-    (tu/testing-binary-null elm/equal #elm/date "2013-01-01"))
+    (tu/testing-binary-null elm/equal #elm/date"2013-01-01"))
 
   (testing "Date with differing precisions"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/date x y))
@@ -219,7 +219,7 @@
 
       "2013-01-01T00" "2013-01-01T00:00:00" true)
 
-    (tu/testing-binary-null elm/equal #elm/date-time "2013-01-01"))
+    (tu/testing-binary-null elm/equal #elm/date-time"2013-01-01"))
 
   (testing "Time"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/time x y))
@@ -406,7 +406,7 @@
       #elm/list [#elm/integer "1" {:type "Null"}]
       #elm/list [#elm/integer "1" {:type "Null"}] true
       #elm/list [{:type "Null"}] #elm/list [{:type "Null"}] true
-      #elm/list [#elm/date "2019"] #elm/list [#elm/date "2019-01"] false
+      #elm/list [#elm/date"2019"] #elm/list [#elm/date"2019-01"] false
 
       {:type "Null"} #elm/list [] false
       #elm/list [] {:type "Null"} false))
@@ -495,28 +495,28 @@
       "2014" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/greater #elm/date "2013"))
+    (tu/testing-binary-null elm/greater #elm/date"2013"))
 
   (testing "DateTime with year precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date-time x y))
       "2014" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/greater #elm/date-time "2013"))
+    (tu/testing-binary-null elm/greater #elm/date-time"2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date-time x y))
       "2013-07" "2013-06" true
       "2013-06" "2013-06" false)
 
-    (tu/testing-binary-null elm/greater #elm/date-time "2013-06"))
+    (tu/testing-binary-null elm/greater #elm/date-time"2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date-time x y))
       "2013-06-16" "2013-06-15" true
       "2013-06-15" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/greater #elm/date-time "2013-06-15"))
+    (tu/testing-binary-null elm/greater #elm/date-time"2013-06-15"))
 
   (testing "Comparing dates with mixed precisions (year and year-month) results in null."
     (are [x y res] (= res (tu/compile-binop elm/greater elm/date x y))
@@ -589,7 +589,7 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-14" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013-06-15"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013-06-15"))
 
   (testing "DateTime with year precision"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -597,7 +597,7 @@
       "2013" "2013" true
       "2012" "2013" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -605,7 +605,7 @@
       "2013-06" "2013-06" true
       "2013-05" "2013-06" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013-06"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -613,7 +613,7 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-14" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/greater-or-equal #elm/date "2013-06-15"))
+    (tu/testing-binary-null elm/greater-or-equal #elm/date"2013-06-15"))
 
   (testing "DateTime with mixed precision"
     (are [x y] (nil? (tu/compile-binop elm/greater-or-equal elm/date-time x y))
@@ -696,7 +696,7 @@
       "2012" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/less #elm/date "2013"))
+    (tu/testing-binary-null elm/less #elm/date"2013"))
 
   (testing "Comparing dates with mixed precisions (year and year-month) results in null."
     (are [x y res] (= res (tu/compile-binop elm/less elm/date x y))
@@ -708,7 +708,7 @@
       "2013-06-14" "2013-06-15" true
       "2013-06-15" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less #elm/date "2013-06-15"))
+    (tu/testing-binary-null elm/less #elm/date"2013-06-15"))
 
   (testing "Comparing dates with mixed precisions (year-month and full) results in null."
     (are [x y res] (= res (tu/compile-binop elm/less elm/date x y))
@@ -720,28 +720,28 @@
       "2012" "2013" true
       "2013" "2013" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time "2013"))
+    (tu/testing-binary-null elm/less #elm/date-time"2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/less elm/date-time x y))
       "2013-05" "2013-06" true
       "2013-06" "2013-06" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time "2013-06"))
+    (tu/testing-binary-null elm/less #elm/date-time"2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/less elm/date-time x y))
       "2013-06-14" "2013-06-15" true
       "2013-06-15" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time "2013-06-15"))
+    (tu/testing-binary-null elm/less #elm/date-time"2013-06-15"))
 
   (testing "DateTime with full precision (there is only one precision)"
     (are [x y res] (= res (tu/compile-binop elm/less elm/date-time x y))
       "2013-06-15T11" "2013-06-15T12" true
       "2013-06-15T12" "2013-06-15T12" false)
 
-    (tu/testing-binary-null elm/less #elm/date-time "2013-06-15T12"))
+    (tu/testing-binary-null elm/less #elm/date-time"2013-06-15T12"))
 
   (testing "Time with full precision (there is only one precision)"
     (are [x y res] (= res (tu/compile-binop elm/less elm/time x y))
@@ -814,12 +814,12 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-16" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date "2013-06-15"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date"2013-06-15"))
 
   (testing "Mixed Date and DateTime"
     (are [x y res] (= res (c/compile {} (elm/less-or-equal [x y])))
-      #elm/date "2013-06-15" #elm/date-time "2013-06-15T00" nil
-      #elm/date-time "2013-06-15T00" #elm/date "2013-06-15" nil))
+      #elm/date"2013-06-15" #elm/date-time"2013-06-15T00" nil
+      #elm/date-time"2013-06-15T00" #elm/date"2013-06-15" nil))
 
   (testing "DateTime with year precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date-time x y))
@@ -827,7 +827,7 @@
       "2013" "2013" true
       "2014" "2013" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date "2013"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date"2013"))
 
   (testing "DateTime with year-month precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date-time x y))
@@ -835,7 +835,7 @@
       "2013-06" "2013-06" true
       "2013-07" "2013-06" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date "2013-06"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date"2013-06"))
 
   (testing "DateTime with date precision"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/date-time x y))
@@ -843,7 +843,7 @@
       "2013-06-15" "2013-06-15" true
       "2013-06-16" "2013-06-15" false)
 
-    (tu/testing-binary-null elm/less-or-equal #elm/date "2013-06-15"))
+    (tu/testing-binary-null elm/less-or-equal #elm/date"2013-06-15"))
 
   (testing "Time"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/time x y))

--- a/modules/cql/test/blaze/elm/compiler/interval_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/interval_operators_test.clj
@@ -12,7 +12,6 @@
     [blaze.elm.interval :refer [interval]]
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
-    [blaze.fhir.spec.type.system :as system]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest testing]]))
 
@@ -78,15 +77,15 @@
 
     (testing "Date"
       (are [s e res] (= res (tu/compile-binop elm/closed-interval elm/date s e))
-        "2020" "2021" (interval (system/date 2020) (system/date 2021))))
+        "2020" "2021" (interval #system/date"2020" #system/date"2021")))
 
     (testing "DateTime"
       (are [s e res] (= res (tu/compile-binop elm/closed-interval elm/date-time s e))
-        "2020" "2021" (interval (system/date-time 2020) (system/date-time 2021)))
+        "2020" "2021" (interval #system/date-time"2020" #system/date-time"2021"))
 
       (testing "with ToDateTime"
         (are [s e res] (= res (c/compile {} (elm/closed-interval [(elm/to-date-time (elm/date s)) (elm/date-time e)])))
-          "2020" "2021" (interval (system/date-time 2020) (system/date-time 2021)))))
+          "2020" "2021" (interval #system/date-time"2020" #system/date-time"2021"))))
 
     (are [elm res] (= res (c/compile {} elm))
       #elm/interval [:< #elm/as ["{urn:hl7-org:elm-types:r1}Integer" {:type "Null"}]
@@ -205,9 +204,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/after #elm/date "2019")
-    (tu/testing-binary-null elm/after #elm/date "2019-04")
-    (tu/testing-binary-null elm/after #elm/date "2019-04-17")
+    (tu/testing-binary-null elm/after #elm/date"2019")
+    (tu/testing-binary-null elm/after #elm/date"2019-04")
+    (tu/testing-binary-null elm/after #elm/date"2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/after elm/date x y "year"))
@@ -233,9 +232,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-18" false)
 
-    (tu/testing-binary-null elm/after #elm/date-time "2019")
-    (tu/testing-binary-null elm/after #elm/date-time "2019-04")
-    (tu/testing-binary-null elm/after #elm/date-time "2019-04-17")
+    (tu/testing-binary-null elm/after #elm/date-time"2019")
+    (tu/testing-binary-null elm/after #elm/date-time"2019-04")
+    (tu/testing-binary-null elm/after #elm/date-time"2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/after elm/date-time
@@ -341,9 +340,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-16" false)
 
-    (tu/testing-binary-null elm/before #elm/date "2019")
-    (tu/testing-binary-null elm/before #elm/date "2019-04")
-    (tu/testing-binary-null elm/before #elm/date "2019-04-17")
+    (tu/testing-binary-null elm/before #elm/date"2019")
+    (tu/testing-binary-null elm/before #elm/date"2019-04")
+    (tu/testing-binary-null elm/before #elm/date"2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/before elm/date x y
@@ -370,9 +369,9 @@
       "2019-04-17" "2019-04-17" false
       "2019-04-17" "2019-04-16" false)
 
-    (tu/testing-binary-null elm/before #elm/date-time "2019")
-    (tu/testing-binary-null elm/before #elm/date-time "2019-04")
-    (tu/testing-binary-null elm/before #elm/date-time "2019-04-17")
+    (tu/testing-binary-null elm/before #elm/date-time"2019")
+    (tu/testing-binary-null elm/before #elm/date-time"2019-04")
+    (tu/testing-binary-null elm/before #elm/date-time"2019-04-17")
 
     (testing "with year precision"
       (are [x y res] (= res (tu/compile-binop-precision elm/before elm/date-time
@@ -440,10 +439,10 @@
 
   (testing "DateTime"
     (are [source per res] (= res (core/-eval (c/compile {} (elm/collapse [source per])) {} nil nil))
-      #elm/list [#elm/interval [#elm/date-time "2012-01-01" #elm/date-time "2012-01-15"]
-                #elm/interval [#elm/date-time "2012-01-16" #elm/date-time "2012-05-25"]]
+      #elm/list [#elm/interval [#elm/date-time"2012-01-01" #elm/date-time"2012-01-15"]
+                #elm/interval [#elm/date-time"2012-01-16" #elm/date-time"2012-05-25"]]
       {:type "Null"}
-      [(interval (system/date-time 2012 1 1) (system/date-time 2012 5 25))]))
+      [(interval #system/date-time"2012-01-01" #system/date-time"2012-05-25")]))
 
   (tu/testing-binary-form elm/collapse))
 
@@ -487,7 +486,7 @@
 
       #elm/list [#elm/quantity [1 "m"]] #elm/quantity [100 "cm"] true
 
-      #elm/list [#elm/date "2019"] #elm/date "2019-01" false)
+      #elm/list [#elm/date"2019"] #elm/date"2019-01" false)
 
     (tu/testing-binary-null elm/contains #elm/list [] #elm/integer "1"))
 

--- a/modules/cql/test/blaze/elm/compiler/library_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/library_test.clj
@@ -5,7 +5,7 @@
     [blaze.elm.compiler :as compiler]
     [blaze.elm.compiler.library :as library]
     [blaze.elm.compiler.library-spec]
-    [blaze.fhir.spec.type.system :as system]
+    [blaze.fhir.spec.type.system]
     [blaze.test-util :refer [with-system]]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [deftest testing]]
@@ -134,8 +134,8 @@
     parameter \"Measurement Period\" Interval<Date> default Interval[@2020-01-01, @2020-12-31]")]
       (with-system [{:blaze.db/keys [node]} mem-node-system]
         (given (library/compile-library node library {})
-          [:parameter-default-values "Measurement Period" :start] := (system/date 2020 1 1)
-          [:parameter-default-values "Measurement Period" :end] := (system/date 2020 12 31)))))
+          [:parameter-default-values "Measurement Period" :start] := #system/date"2020-01-01"
+          [:parameter-default-values "Measurement Period" :end] := #system/date"2020-12-31"))))
 
   (testing "with invalid parameter default"
     (let [library (t/translate "library Test

--- a/modules/cql/test/blaze/elm/compiler/reusing_logic_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/reusing_logic_test.clj
@@ -134,6 +134,22 @@
       (testing "form"
         (is (= '(call "ToQuantity" (param-ref "x")) (core/-form expr))))))
 
+  (testing "ToDate"
+    (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}
+          elm #elm/function-ref ["ToDate" #elm/parameter-ref "x"]
+          expr (c/compile compile-ctx elm)
+          eval-ctx (fn [x] {:now tu/now :parameters {"x" x}})]
+      (testing "eval"
+        (are [x res] (= res (core/-eval expr (eval-ctx x) nil nil))
+          #fhir/date{:id "foo"} nil
+          #fhir/date{:extension [#fhir/Extension{:url "foo"}]} nil
+          #fhir/date"2023" #system/date"2023"
+          #fhir/date"2023-05" #system/date"2023-05"
+          #fhir/date"2023-05-07" #system/date"2023-05-07"))
+
+      (testing "form"
+        (is (= '(call "ToDate" (param-ref "x")) (core/-form expr))))))
+
   (testing "ToDateTime"
     (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}
           elm #elm/function-ref ["ToDateTime" #elm/parameter-ref "x"]
@@ -141,12 +157,17 @@
           eval-ctx (fn [x] {:now tu/now :parameters {"x" x}})]
       (testing "eval"
         (are [x res] (= res (core/-eval expr (eval-ctx x) nil nil))
-          #fhir/dateTime"2022-02-22"
-          (system/date-time 2022 2 22)
-          #fhir/instant"2021-02-23T15:12:45Z"
-          (system/date-time 2021 2 23 15 12 45)
-          #fhir/instant"2021-02-23T15:12:45+01:00"
-          (system/date-time 2021 2 23 14 12 45)))
+          #fhir/dateTime{:id "foo"} nil
+          #fhir/dateTime{:extension [#fhir/Extension{:url "foo"}]} nil
+          #fhir/dateTime"2022" #system/date-time"2022"
+          #fhir/dateTime"2022-02" #system/date-time"2022-02"
+          #fhir/dateTime"2022-02-22" #system/date-time"2022-02-22"
+          #fhir/dateTime"2023-05-07T17:39" #system/date-time"2023-05-07T17:39"
+
+          #fhir/instant{:id "foo"} nil
+          #fhir/instant{:extension [#fhir/Extension{:url "foo"}]} nil
+          #fhir/instant"2021-02-23T15:12:45Z" #system/date-time"2021-02-23T15:12:45"
+          #fhir/instant"2021-02-23T15:12:45+01:00" #system/date-time"2021-02-23T14:12:45"))
 
       (testing "form"
         (is (= '(call "ToDateTime" (param-ref "x")) (core/-form expr))))))

--- a/modules/cql/test/blaze/elm/compiler/test_util.clj
+++ b/modules/cql/test/blaze/elm/compiler/test_util.clj
@@ -163,6 +163,15 @@
   (c/compile {} (constructor [(op-constructor op-1) (op-constructor op-2) precision])))
 
 
+(defmacro testing-constant-form [elm-constructor]
+  (let [form-name (symbol (name elm-constructor))]
+    `(testing "form"
+       (let [compile-ctx# {:library {:parameters {:def [{:name "x"}]}}}
+             elm# ~elm-constructor
+             expr# (c/compile compile-ctx# elm#)]
+         (is (= (quote ~form-name) (core/-form expr#)))))))
+
+
 (defmacro testing-unary-form [elm-constructor]
   (let [form-name (symbol (name elm-constructor))]
     `(testing "form"

--- a/modules/cql/test/blaze/elm/compiler/type_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/type_operators_test.clj
@@ -115,7 +115,7 @@
       #elm/as ["{urn:hl7-org:elm-types:r1}Integer" {:type "Null"}]
       nil
 
-      #elm/as ["{urn:hl7-org:elm-types:r1}DateTime" #elm/date-time "2019-09-04"]
+      #elm/as ["{urn:hl7-org:elm-types:r1}DateTime" #elm/date-time"2019-09-04"]
       (system/date-time 2019 9 4)))
 
   (testing "form"
@@ -1058,9 +1058,9 @@
 
       #elm/is ["{urn:hl7-org:elm-types:r1}String" #elm/string "foo"]
 
-      #elm/is ["{urn:hl7-org:elm-types:r1}Date" #elm/date "2020-03-08"]
+      #elm/is ["{urn:hl7-org:elm-types:r1}Date" #elm/date"2020-03-08"]
 
-      #elm/is ["{urn:hl7-org:elm-types:r1}DateTime" #elm/date-time "2019-09-04"])
+      #elm/is ["{urn:hl7-org:elm-types:r1}DateTime" #elm/date-time"2019-09-04"])
 
     (are [elm] (false? (core/-eval (c/compile {} elm) {} nil nil))
       #elm/is ["{urn:hl7-org:elm-types:r1}Boolean" #elm/integer "1"]
@@ -1081,7 +1081,7 @@
       #elm/is ["{urn:hl7-org:elm-types:r1}String" #elm/decimal "-1.1"]
       #elm/is ["{urn:hl7-org:elm-types:r1}String" {:type "Null"}]
 
-      #elm/is ["{urn:hl7-org:elm-types:r1}Date" #elm/date-time "2020-03-08"]
+      #elm/is ["{urn:hl7-org:elm-types:r1}Date" #elm/date-time"2020-03-08"]
       #elm/is ["{urn:hl7-org:elm-types:r1}Date" {:type "Null"}]
 
       #elm/is ["{urn:hl7-org:elm-types:r1}DateTime" #elm/string "2019-09-04"]
@@ -1303,9 +1303,9 @@
   (let [eval #(core/-eval % {:now tu/now} nil nil)]
     (testing "String"
       (are [x res] (= res (eval (tu/compile-unop elm/to-date elm/string x)))
-        "2019" (system/date 2019)
-        "2019-01" (system/date 2019 1)
-        "2019-01-01" (system/date 2019 1 1)
+        "2019" #system/date"2019"
+        "2019-01" #system/date"2019-01"
+        "2019-01-01" #system/date"2019-01-01"
 
         "aaaa" nil
         "2019-13" nil
@@ -1313,16 +1313,32 @@
 
     (testing "Date"
       (are [x res] (= res (eval (tu/compile-unop elm/to-date elm/date x)))
-        "2019" (system/date 2019)
-        "2019-01" (system/date 2019 1)
-        "2019-01-01" (system/date 2019 1 1)))
+        "2019" #system/date"2019"
+        "2019-01" #system/date"2019-01"
+        "2019-01-01" #system/date"2019-01-01"))
 
     (testing "DateTime"
       (are [x res] (= res (eval (tu/compile-unop elm/to-date elm/date-time x)))
-        "2019" (system/date 2019)
-        "2019-01" (system/date 2019 1)
-        "2019-01-01" (system/date 2019 1 1)
-        "2019-01-01T12:13" (system/date 2019 1 1))))
+        "2019" #system/date"2019"
+        "2019-01" #system/date"2019-01"
+        "2019-01-01" #system/date"2019-01-01"
+        "2019-01-01T12:13" #system/date"2019-01-01"
+        "2019-01-01T12:13:14" #system/date"2019-01-01"
+        "2019-01-01T12:13:14.000-01:00" #system/date"2019-01-01")
+
+      (testing "dynamic"
+        (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}
+              elm #elm/to-date #elm/parameter-ref "x"
+              expr (c/compile compile-ctx elm)
+              eval-ctx (fn [x] {:now tu/now :parameters {"x" x}})]
+          (are [date-time date] (= date (core/-eval expr (eval-ctx date-time) nil nil))
+            #system/date-time"2023" #system/date"2023"
+            #system/date-time"2023-05" #system/date"2023-05"
+            #system/date-time"2023-05-07" #system/date"2023-05-07"
+            #system/date-time"2023-05-07T16" #system/date"2023-05-07"
+            #system/date-time"2023-05-07T16:07" #system/date"2023-05-07"
+            #system/date-time"2023-05-07T16:07:00" #system/date"2023-05-07"
+            #system/date-time"2023-05-07T16:07:00+02:00" #system/date"2023-05-07")))))
 
   (tu/testing-unary-null elm/to-date))
 
@@ -1355,9 +1371,9 @@
   (let [eval #(core/-eval % {:now tu/now} nil nil)]
     (testing "String"
       (are [x res] (= res (eval (tu/compile-unop elm/to-date-time elm/string x)))
-        "2020" (system/date-time 2020)
-        "2020-03" (system/date-time 2020 3)
-        "2020-03-08" (system/date-time 2020 3 8)
+        "2020" #system/date-time"2020"
+        "2020-03" #system/date-time"2020-03"
+        "2020-03-08" #system/date-time"2020-03-08"
         "2020-03-08T12:54:00" (system/date-time 2020 3 8 12 54)
         "2020-03-08T12:54:00+00:00" (system/date-time 2020 3 8 12 54)
         "2020-03-08T12:54:00+01:00" (system/date-time 2020 3 8 11 54)
@@ -1369,16 +1385,16 @@
     (testing "Date"
       (testing "Static"
         (are [x res] (= res (tu/compile-unop elm/to-date-time elm/date x))
-          "2020" (system/date-time 2020)
-          "2020-03" (system/date-time 2020 3)
-          "2020-03-08" (system/date-time 2020 3 8))))
+          "2020" #system/date-time"2020"
+          "2020-03" #system/date-time"2020-03"
+          "2020-03-08" #system/date-time"2020-03-08")))
 
     (testing "DateTime"
       (are [x res] (= res (eval (tu/compile-unop elm/to-date-time elm/date-time x)))
-        "2020" (system/date-time 2020)
-        "2020-03" (system/date-time 2020 3)
-        "2020-03-08" (system/date-time 2020 3 8)
-        "2020-03-08T12:13" (system/date-time 2020 3 8 12 13))))
+        "2020" #system/date-time"2020"
+        "2020-03" #system/date-time"2020-03"
+        "2020-03-08" #system/date-time"2020-03-08"
+        "2020-03-08T12:13" #system/date-time"2020-03-08T12:13")))
 
   (tu/testing-unary-null elm/to-date-time)
 

--- a/modules/cql/test/blaze/elm/literal.clj
+++ b/modules/cql/test/blaze/elm/literal.clj
@@ -481,7 +481,7 @@
    :operand op})
 
 
-;; 18.7. DateTime
+;; 18.8. DateTime
 (defn date-time [arg]
   (if (string? arg)
     (date-time (map integer (str/split arg #"[-T:.]")))
@@ -497,21 +497,6 @@
         second (assoc :second second)
         millisecond (assoc :millisecond millisecond)
         timezone-offset (assoc :timezoneOffset timezone-offset)))))
-
-
-;; 18.18. Time
-(defn time [arg]
-  (if (string? arg)
-    (time (map integer (str/split (if (.contains ^String arg ".")
-                                    (subs (str arg "000") 0 12)
-                                    arg) #"[:.]")))
-    (let [[hour minute second millisecond] arg]
-      (cond->
-        {:type "Time"
-         :hour hour}
-        minute (assoc :minute minute)
-        second (assoc :second second)
-        millisecond (assoc :millisecond millisecond)))))
 
 
 ;; 18.9. DateTimeComponentFrom
@@ -533,6 +518,26 @@
   {:type "DurationBetween"
    :operand [x y]
    :precision precision})
+
+
+;; 18.18. Time
+(defn time [arg]
+  (if (string? arg)
+    (time (map integer (str/split (if (.contains ^String arg ".")
+                                    (subs (str arg "000") 0 12)
+                                    arg) #"[:.]")))
+    (let [[hour minute second millisecond] arg]
+      (cond->
+        {:type "Time"
+         :hour hour}
+        minute (assoc :minute minute)
+        second (assoc :second second)
+        millisecond (assoc :millisecond millisecond)))))
+
+
+;; 18.22. Today
+(def today
+  {:type "Today"})
 
 
 ;; 19.1. Interval

--- a/modules/db/test/blaze/db/node/resource_indexer_test.clj
+++ b/modules/db/test/blaze/db/node/resource_indexer_test.clj
@@ -33,7 +33,7 @@
     [integrant.core :as ig]
     [taoensso.timbre :as log])
   (:import
-    [java.time Instant LocalDate]))
+    [java.time Instant]))
 
 
 (set! *warn-on-reflection* true)
@@ -245,7 +245,7 @@
                 ["code" (codec/v-hash "code-204441")]
                 ["code" (codec/v-hash "system-204435|")]
                 ["code" (codec/v-hash "system-204435|code-204441")]
-                ["onset-date" (codec-date/encode-range (LocalDate/of 2020 1 30))]
+                ["onset-date" (codec-date/encode-range #system/date-time"2020-01-30")]
                 ["subject" (codec/v-hash "Patient/id-145552")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")
@@ -268,7 +268,7 @@
                 ["code" (codec/v-hash "code-204441")]
                 ["code" (codec/v-hash "system-204435|")]
                 ["code" (codec/v-hash "system-204435|code-204441")]
-                ["onset-date" (codec-date/encode-range (LocalDate/of 2020 1 30))]
+                ["onset-date" (codec-date/encode-range #system/date-time"2020-01-30")]
                 ["subject" (codec/v-hash "Patient/id-145552")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")
@@ -296,7 +296,7 @@
                 ["code" (codec/v-hash "code-204441")]
                 ["code" (codec/v-hash "system-204435|")]
                 ["code" (codec/v-hash "system-204435|code-204441")]
-                ["onset-date" (codec-date/encode-range (LocalDate/of 2020 1 30))]
+                ["onset-date" (codec-date/encode-range #system/date-time"2020-01-30")]
                 ["subject" (codec/v-hash "Patient/id-145552")]
                 ["subject" (codec/tid-id
                              (codec/tid "Patient")
@@ -373,7 +373,7 @@
                  (bs/concat (codec/v-hash "code-193824")
                             (codec/quantity "http://unitsofmeasure.org|kg/m2"
                                             23.42M))]
-                ["date" (codec-date/encode-range (LocalDate/of 2005 6 17))]
+                ["date" (codec-date/encode-range #system/date-time"2005-06-17")]
                 ["category" (codec/v-hash "system-193558|code-193603")]
                 ["category" (codec/v-hash "system-193558|")]
                 ["category" (codec/v-hash "code-193603")]

--- a/modules/executor/Makefile
+++ b/modules/executor/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/executor/deps.edn
+++ b/modules/executor/deps.edn
@@ -1,4 +1,10 @@
-{:aliases
+{:deps
+ {
+  ;; TODO: only needed for prepping
+  blaze/fhir-structure
+  {:local/root "../fhir-structure"}}
+
+ :aliases
  {:test
   {:extra-paths ["test"]
 

--- a/modules/extern-terminology-service/Makefile
+++ b/modules/extern-terminology-service/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/fhir-client/Makefile
+++ b/modules/fhir-client/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/fhir-path/Makefile
+++ b/modules/fhir-path/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/fhir-path/test/blaze/fhir_path_test.clj
+++ b/modules/fhir-path/test/blaze/fhir_path_test.clj
@@ -6,7 +6,6 @@
     [blaze.fhir-path-spec]
     [blaze.fhir.spec :as fhir-spec]
     [blaze.fhir.spec.type]
-    [blaze.fhir.spec.type.system :as system]
     [blaze.test-util :as tu]
     [clojure.spec.test.alpha :as st]
     [clojure.test :as test :refer [are deftest is testing]]
@@ -106,17 +105,17 @@
 
 (deftest date-test
   (are [expr date] (= date (first (eval expr "foo")))
-    "@2020" (system/date 2020)
-    "@2020-01" (system/date 2020 1)
-    "@2020-01-02" (system/date 2020 1 2)))
+    "@2020" #system/date"2020"
+    "@2020-01" #system/date"2020-01"
+    "@2020-01-02" #system/date"2020-01-02"))
 
 
 (deftest date-time-test
   (are [expr date-time] (= date-time (first (eval expr "foo")))
-    "@2020T" (system/date-time 2020)
-    "@2020-01T" (system/date-time 2020 1)
-    "@2020-01-02T" (system/date-time 2020 1 2)
-    "@2020-01-02T03" (system/date-time 2020 1 2 3)))
+    "@2020T" #system/date-time"2020"
+    "@2020-01T" #system/date-time"2020-01"
+    "@2020-01-02T" #system/date-time"2020-01-02"
+    "@2020-01-02T03" #system/date-time"2020-01-02T03"))
 
 
 ;; 4.5. Singleton Evaluation of Collections

--- a/modules/fhir-structure/Makefile
+++ b/modules/fhir-structure/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+build:
+	clojure -T:build compile
+
+test: build
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: build
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint build test test-coverage clean

--- a/modules/fhir-structure/build.clj
+++ b/modules/fhir-structure/build.clj
@@ -1,0 +1,11 @@
+(ns build
+  (:refer-clojure :exclude [compile])
+  (:require [clojure.tools.build.api :as b]))
+
+
+(defn compile [_]
+  (b/javac
+    {:basis (b/create-basis {:project "deps.edn"})
+     :src-dirs ["java"]
+     :class-dir "target/classes"
+     :javac-opts ["-Xlint:all" "-source" "11" "-target" "11"]}))

--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources"]
+{:paths ["src" "resources" "target/classes"]
 
  :deps
  {blaze/anomaly
@@ -41,8 +41,19 @@
   org.clojure/data.xml
   {:mvn/version "0.2.0-alpha8"}}
 
+ :deps/prep-lib
+ {:alias :build
+  :fn compile
+  :ensure "target/classes"}
+
  :aliases
- {:test
+ {:build
+  {:deps
+   {io.github.clojure/tools.build
+    {:git/tag "v0.9.4" :git/sha "76b78fe"}}
+   :ns-default build}
+
+  :test
   {:extra-paths ["test"]
 
    :extra-deps

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/Date.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/Date.java
@@ -1,0 +1,34 @@
+package blaze.fhir.spec.type.system;
+
+import clojure.lang.Keyword;
+
+import java.time.DateTimeException;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
+import java.time.temporal.ValueRange;
+
+public interface Date extends JavaSystemType, Temporal {
+
+    Keyword TYPE = Keyword.intern("system", "date");
+
+    ValueRange YEAR_RANGE = ValueRange.of(1, 9999);
+
+    default Keyword type() {
+        return TYPE;
+    }
+
+    DateTime toDateTime();
+
+    static Date parse(String s) {
+        switch (s.length()) {
+            case 10:
+                return DateDate.parse(s);
+            case 7:
+                return DateYearMonth.parse(s);
+            case 4:
+                return DateYear.parse(s);
+            default:
+                throw new DateTimeException(String.format("Can't parse `%s` as System.Date because it doesn't has the right length.", s));
+        }
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateDate.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateDate.java
@@ -1,0 +1,346 @@
+package blaze.fhir.spec.type.system;
+
+import com.google.common.hash.PrimitiveSink;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+
+import static java.time.temporal.ChronoField.*;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class DateDate implements Date, Comparable<DateDate> {
+
+    /**
+     * The number of days in a 400 year cycle.
+     */
+    private static final int DAYS_PER_CYCLE = 146097;
+
+    /**
+     * The number of days from year zero to year 1970.
+     * There are five 400 year cycles from year zero to 2000.
+     * There are 7 leap years from 1970 to 2000.
+     */
+    private static final int DAYS_0000_TO_1970 = (DAYS_PER_CYCLE * 5) - (30 * 365 + 7);
+
+    private final int year;
+    private final short month;
+    private final short day;
+
+    DateDate(int year, int month, int dayOfMonth) {
+        this.year = year;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
+    }
+
+    private static DateDate create(int year, int month, int dayOfMonth) {
+        if (dayOfMonth > 28) {
+            int dom = 31;
+            switch (month) {
+                case 2:
+                    dom = (IsoChronology.INSTANCE.isLeapYear(year) ? 29 : 28);
+                    break;
+                case 4:
+                case 6:
+                case 9:
+                case 11:
+                    dom = 30;
+                    break;
+            }
+            if (dayOfMonth > dom) {
+                if (dayOfMonth == 29) {
+                    throw new DateTimeException("Invalid date 'February 29' as '" + year + "' is not a leap year");
+                } else {
+                    throw new DateTimeException("Invalid date '" + Month.of(month).name() + " " + dayOfMonth + "'");
+                }
+            }
+        }
+        return new DateDate(year, month, dayOfMonth);
+    }
+
+    public static DateDate of(int year, int month, int dayOfMonth) {
+        YEAR_RANGE.checkValidValue(year, YEAR);
+        MONTH_OF_YEAR.checkValidValue(month);
+        DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        return create(year, month, dayOfMonth);
+    }
+
+    /**
+     * Obtains an instance of {@code DateDate} from the epoch day count.
+     * <p>
+     * This returns a {@code DateDate} with the specified epoch-day.
+     * The {@link ChronoField#EPOCH_DAY EPOCH_DAY} is a simple incrementing count
+     * of days where day 0 is 1970-01-01. Negative numbers represent earlier days.
+     *
+     * @param epochDay the Epoch Day to convert, based on the epoch 1970-01-01
+     * @return the local date, not null
+     * @throws DateTimeException if the epoch day exceeds the supported date range
+     */
+    public static DateDate ofEpochDay(int epochDay) {
+        int zeroDay = epochDay + DAYS_0000_TO_1970;
+        // find the march-based year
+        zeroDay -= 60;  // adjust to 0000-03-01 so leap day is at end of four year cycle
+        int adjust = 0;
+        if (zeroDay < 0) {
+            // adjust negative years to positive for calculation
+            int adjustCycles = (zeroDay + 1) / DAYS_PER_CYCLE - 1;
+            adjust = adjustCycles * 400;
+            zeroDay += -adjustCycles * DAYS_PER_CYCLE;
+        }
+        int yearEst = (400 * zeroDay + 591) / DAYS_PER_CYCLE;
+        int doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+        if (doyEst < 0) {
+            // fix estimate
+            yearEst--;
+            doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+        }
+        yearEst += adjust;  // reset any negative year
+        int marchDoy0 = doyEst;
+
+        // convert march-based values back to january-based
+        int marchMonth0 = (marchDoy0 * 5 + 2) / 153;
+        int month = (marchMonth0 + 2) % 12 + 1;
+        int dom = marchDoy0 - (marchMonth0 * 306 + 5) / 10 + 1;
+        yearEst += marchMonth0 / 10;
+
+        // check year now we are certain it is correct
+        int year = YEAR_RANGE.checkValidIntValue(yearEst, YEAR);
+        return new DateDate(year, month, dom);
+    }
+
+    static DateDate parse(String text) {
+        try {
+            return of(Integer.parseInt(text.substring(0, 4)),
+                    Integer.parseInt(text.substring(5, 7)),
+                    Integer.parseInt(text.substring(8, 10)));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    public static DateDate fromLocalDate(LocalDate date) {
+        return of(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+    }
+
+    public int year() {
+        return year;
+    }
+
+    public int month() {
+        return month;
+    }
+
+    public int day() {
+        return day;
+    }
+
+    @Override
+    public void hashInto(PrimitiveSink sink) {
+        sink.putByte((byte) 5);
+        sink.putInt(year);
+        sink.putInt(month);
+        sink.putInt(day);
+    }
+
+    public DateTimeDate toDateTime() {
+        return DateTimeDate.of(year, month, day);
+    }
+
+    public LocalDateTime atStartOfDay() {
+        return LocalDate.of(year, month, day).atStartOfDay();
+    }
+
+    public LocalDateTime atTime(int hour, int minute, int second) {
+        return LocalDate.of(year, month, day).atTime(hour, minute, second);
+    }
+
+    /**
+     * Checks if the year is a leap year, according to the ISO proleptic
+     * calendar system rules.
+     * <p>
+     * This method applies the current rules for leap years across the whole time-line.
+     * In general, a year is a leap year if it is divisible by four without
+     * remainder. However, years divisible by 100, are not leap years, with
+     * the exception of years divisible by 400 which are.
+     * <p>
+     * For example, 1904 is a leap year it is divisible by 4.
+     * 1900 was not a leap year as it is divisible by 100, however 2000 was a
+     * leap year as it is divisible by 400.
+     * <p>
+     * The calculation is proleptic - applying the same rules into the far future and far past.
+     * This is historically inaccurate, but is correct for the ISO-8601 standard.
+     *
+     * @return true if the year is leap, false otherwise
+     */
+    public boolean isLeapYear() {
+        return IsoChronology.INSTANCE.isLeapYear(year);
+    }
+
+    /**
+     * Returns the length of the month represented by this date.
+     * <p>
+     * This returns the length of the month in days.
+     * For example, a date in January would return 31.
+     *
+     * @return the length of the month in days
+     */
+    public int lengthOfMonth() {
+        switch (month) {
+            case 2:
+                return (isLeapYear() ? 29 : 28);
+            case 4:
+            case 6:
+            case 9:
+            case 11:
+                return 30;
+            default:
+                return 31;
+        }
+    }
+
+    public int toEpochDay() {
+        int y = year;
+        int m = month;
+        int total = 0;
+        total += 365 * y;
+        if (y >= 0) {
+            total += (y + 3) / 4 - (y + 99) / 100 + (y + 399) / 400;
+        } else {
+            total -= y / -4 - y / -100 + y / -400;
+        }
+        total += ((367 * m - 362) / 12);
+        total += day - 1;
+        if (m > 2) {
+            total--;
+            if (!isLeapYear()) {
+                total--;
+            }
+        }
+        return total - DAYS_0000_TO_1970;
+    }
+
+    @Override
+    public boolean isSupported(TemporalUnit unit) {
+        return LocalDate.of(year, month, day).isSupported(unit);
+    }
+
+    @Override
+    public Temporal with(TemporalField field, long newValue) {
+        return fromLocalDate(LocalDate.of(year, month, day).with(field, newValue));
+    }
+
+    @Override
+    public Temporal plus(long amountToAdd, TemporalUnit unit) {
+        return fromLocalDate(LocalDate.of(year, month, day).plus(amountToAdd, unit));
+    }
+
+    /**
+     * Returns a copy of this {@code DateDate} with the specified number of days added.
+     * <p>
+     * This method adds the specified amount to the days field incrementing the
+     * month and year fields as necessary to ensure the result remains valid.
+     * The result is only invalid if the maximum/minimum year is exceeded.
+     * <p>
+     * For example, 2008-12-31 plus one day would result in 2009-01-01.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param daysToAdd the days to add, may be negative
+     * @return a {@code DateDate} based on this date with the days added, not null
+     * @throws DateTimeException if the result exceeds the supported date range
+     */
+    public DateDate plusDays(int daysToAdd) {
+        if (daysToAdd == 0) {
+            return this;
+        }
+        int dom = day + daysToAdd;
+        if (dom > 0) {
+            if (dom <= 28) {
+                return new DateDate(year, month, dom);
+            } else if (dom <= 59) { // 59th Jan is 28th Feb, 59th Feb is 31st Mar
+                int monthLen = lengthOfMonth();
+                if (dom <= monthLen) {
+                    return new DateDate(year, month, dom);
+                } else if (month < 12) {
+                    return new DateDate(year, month + 1, dom - monthLen);
+                } else {
+                    YEAR_RANGE.checkValidValue(year + 1, YEAR);
+                    return new DateDate(year + 1, 1, dom - monthLen);
+                }
+            }
+        }
+
+        int mjDay = toEpochDay() + daysToAdd;
+        return DateDate.ofEpochDay(mjDay);
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return LocalDate.of(year, month, day).until(endExclusive, unit);
+    }
+
+    @Override
+    public boolean isSupported(TemporalField field) {
+        return LocalDate.of(year, month, day).isSupported(field);
+    }
+
+    @Override
+    public long getLong(TemporalField field) {
+        return LocalDate.of(year, month, day).getLong(field);
+    }
+
+    @Override
+    public int compareTo(DateDate other) {
+        int cmp = (year - other.year);
+        if (cmp == 0) {
+            cmp = (month - other.month);
+            if (cmp == 0) {
+                cmp = (day - other.day);
+            }
+        }
+        return cmp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DateDate) {
+            return compareTo((DateDate) obj) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int yearValue = year;
+        return (yearValue & 0xFFFFF800) ^ ((yearValue << 11) + ((int) month << 6) + ((int) day));
+    }
+
+    @Override
+    public String toString() {
+        int yearValue = year;
+        int monthValue = month;
+        int dayValue = day;
+        int absYear = Math.abs(yearValue);
+        StringBuilder buf = new StringBuilder(10);
+        if (absYear < 1000) {
+            buf.append(yearValue + 10000).deleteCharAt(0);
+        } else {
+            buf.append(yearValue);
+        }
+        return buf.append(monthValue < 10 ? "-0" : "-")
+                .append(monthValue)
+                .append(dayValue < 10 ? "-0" : "-")
+                .append(dayValue)
+                .toString();
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTime.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTime.java
@@ -1,0 +1,33 @@
+package blaze.fhir.spec.type.system;
+
+import clojure.lang.Keyword;
+
+import java.time.DateTimeException;
+import java.time.temporal.Temporal;
+import java.time.temporal.ValueRange;
+
+public interface DateTime extends JavaSystemType, Temporal {
+
+    Keyword TYPE = Keyword.intern("system", "date-time");
+
+    ValueRange YEAR_RANGE = ValueRange.of(1, 9999);
+
+    default Keyword type() {
+        return TYPE;
+    }
+
+    Date toDate();
+
+    static DateTime parse(String s) {
+        switch (s.length()) {
+            case 10:
+                return DateTimeDate.parse(s);
+            case 7:
+                return DateTimeYearMonth.parse(s);
+            case 4:
+                return DateTimeYear.parse(s);
+            default:
+                throw new DateTimeException(String.format("Can't parse `%s` as System.DateTime because it doesn't has the right length.", s));
+        }
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTimeDate.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTimeDate.java
@@ -1,0 +1,203 @@
+package blaze.fhir.spec.type.system;
+
+import com.google.common.hash.PrimitiveSink;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.chrono.IsoChronology;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+
+import static java.time.temporal.ChronoField.*;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class DateTimeDate implements DateTime, Comparable<DateTimeDate> {
+
+    private final int year;
+    private final short month;
+    private final short day;
+
+    DateTimeDate(int year, int month, int dayOfMonth) {
+        this.year = year;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
+    }
+
+    private static DateTimeDate create(int year, int month, int dayOfMonth) {
+        if (dayOfMonth > 28) {
+            int dom = 31;
+            switch (month) {
+                case 2:
+                    dom = (IsoChronology.INSTANCE.isLeapYear(year) ? 29 : 28);
+                    break;
+                case 4:
+                case 6:
+                case 9:
+                case 11:
+                    dom = 30;
+                    break;
+            }
+            if (dayOfMonth > dom) {
+                if (dayOfMonth == 29) {
+                    throw new DateTimeException("Invalid date 'February 29' as '" + year + "' is not a leap year");
+                } else {
+                    throw new DateTimeException("Invalid date '" + Month.of(month).name() + " " + dayOfMonth + "'");
+                }
+            }
+        }
+        return new DateTimeDate(year, month, dayOfMonth);
+    }
+
+    public static DateTimeDate of(int year, int month, int dayOfMonth) {
+        YEAR_RANGE.checkValidValue(year, YEAR);
+        MONTH_OF_YEAR.checkValidValue(month);
+        DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        return create(year, month, dayOfMonth);
+    }
+
+    static DateTimeDate parse(String text) {
+        try {
+            return of(Integer.parseInt(text.substring(0, 4)),
+                    Integer.parseInt(text.substring(5, 7)),
+                    Integer.parseInt(text.substring(8, 10)));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    public static DateTimeDate fromLocalDate(LocalDate date) {
+        return of(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+    }
+
+    public int year() {
+        return year;
+    }
+
+    public int month() {
+        return month;
+    }
+
+    public int day() {
+        return day;
+    }
+
+    @Override
+    public void hashInto(PrimitiveSink sink) {
+        sink.putByte((byte) 6);
+        sink.putInt(year);
+        sink.putInt(month);
+        sink.putInt(day);
+    }
+
+    public DateDate toDate() {
+        return DateDate.of(year, month, day);
+    }
+
+    public LocalDateTime atStartOfDay() {
+        return LocalDate.of(year, month, day).atStartOfDay();
+    }
+
+    public LocalDateTime atTime(int hour, int minute, int second) {
+        return LocalDate.of(year, month, day).atTime(hour, minute, second);
+    }
+
+    @Override
+    public boolean isSupported(TemporalUnit unit) {
+        return LocalDate.of(year, month, day).isSupported(unit);
+    }
+
+    @Override
+    public Temporal with(TemporalField field, long newValue) {
+        return fromLocalDate(LocalDate.of(year, month, day).with(field, newValue));
+    }
+
+    @Override
+    public Temporal plus(long amountToAdd, TemporalUnit unit) {
+        return fromLocalDate(LocalDate.of(year, month, day).plus(amountToAdd, unit));
+    }
+
+    /**
+     * Returns a copy of this {@code DateTimeDate} with the specified number of days added.
+     * <p>
+     * This method adds the specified amount to the days field incrementing the
+     * month and year fields as necessary to ensure the result remains valid.
+     * The result is only invalid if the maximum/minimum year is exceeded.
+     * <p>
+     * For example, 2008-12-31 plus one day would result in 2009-01-01.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param daysToAdd the days to add, may be negative
+     * @return a {@code DateTimeDate} based on this date with the days added, not null
+     * @throws DateTimeException if the result exceeds the supported date range
+     */
+    public DateTimeDate plusDays(int daysToAdd) {
+        return toDate().plusDays(daysToAdd).toDateTime();
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return LocalDate.of(year, month, day).until(endExclusive, unit);
+    }
+
+    @Override
+    public boolean isSupported(TemporalField field) {
+        return LocalDate.of(year, month, day).isSupported(field);
+    }
+
+    @Override
+    public long getLong(TemporalField field) {
+        return LocalDate.of(year, month, day).getLong(field);
+    }
+
+    @Override
+    public int compareTo(DateTimeDate other) {
+        int cmp = (year - other.year);
+        if (cmp == 0) {
+            cmp = (month - other.month);
+            if (cmp == 0) {
+                cmp = (day - other.day);
+            }
+        }
+        return cmp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DateTimeDate) {
+            return compareTo((DateTimeDate) obj) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int yearValue = year;
+        return (yearValue & 0xFFFFF800) ^ ((yearValue << 11) + ((int) month << 6) + ((int) day));
+    }
+
+    @Override
+    public String toString() {
+        int yearValue = year;
+        int monthValue = month;
+        int dayValue = day;
+        int absYear = Math.abs(yearValue);
+        StringBuilder buf = new StringBuilder(10);
+        if (absYear < 1000) {
+            buf.append(yearValue + 10000).deleteCharAt(0);
+        } else {
+            buf.append(yearValue);
+        }
+        return buf.append(monthValue < 10 ? "-0" : "-")
+                .append(monthValue)
+                .append(dayValue < 10 ? "-0" : "-")
+                .append(dayValue)
+                .toString();
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTimeYear.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTimeYear.java
@@ -1,0 +1,132 @@
+package blaze.fhir.spec.type.system;
+
+import com.google.common.hash.PrimitiveSink;
+
+import java.time.DateTimeException;
+import java.time.Year;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+
+import static java.time.temporal.ChronoField.YEAR;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class DateTimeYear implements DateTime, Comparable<DateTimeYear> {
+
+    private final int year;
+
+    private DateTimeYear(int year) {
+        this.year = year;
+    }
+
+    public static DateTimeYear of(int year) {
+        YEAR_RANGE.checkValidValue(year, YEAR);
+        return new DateTimeYear(year);
+    }
+
+    static DateTimeYear parse(String text) {
+        try {
+            return of(Integer.parseInt(text.substring(0, 4)));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    private static DateTimeYear fromYear(Year year) {
+        return of(year.getValue());
+    }
+
+    @Override
+    public void hashInto(PrimitiveSink sink) {
+        sink.putByte((byte) 6);
+        sink.putInt(year);
+    }
+
+    public DateYear toDate() {
+        return DateYear.of(year);
+    }
+
+    public DateTimeDate atStartOfYear() {
+        return new DateTimeDate(year, 1, 1);
+    }
+
+    public DateTimeDate atEndOfYear() {
+        return new DateTimeDate(year, 12, 31);
+    }
+
+    @Override
+    public boolean isSupported(TemporalUnit unit) {
+        return Year.of(year).isSupported(unit);
+    }
+
+    @Override
+    public Temporal with(TemporalField field, long newValue) {
+        return fromYear(Year.of(year).with(field, newValue));
+    }
+
+    @Override
+    public Temporal plus(long amountToAdd, TemporalUnit unit) {
+        try {
+            return fromYear(Year.of(year).plus(amountToAdd, unit));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Returns a copy of this {@code DateTimeYear} with the specified number of years added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param yearsToAdd the years to add, may be negative
+     * @return a {@code DateTimeYear} based on this year with the years added, not null
+     * @throws DateTimeException if the result exceeds the supported range
+     */
+    public DateTimeYear plusYears(int yearsToAdd) {
+        if (yearsToAdd == 0) {
+            return this;
+        }
+        return of(year + yearsToAdd);
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return Year.of(year).until(endExclusive, unit);
+    }
+
+    @Override
+    public boolean isSupported(TemporalField field) {
+        return Year.of(year).isSupported(field);
+    }
+
+    @Override
+    public long getLong(TemporalField field) {
+        return Year.of(year).getLong(field);
+    }
+
+    @Override
+    public int compareTo(DateTimeYear other) {
+        return year - other.year;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DateTimeYear) {
+            return year == ((DateTimeYear) obj).year;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return year;
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(year);
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTimeYearMonth.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateTimeYearMonth.java
@@ -1,0 +1,205 @@
+package blaze.fhir.spec.type.system;
+
+import com.google.common.hash.PrimitiveSink;
+
+import java.time.DateTimeException;
+import java.time.YearMonth;
+import java.time.chrono.IsoChronology;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class DateTimeYearMonth implements DateTime, Comparable<DateTimeYearMonth> {
+
+    private final int year;
+    private final int month;
+
+    private DateTimeYearMonth(int year, int month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public static DateTimeYearMonth of(int year, int month) {
+        YEAR_RANGE.checkValidValue(year, YEAR);
+        MONTH_OF_YEAR.checkValidValue(month);
+        return new DateTimeYearMonth(year, month);
+    }
+
+    static DateTimeYearMonth parse(String text) {
+        try {
+            return of(Integer.parseInt(text.substring(0, 4)),
+                    Integer.parseInt(text.substring(5, 7)));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    private static DateTimeYearMonth fromYearMonth(YearMonth yearMonth) {
+        return of(yearMonth.getYear(), yearMonth.getMonthValue());
+    }
+
+    public int year() {
+        return year;
+    }
+
+    public int month() {
+        return month;
+    }
+
+    /**
+     * Checks if the year is a leap year, according to the ISO proleptic
+     * calendar system rules.
+     * <p>
+     * This method applies the current rules for leap years across the whole time-line.
+     * In general, a year is a leap year if it is divisible by four without
+     * remainder. However, years divisible by 100, are not leap years, with
+     * the exception of years divisible by 400 which are.
+     * <p>
+     * For example, 1904 is a leap year it is divisible by 4.
+     * 1900 was not a leap year as it is divisible by 100, however 2000 was a
+     * leap year as it is divisible by 400.
+     * <p>
+     * The calculation is proleptic - applying the same rules into the far future and far past.
+     * This is historically inaccurate, but is correct for the ISO-8601 standard.
+     *
+     * @return true if the year is leap, false otherwise
+     */
+    public boolean isLeapYear() {
+        return IsoChronology.INSTANCE.isLeapYear(year);
+    }
+
+    /**
+     * Returns the length of the month represented by this date.
+     * <p>
+     * This returns the length of the month in days.
+     * For example, a date in January would return 31.
+     *
+     * @return the length of the month in days
+     */
+    public int lengthOfMonth() {
+        switch (month) {
+            case 2:
+                return (isLeapYear() ? 29 : 28);
+            case 4:
+            case 6:
+            case 9:
+            case 11:
+                return 30;
+            default:
+                return 31;
+        }
+    }
+
+    @Override
+    public void hashInto(PrimitiveSink sink) {
+        sink.putByte((byte) 6);
+        sink.putInt(year);
+        sink.putInt(month);
+    }
+
+    public DateYearMonth toDate() {
+        return DateYearMonth.of(year, month);
+    }
+
+    public DateTimeDate atStartOfMonth() {
+        return new DateTimeDate(year, month, 1);
+    }
+
+    public DateTimeDate atEndOfMonth() {
+        return new DateTimeDate(year, month, lengthOfMonth());
+    }
+
+    @Override
+    public boolean isSupported(TemporalUnit unit) {
+        return YearMonth.of(year, month).isSupported(unit);
+    }
+
+    @Override
+    public Temporal with(TemporalField field, long newValue) {
+        return fromYearMonth(YearMonth.of(year, month).with(field, newValue));
+    }
+
+    @Override
+    public Temporal plus(long amountToAdd, TemporalUnit unit) {
+        return fromYearMonth(YearMonth.of(year, month).plus(amountToAdd, unit));
+    }
+
+    /**
+     * Returns a copy of this {@code DateTimeYearMonth} with the specified number of months added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param monthsToAdd the months to add, may be negative
+     * @return a {@code DateTimeYearMonth} based on this year-month with the months added, not null
+     * @throws DateTimeException if the result exceeds the supported range
+     */
+    public DateTimeYearMonth plusMonths(int monthsToAdd) {
+        if (monthsToAdd == 0) {
+            return this;
+        }
+        int monthCount = year * 12 + (month - 1);
+        int calcMonths = monthCount + monthsToAdd;
+        int newYear = YEAR_RANGE.checkValidIntValue(Math.floorDiv(calcMonths, 12), YEAR);
+        int newMonth = Math.floorMod(calcMonths, 12) + 1;
+        return new DateTimeYearMonth(newYear, newMonth);
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return YearMonth.of(year, month).until(endExclusive, unit);
+    }
+
+    @Override
+    public boolean isSupported(TemporalField field) {
+        return YearMonth.of(year, month).isSupported(field);
+    }
+
+    @Override
+    public long getLong(TemporalField field) {
+        return YearMonth.of(year, month).getLong(field);
+    }
+
+    @Override
+    public int compareTo(DateTimeYearMonth other) {
+        int cmp = (year - other.year);
+        if (cmp == 0) {
+            cmp = (month - other.month);
+        }
+        return cmp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DateTimeYearMonth) {
+            return year == ((DateTimeYearMonth) obj).year &&
+                    month == ((DateTimeYearMonth) obj).month;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return year ^ (month << 27);
+    }
+
+    @Override
+    public String toString() {
+        int absYear = Math.abs(year);
+        StringBuilder buf = new StringBuilder(9);
+        if (absYear < 1000) {
+            buf.append(year + 10000).deleteCharAt(0);
+        } else {
+            buf.append(year);
+        }
+        return buf.append(month < 10 ? "-0" : "-")
+                .append(month)
+                .toString();
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateYear.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateYear.java
@@ -1,0 +1,128 @@
+package blaze.fhir.spec.type.system;
+
+import com.google.common.hash.PrimitiveSink;
+
+import java.time.DateTimeException;
+import java.time.Year;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+
+import static java.time.temporal.ChronoField.YEAR;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class DateYear implements Date, Comparable<DateYear> {
+
+    private final int year;
+
+    private DateYear(int year) {
+        this.year = year;
+    }
+
+    public static DateYear of(int year) {
+        YEAR_RANGE.checkValidValue(year, YEAR);
+        return new DateYear(year);
+    }
+
+    static DateYear parse(String text) {
+        try {
+            return of(Integer.parseInt(text.substring(0, 4)));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    private static DateYear fromYear(Year year) {
+        return of(year.getValue());
+    }
+
+    @Override
+    public void hashInto(PrimitiveSink sink) {
+        sink.putByte((byte) 5);
+        sink.putInt(year);
+    }
+
+    public DateTimeYear toDateTime() {
+        return DateTimeYear.of(year);
+    }
+
+    public DateDate atStartOfYear() {
+        return new DateDate(year, 1, 1);
+    }
+
+    public DateDate atEndOfYear() {
+        return new DateDate(year, 12, 31);
+    }
+
+    @Override
+    public boolean isSupported(TemporalUnit unit) {
+        return Year.of(year).isSupported(unit);
+    }
+
+    @Override
+    public Temporal with(TemporalField field, long newValue) {
+        return fromYear(Year.of(year).with(field, newValue));
+    }
+
+    @Override
+    public Temporal plus(long amountToAdd, TemporalUnit unit) {
+        return fromYear(Year.of(year).plus(amountToAdd, unit));
+    }
+
+    /**
+     * Returns a copy of this {@code DateYear} with the specified number of years added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param yearsToAdd the years to add, may be negative
+     * @return a {@code DateYear} based on this year with the years added, not null
+     * @throws DateTimeException if the result exceeds the supported range
+     */
+    public DateYear plusYears(int yearsToAdd) {
+        if (yearsToAdd == 0) {
+            return this;
+        }
+        return of(year + yearsToAdd);
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return Year.of(year).until(endExclusive, unit);
+    }
+
+    @Override
+    public boolean isSupported(TemporalField field) {
+        return Year.of(year).isSupported(field);
+    }
+
+    @Override
+    public long getLong(TemporalField field) {
+        return Year.of(year).getLong(field);
+    }
+
+    @Override
+    public int compareTo(DateYear other) {
+        return year - other.year;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DateYear) {
+            return year == ((DateYear) obj).year;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return year;
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(year);
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateYearMonth.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/DateYearMonth.java
@@ -1,0 +1,205 @@
+package blaze.fhir.spec.type.system;
+
+import com.google.common.hash.PrimitiveSink;
+
+import java.time.DateTimeException;
+import java.time.YearMonth;
+import java.time.chrono.IsoChronology;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class DateYearMonth implements Date, Comparable<DateYearMonth> {
+
+    private final int year;
+    private final int month;
+
+    private DateYearMonth(int year, int month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public static DateYearMonth of(int year, int month) {
+        YEAR_RANGE.checkValidValue(year, YEAR);
+        MONTH_OF_YEAR.checkValidValue(month);
+        return new DateYearMonth(year, month);
+    }
+
+    static DateYearMonth parse(String text) {
+        try {
+            return of(Integer.parseInt(text.substring(0, 4)),
+                    Integer.parseInt(text.substring(5, 7)));
+        } catch (NumberFormatException e) {
+            throw new DateTimeException("Invalid date component: " + e.getMessage());
+        }
+    }
+
+    private static DateYearMonth fromYearMonth(YearMonth yearMonth) {
+        return of(yearMonth.getYear(), yearMonth.getMonthValue());
+    }
+
+    public int year() {
+        return year;
+    }
+
+    public int month() {
+        return month;
+    }
+
+    /**
+     * Checks if the year is a leap year, according to the ISO proleptic
+     * calendar system rules.
+     * <p>
+     * This method applies the current rules for leap years across the whole time-line.
+     * In general, a year is a leap year if it is divisible by four without
+     * remainder. However, years divisible by 100, are not leap years, with
+     * the exception of years divisible by 400 which are.
+     * <p>
+     * For example, 1904 is a leap year it is divisible by 4.
+     * 1900 was not a leap year as it is divisible by 100, however 2000 was a
+     * leap year as it is divisible by 400.
+     * <p>
+     * The calculation is proleptic - applying the same rules into the far future and far past.
+     * This is historically inaccurate, but is correct for the ISO-8601 standard.
+     *
+     * @return true if the year is leap, false otherwise
+     */
+    public boolean isLeapYear() {
+        return IsoChronology.INSTANCE.isLeapYear(year);
+    }
+
+    /**
+     * Returns the length of the month represented by this date.
+     * <p>
+     * This returns the length of the month in days.
+     * For example, a date in January would return 31.
+     *
+     * @return the length of the month in days
+     */
+    public int lengthOfMonth() {
+        switch (month) {
+            case 2:
+                return (isLeapYear() ? 29 : 28);
+            case 4:
+            case 6:
+            case 9:
+            case 11:
+                return 30;
+            default:
+                return 31;
+        }
+    }
+
+    @Override
+    public void hashInto(PrimitiveSink sink) {
+        sink.putByte((byte) 5);
+        sink.putInt(year);
+        sink.putInt(month);
+    }
+
+    public DateTimeYearMonth toDateTime() {
+        return DateTimeYearMonth.of(year, month);
+    }
+
+    public DateDate atStartOfMonth() {
+        return new DateDate(year, month, 1);
+    }
+
+    public DateDate atEndOfMonth() {
+        return new DateDate(year, month, lengthOfMonth());
+    }
+
+    @Override
+    public boolean isSupported(TemporalUnit unit) {
+        return YearMonth.of(year, month).isSupported(unit);
+    }
+
+    @Override
+    public Temporal with(TemporalField field, long newValue) {
+        return fromYearMonth(YearMonth.of(year, month).with(field, newValue));
+    }
+
+    @Override
+    public Temporal plus(long amountToAdd, TemporalUnit unit) {
+        return fromYearMonth(YearMonth.of(year, month).plus(amountToAdd, unit));
+    }
+
+    /**
+     * Returns a copy of this {@code DateYearMonth} with the specified number of months added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param monthsToAdd the months to add, may be negative
+     * @return a {@code DateYearMonth} based on this year-month with the months added, not null
+     * @throws DateTimeException if the result exceeds the supported range
+     */
+    public DateYearMonth plusMonths(int monthsToAdd) {
+        if (monthsToAdd == 0) {
+            return this;
+        }
+        int monthCount = year * 12 + (month - 1);
+        int calcMonths = monthCount + monthsToAdd;
+        int newYear = YEAR_RANGE.checkValidIntValue(Math.floorDiv(calcMonths, 12), YEAR);
+        int newMonth = Math.floorMod(calcMonths, 12) + 1;
+        return new DateYearMonth(newYear, newMonth);
+    }
+
+    @Override
+    public long until(Temporal endExclusive, TemporalUnit unit) {
+        return YearMonth.of(year, month).until(endExclusive, unit);
+    }
+
+    @Override
+    public boolean isSupported(TemporalField field) {
+        return YearMonth.of(year, month).isSupported(field);
+    }
+
+    @Override
+    public long getLong(TemporalField field) {
+        return YearMonth.of(year, month).getLong(field);
+    }
+
+    @Override
+    public int compareTo(DateYearMonth other) {
+        int cmp = (year - other.year);
+        if (cmp == 0) {
+            cmp = (month - other.month);
+        }
+        return cmp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DateYearMonth) {
+            return year == ((DateYearMonth) obj).year &&
+                    month == ((DateYearMonth) obj).month;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return year ^ (month << 27);
+    }
+
+    @Override
+    public String toString() {
+        int absYear = Math.abs(year);
+        StringBuilder buf = new StringBuilder(9);
+        if (absYear < 1000) {
+            buf.append(year + 10000).deleteCharAt(0);
+        } else {
+            buf.append(year);
+        }
+        return buf.append(month < 10 ? "-0" : "-")
+                .append(month)
+                .toString();
+    }
+}

--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/JavaSystemType.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/JavaSystemType.java
@@ -1,0 +1,12 @@
+package blaze.fhir.spec.type.system;
+
+import clojure.lang.Keyword;
+import com.google.common.hash.PrimitiveSink;
+
+@SuppressWarnings("UnstableApiUsage")
+public interface JavaSystemType {
+
+    Keyword type();
+
+    void hashInto(PrimitiveSink sink);
+}

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -16,7 +16,7 @@
     [clojure.string :as str])
   (:import
     [blaze.fhir.spec.type.system
-     DateTimeYear DateTimeYearMonth DateTimeYearMonthDay]
+     Date DateDate DateTimeDate DateTimeYear DateTimeYearMonth DateYear DateYearMonth]
     [clojure.lang IPersistentMap Keyword]
     [com.fasterxml.jackson.core JsonGenerator]
     [com.fasterxml.jackson.databind.module SimpleModule]
@@ -24,9 +24,8 @@
     [com.google.common.hash PrimitiveSink]
     [java.io Writer]
     [java.time
-     Instant LocalDate LocalDateTime LocalTime OffsetDateTime Year YearMonth
-     ZoneOffset]
-    [java.time.format DateTimeFormatter DateTimeParseException]
+     DateTimeException Instant LocalDate LocalDateTime LocalTime OffsetDateTime ZoneOffset]
+    [java.time.format DateTimeFormatter]
     [java.util Comparator List Map Map$Entry UUID]
     [jsonista.jackson
      KeywordKeyDeserializer PersistentHashMapDeserializer
@@ -560,7 +559,7 @@
 ;; -- date --------------------------------------------------------------------
 
 (extend-protocol p/FhirType
-  Year
+  DateYear
   (-type [_] :fhir/date)
   (-interned [_] false)
   (-value [date] date)
@@ -576,10 +575,10 @@
     (doto ^PrimitiveSink sink
       (.putByte (byte 10))                                  ; :fhir/date
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into date sink))
+    (.hashInto date sink))
   (-references [_])
 
-  YearMonth
+  DateYearMonth
   (-type [_] :fhir/date)
   (-interned [_] false)
   (-value [date] date)
@@ -595,10 +594,10 @@
     (doto ^PrimitiveSink sink
       (.putByte (byte 10))                                  ; :fhir/date
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into date sink))
+    (.hashInto date sink))
   (-references [_])
 
-  LocalDate
+  DateDate
   (-type [_] :fhir/date)
   (-interned [_] false)
   (-value [date] date)
@@ -614,7 +613,7 @@
     (doto ^PrimitiveSink sink
       (.putByte (byte 10))                                  ; :fhir/date
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into date sink))
+    (.hashInto date sink))
   (-references [_]))
 
 
@@ -624,8 +623,8 @@
 
 (defn- parse-date-value [value]
   (try
-    (system/parse-date* value)
-    (catch DateTimeParseException _
+    (Date/parse value)
+    (catch DateTimeException _
       ;; in case of leap year errors not covered by regex
       ::s2/invalid)))
 
@@ -682,58 +681,58 @@
   DateTimeYear
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
-  (-value [year] year)
+  (-value [date] date)
   (-has-primary-content [_] true)
-  (-serialize-json [year generator]
-    (.writeString ^JsonGenerator generator (str year)))
+  (-serialize-json [date generator]
+    (.writeString ^JsonGenerator generator (str date)))
   (-has-secondary-content [_] false)
   (-serialize-json-secondary [_ generator]
     (.writeNull ^JsonGenerator generator))
-  (-to-xml [year]
-    (xml-node/element nil {:value (str year)}))
-  (-hash-into [year sink]
+  (-to-xml [date]
+    (xml-node/element nil {:value (str date)}))
+  (-hash-into [date sink]
     (doto ^PrimitiveSink sink
       (.putByte (byte 11))                                  ; :fhir/dateTime
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into year sink))
+    (.hashInto date sink))
   (-references [_])
 
   DateTimeYearMonth
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
-  (-value [year-month] year-month)
+  (-value [date] date)
   (-has-primary-content [_] true)
-  (-serialize-json [year-month generator]
-    (.writeString ^JsonGenerator generator (str year-month)))
+  (-serialize-json [date generator]
+    (.writeString ^JsonGenerator generator (str date)))
   (-has-secondary-content [_] false)
   (-serialize-json-secondary [_ generator]
     (.writeNull ^JsonGenerator generator))
-  (-to-xml [year-month]
-    (xml-node/element nil {:value (str year-month)}))
-  (-hash-into [year-month sink]
+  (-to-xml [date]
+    (xml-node/element nil {:value (str date)}))
+  (-hash-into [date sink]
     (doto ^PrimitiveSink sink
       (.putByte (byte 11))                                  ; :fhir/dateTime
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into year-month sink))
+    (.hashInto date sink))
   (-references [_])
 
-  DateTimeYearMonthDay
+  DateTimeDate
   (-type [_] :fhir/dateTime)
   (-interned [_] false)
-  (-value [year-month-day] year-month-day)
+  (-value [date] date)
   (-has-primary-content [_] true)
-  (-serialize-json [year-month-day generator]
-    (.writeString ^JsonGenerator generator (str year-month-day)))
+  (-serialize-json [date generator]
+    (.writeString ^JsonGenerator generator (str date)))
   (-has-secondary-content [_] false)
   (-serialize-json-secondary [_ generator]
     (.writeNull ^JsonGenerator generator))
-  (-to-xml [year-month-day]
-    (xml-node/element nil {:value (str year-month-day)}))
-  (-hash-into [year-month-day sink]
+  (-to-xml [date]
+    (xml-node/element nil {:value (str date)}))
+  (-hash-into [date sink]
     (doto ^PrimitiveSink sink
       (.putByte (byte 11))                                  ; :fhir/dateTime
       (.putByte (byte 2)))                                  ; :value
-    (system/-hash-into year-month-day sink))
+    (.hashInto date sink))
   (-references [_]))
 
 
@@ -784,7 +783,7 @@
 (defn- parse-date-time-value [value]
   (try
     (system/parse-date-time* value)
-    (catch DateTimeParseException _
+    (catch DateTimeException _
       ;; in case of leap year errors not covered by regex
       ::s2/invalid)))
 
@@ -1267,35 +1266,11 @@
 
 ;; ---- print -----------------------------------------------------------------
 
-(defmethod print-dup Year [^Year year ^Writer w]
-  (.write w "#=(java.time.Year/of ")
-  (.write w (str (.getValue year)))
-  (.write w ")"))
-
-
 (defmethod print-dup Instant [^Instant instant ^Writer w]
   (.write w "#=(java.time.Instant/ofEpochSecond ")
   (.write w (str (.getEpochSecond instant)))
   (.write w " ")
   (.write w (str (.getNano instant)))
-  (.write w ")"))
-
-
-(defmethod print-dup YearMonth [^YearMonth yearMonth ^Writer w]
-  (.write w "#=(java.time.YearMonth/of ")
-  (.write w (str (.getYear yearMonth)))
-  (.write w " ")
-  (.write w (str (.getMonthValue yearMonth)))
-  (.write w ")"))
-
-
-(defmethod print-dup LocalDate [^LocalDate date ^Writer w]
-  (.write w "#=(java.time.LocalDate/of ")
-  (.write w (str (.getYear date)))
-  (.write w " ")
-  (.write w (str (.getMonthValue date)))
-  (.write w " ")
-  (.write w (str (.getDayOfMonth date)))
   (.write w ")"))
 
 

--- a/modules/fhir-structure/test-perf/blaze/fhir/spec/type/system_test_perf.clj
+++ b/modules/fhir-structure/test-perf/blaze/fhir/spec/type/system_test_perf.clj
@@ -1,0 +1,15 @@
+(ns blaze.fhir.spec.type.system-test-perf
+  (:require
+    [blaze.fhir.spec.type.system :as system]
+    [blaze.test-util]
+    [criterium.core :as criterium])
+  (:import
+    [java.time LocalDate]))
+
+
+(comment
+  (criterium/quick-bench (system/parse-date "2020-01-01"))
+  (criterium/quick-bench (system/parse-date-time "2020-01-01"))
+  (criterium/quick-bench (LocalDate/parse "2020-01-01"))
+  (criterium/quick-bench (DateTime. nil nil "2020-01-01"))
+  )

--- a/modules/fhir-structure/test-perf/blaze/fhir/spec/type_test_mem.clj
+++ b/modules/fhir-structure/test-perf/blaze/fhir/spec/type_test_mem.clj
@@ -42,9 +42,9 @@
     #fhir/date"2020-01" 24
     #fhir/date"2020-01-01" 24
 
-    #fhir/dateTime"2020" 32
-    #fhir/dateTime"2020-01" 40
-    #fhir/dateTime"2020-01-01" 40
+    #fhir/dateTime"2020" 16
+    #fhir/dateTime"2020-01" 24
+    #fhir/dateTime"2020-01-01" 24
 
     #fhir/dateTime"2020-01-01T00:00:00" 72
     #fhir/dateTime"2020-01-01T00:00:00.000" 72

--- a/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type_test.clj
@@ -5,7 +5,6 @@
     [blaze.fhir.spec.type :as type]
     [blaze.fhir.spec.type-spec]
     [blaze.fhir.spec.type.protocols :as p]
-    [blaze.fhir.spec.type.system :as system]
     [blaze.fhir.spec.type.system.spec]
     [blaze.test-util :as tu :refer [satisfies-prop]]
     [clojure.data.xml.name :as xml-name]
@@ -893,7 +892,7 @@
           (type/date {:extension [internable-extension]}))))
 
     (testing "value"
-      (are [x] (= (system/date 2020) (type/value x))
+      (are [x] (= #system/date"2020" (type/value x))
         #fhir/date"2020"
         #fhir/date{:id "foo" :value "2020"}))
 
@@ -939,7 +938,7 @@
       (is (not-interned? #fhir/date"2020-01" #fhir/date"2020-01")))
 
     (testing "value"
-      (are [x] (= (system/date 2020 1) (type/value x))
+      (are [x] (= #system/date"2020-01" (type/value x))
         #fhir/date"2020-01"
         #fhir/date{:id "foo" :value "2020-01"}))
 
@@ -985,7 +984,7 @@
       (is (not-interned? #fhir/date"2020-01-01" #fhir/date"2020-01-01")))
 
     (testing "value"
-      (are [x] (= (system/date 2020 1 2) (type/value x))
+      (are [x] (= #system/date"2020-01-02" (type/value x))
         #fhir/date"2020-01-02"
         #fhir/date{:id "foo" :value "2020-01-02"}))
 
@@ -1023,7 +1022,10 @@
     (testing "dateTime?"
       (are [x] (type/dateTime? x)
         #fhir/dateTime"2022"
-        #fhir/dateTime{:id "foo"}))
+        #fhir/dateTime"2022-01"
+        #fhir/dateTime"2022-01-01"
+        #fhir/dateTime{:id "foo"}
+        #fhir/dateTime{:extension [#fhir/Extension{:url "foo"}]}))
 
     (testing "type"
       (are [x] (= :fhir/dateTime (type/type x))
@@ -1037,7 +1039,7 @@
       (is (not-interned? #fhir/dateTime"2020" #fhir/dateTime"2020")))
 
     (testing "value"
-      (are [x] (= (system/date-time 2020) (type/value x))
+      (are [x] (= #system/date-time"2020" (type/value x))
         #fhir/dateTime"2020"
         #fhir/dateTime{:id "foo" :value "2020"}))
 
@@ -1083,7 +1085,7 @@
       (is (not-interned? #fhir/dateTime"2022-05" #fhir/dateTime"2022-05")))
 
     (testing "value"
-      (are [x] (= (system/date-time 2020 1) (type/value x))
+      (are [x] (= #system/date-time"2020-01" (type/value x))
         #fhir/dateTime"2020-01"
         #fhir/dateTime{:id "foo" :value "2020-01"}))
 
@@ -1129,7 +1131,7 @@
       (is (not-interned? #fhir/dateTime"2022-05-23" #fhir/dateTime"2022-05-23")))
 
     (testing "value"
-      (are [x] (= (system/date-time 2020 1 1) (type/value x))
+      (are [x] (= #system/date-time"2020-01-01" (type/value x))
         #fhir/dateTime"2020-01-01"
         #fhir/dateTime{:id "foo" :value "2020-01-01"}))
 
@@ -1413,7 +1415,7 @@
                            (type/dateTime {:extension [string-extension] :value "2020"}))))
 
       (testing "value"
-        (is (= (system/date-time 2020) (type/value extended-date-time))))
+        (is (= #system/date-time"2020" (type/value extended-date-time))))
 
       (testing "to-xml"
         (is (= extended-date-time-element (type/to-xml extended-date-time))))

--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -1816,6 +1816,7 @@
 
 
 (deftest fhir-dateTime-test
+  (s2/form :fhir/dateTime)
   (testing "conforming"
     (testing "JSON"
       (testing "valid"

--- a/modules/http-client/Makefile
+++ b/modules/http-client/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/jepsen/Makefile
+++ b/modules/jepsen/Makefile
@@ -1,16 +1,19 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
 test-coverage:
 	true
 
-register-test:
+register-test: prep
 	clojure -M:register test --concurrency 16 --time-limit 60 -n localhost:8080 --delta-time 0.1
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/kv/Makefile
+++ b/modules/kv/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/luid/Makefile
+++ b/modules/luid/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/luid/deps.edn
+++ b/modules/luid/deps.edn
@@ -1,5 +1,10 @@
 {:deps
- {blaze/spec
+ {
+  ;; TODO: only needed for prepping
+  blaze/fhir-structure
+  {:local/root "../fhir-structure"}
+
+  blaze/spec
   {:local/root "../spec"}
 
   com.google.guava/guava

--- a/modules/metrics/Makefile
+++ b/modules/metrics/Makefile
@@ -1,7 +1,10 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-build:
+prep:
+	clojure -X:deps prep
+
+build: prep
 	clojure -T:build compile
 
 test: build
@@ -13,4 +16,4 @@ test-coverage: build
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint build test test-coverage clean
+.PHONY: lint prep build test test-coverage clean

--- a/modules/openid-auth/Makefile
+++ b/modules/openid-auth/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -1,5 +1,6 @@
 (ns blaze.fhir.operation.evaluate-measure.measure-test
   (:require
+    [blaze.anomaly :as ba]
     [blaze.db.api :as d]
     [blaze.db.api-stub :refer [mem-node-system with-system-data]]
     [blaze.fhir.operation.evaluate-measure.measure :as measure]
@@ -545,7 +546,7 @@
     [0 :value :text type/value] := "Jena"
     [0 :population 0 :count] := 2)
 
-  (is (= ::anom/incorrect (::anom/category (evaluate "q22-stratifier-multiple-cities-fail"))))
+  (is (ba/incorrect? (evaluate "q22-stratifier-multiple-cities-fail")))
 
   (given (first-stratifier-strata (evaluate "q23-stratifier-ageclass-and-gender"))
     [0 :component 0 :code :text type/value] := "age-class"

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q11.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q11.cql
@@ -5,4 +5,4 @@ include FHIRHelpers version '4.0.0'
 define InInitialPopulation:
   exists
     from [Specimen] S
-    where FHIRHelpers.ToDateTime(S.collection.collected) < @2006
+    where S.collection.collected < @2006

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q12.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q12.cql
@@ -5,4 +5,4 @@ include FHIRHelpers version '4.0.0'
 context Specimen
 
 define InInitialPopulation:
-  FHIRHelpers.ToDateTime(Specimen.collection.collected) < @2006
+  Specimen.collection.collected < @2006

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q14.cql
@@ -7,4 +7,4 @@ context Patient
 define InInitialPopulation:
   exists
     from [Condition] C
-    where AgeInYearsAt(FHIRHelpers.ToDateTime(C.onset)) between 18 and 45
+    where AgeInYearsAt(C.onset) between 18 and 45

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q15.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q15.json
@@ -26,6 +26,24 @@
     },
     {
       "resource": {
+        "resourceType": "Patient",
+        "id": "2",
+        "_birthDate": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "unknown"
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/2"
+      }
+    },
+    {
+      "resource": {
         "resourceType": "Measure",
         "id": "0",
         "url": "0",

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q32-stratifier-underweight.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q32-stratifier-underweight.cql
@@ -12,5 +12,5 @@ define InInitialPopulation:
 
 define Underweight:
   exists from [Observation: bmi] O
-    where AgeInYearsAt(FHIRHelpers.ToDateTime(O.effective as dateTime)) >= 18
+    where AgeInYearsAt(O.effective) >= 18
       and O.value as Quantity < 18.6 'kg/m2'

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q7.cql
@@ -5,4 +5,4 @@ include FHIRHelpers version '4.0.0'
 define InInitialPopulation:
   exists
     from [Condition] C
-    where FHIRHelpers.ToDateTime(C.onset) < @2006
+    where C.onset < @2006

--- a/modules/scheduler/Makefile
+++ b/modules/scheduler/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/server/Makefile
+++ b/modules/server/Makefile
@@ -1,13 +1,16 @@
 lint:
 	clj-kondo --lint src test deps.edn
 
-test:
+prep:
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage:
+test-coverage: prep
 	clojure -M:test:coverage
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint test test-coverage clean
+.PHONY: lint prep test test-coverage clean

--- a/modules/test-util/src/blaze/test_util.clj
+++ b/modules/test-util/src/blaze/test_util.clj
@@ -20,6 +20,8 @@
 
 (defn all-ex-data [e]
   (cond-> (ex-data e)
+    (ex-message e)
+    (assoc :message (ex-message e))
     (ex-data (ex-cause e))
     (assoc :cause-data (all-ex-data (ex-cause e)))))
 


### PR DESCRIPTION
For age calculation in CQL, the property birthDate.value is used. That .value part means that we have to get the value of the FHIR date type. We never did this and so got ExtendedDate into the CQL evaluation which doesn't work.

Also overhauled the System.Date and System.DateTime types. Decided to implement them in Java. Improved the parsing performance by about 4 times. For Date/DateTime up to Date precision.

Closes: #973