### PR TITLE
Update Jackson to v2.15.0

### DIFF
--- a/.github/scripts/generate-large-binary-resource.sh
+++ b/.github/scripts/generate-large-binary-resource.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-# generate 8 MB random data as Base64
+# generate 8 MiB random data as Base64
 DATA=$(openssl rand -base64 8388608)
 
+echo "{\"resourceType\": \"Binary\", \"data\": \"$DATA\"}" > large-binary.json
 echo "<Binary xmlns=\"http://hl7.org/fhir\"><data value=\"$DATA\"/></Binary>" > large-binary.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -999,16 +999,22 @@ jobs:
       run: docker load --input /tmp/blaze.tar
 
     - name: Run Blaze
-      run: docker run --name blaze -d -e JAVA_TOOL_OPTIONS=-Xmx2g -p 8080:8080 -v blaze-data:/app/data blaze:latest
+      run: docker run --name blaze -d -e JAVA_TOOL_OPTIONS=-Xmx2g -e DB_RESOURCE_CACHE_SIZE=0 -p 8080:8080 -v blaze-data:/app/data blaze:latest
 
     - name: Wait for Blaze
       run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
 
-    - name: Generate Large Binary Resource
+    - name: Generate Large Binary Resources (JSON and XML)
       run: .github/scripts/generate-large-binary-resource.sh
 
-    - name: Post Large Binary Resource
+    - name: Post Large Binary JSON Resource
+      run:  curl -f -H Content-Type:application/fhir+json -H Prefer:return=minimal -d @large-binary.json http://localhost:8080/fhir/Binary
+
+    - name: Post Large Binary XML Resource
       run:  curl -f -H Content-Type:application/fhir+xml -H Prefer:return=minimal -d @large-binary.xml http://localhost:8080/fhir/Binary
+
+    - name: Download Both Resources
+      run:  test "2" = "$(curl -s http://localhost:8080/fhir/Binary | jq .total)"
 
   missing-resource-content-test:
     needs: build

--- a/modules/byte-string/deps.edn
+++ b/modules/byte-string/deps.edn
@@ -8,4 +8,4 @@
   {:mvn/version "3.22.3"}
 
   com.fasterxml.jackson.core/jackson-databind
-  {:mvn/version "2.14.2"}}}
+  {:mvn/version "2.15.0"}}}

--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -7,7 +7,7 @@
 
   ;; current version of transitive dependency of com.datastax.oss/java-driver-core
   com.fasterxml.jackson.core/jackson-databind
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   ;; current version of transitive dependency of com.datastax.oss/java-driver-core
   io.netty/netty-handler

--- a/modules/cql/deps.edn
+++ b/modules/cql/deps.edn
@@ -5,10 +5,10 @@
   {:local/root "../db"}
 
   com.fasterxml.jackson.module/jackson-module-jaxb-annotations
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   com.fasterxml.jackson.dataformat/jackson-dataformat-xml
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   info.cqframework/cql-to-elm
   {:mvn/version "2.8.0"

--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -20,10 +20,10 @@
   {:mvn/version "31.1-jre"}
 
   com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   com.fasterxml.jackson.dataformat/jackson-dataformat-xml
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   com.taoensso/timbre
   {:mvn/version "5.2.1"}

--- a/modules/http-client/deps.edn
+++ b/modules/http-client/deps.edn
@@ -8,10 +8,10 @@
    [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]}
 
   com.fasterxml.jackson.core/jackson-core
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   com.fasterxml.jackson.dataformat/jackson-dataformat-smile
-  {:mvn/version "2.14.2"}
+  {:mvn/version "2.15.0"}
 
   hato/hato
   {:mvn/version "0.9.0"}}


### PR DESCRIPTION
Had to set StreamReadConstraints.maxStringLen to 50 M in order to support at least our 8 MiB large binary resource test case. Added a download test in order to detect the config also for the CBOR parser used to read data from the resource store.