### PR TITLE
Fix CQL ToString Function

### DIFF
--- a/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
+++ b/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
@@ -136,7 +136,7 @@
 (defrecord ToStringFunctionExpression [operand]
   core/Expression
   (-eval [_ context resource scope]
-    (str (core/-eval operand context resource scope)))
+    (some-> (type/value (core/-eval operand context resource scope)) str))
   (-form [_]
     `(~'call "ToString" ~(core/-form operand))))
 

--- a/modules/cql/test/blaze/elm/compiler/reusing_logic_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/reusing_logic_test.clj
@@ -179,7 +179,9 @@
       (testing "eval"
         (are [x res] (= res (core/-eval expr {:parameters {"x" x}} nil nil))
           "string-195733" "string-195733"
-          #fhir/uri"uri-195924" "uri-195924"))
+          #fhir/uri"uri-195924" "uri-195924"
+          #fhir/code{:id "foo" :value "code-211914"} "code-211914"
+          #fhir/code{:id "foo"} nil))
 
       (testing "form"
         (is (= '(call "ToString" (param-ref "x")) (core/-form expr))))))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
@@ -244,7 +244,7 @@
       [[[:put {:fhir/type :fhir/Patient :id "0"}]]]
       (let [{:keys [db] :as context} (context system library-gender)
             patient (d/resource-handle db "Patient" "0")]
-        (is (false? (cql/evaluate-individual-expression context patient "InInitialPopulation"))))))
+        (is (nil? (cql/evaluate-individual-expression context patient "InInitialPopulation"))))))
 
   (testing "missing expression"
     (with-system-data [system mem-node-system]

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -447,7 +447,7 @@
 
 (deftest integration-test
   (are [name count] (= count (:count (first-population (evaluate name))))
-    "q1" 1
+    "q1" 2
     "q2" 1
     "q3" 1
     "q4" 1
@@ -487,13 +487,14 @@
       (is (s/valid? :blaze/resource (:resource result))))
 
     (given (first-population result)
-      :count := 1
+      :count := 2
       [:subjectResults :reference] := "List/AAAAAAAAAAAAAAAA")
 
     (given (second (first (:tx-ops result)))
       :fhir/type := :fhir/List
       :id := "AAAAAAAAAAAAAAAA"
-      [:entry 0 :item :reference] := "Patient/0"))
+      [:entry 0 :item :reference] := "Patient/0"
+      [:entry 1 :item :reference] := "Patient/3"))
 
   (let [result (evaluate "q19-stratifier-ageclass")]
     (testing "MeasureReport is valid"

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q1.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q1.json
@@ -26,6 +26,70 @@
     },
     {
       "resource": {
+        "resourceType": "Patient",
+        "id": "2",
+        "gender": "female",
+        "_gender": {
+          "extension": [
+            {
+              "url": "http://fhir.de/StructureDefinition/gender-amtlich-de",
+              "valueCoding": {
+                "system": "http://fhir.de/CodeSystem/gender-amtlich-de",
+                "code": "W",
+                "display": "weiblich"
+              }
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/2"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "3",
+        "gender": "male",
+        "_gender": {
+          "extension": [
+            {
+              "url": "http://fhir.de/StructureDefinition/gender-amtlich-de",
+              "valueCoding": {
+                "system": "http://fhir.de/CodeSystem/gender-amtlich-de",
+                "code": "M",
+                "display": "männlich"
+              }
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/3"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "4",
+        "_gender": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "unknown"
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/4"
+      }
+    },
+    {
+      "resource": {
         "resourceType": "Measure",
         "id": "0",
         "url": "0",

--- a/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
+++ b/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
@@ -67,7 +67,7 @@
 
 
 (defn- bind-put [statement token clauses]
-  (let [content (codec/encode clauses)]
+  (let [^bytes content (codec/encode clauses)]
     (prom/observe! clauses-bytes (alength content))
     (cass/bind statement token (bb/wrap content))))
 


### PR DESCRIPTION
The CQL ToString function was not extracting the value out of a FHIR primitive value.