### PR TITLE
Disable Resource Handle Cache if Max-Size Zero

### DIFF
--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -4,10 +4,13 @@ lint:
 prep:
 	clojure -X:deps prep
 
-test: prep
+build: prep
+	clojure -T:build compile
+
+test: build
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: prep
+test-coverage: build
 	clojure -M:test:coverage
 
 deps-tree:
@@ -19,4 +22,4 @@ deps-list:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: lint prep test test-coverage deps-tree deps-list clean
+.PHONY: lint prep build test test-coverage deps-tree deps-list clean

--- a/modules/db/build.clj
+++ b/modules/db/build.clj
@@ -1,0 +1,11 @@
+(ns build
+  (:refer-clojure :exclude [compile])
+  (:require [clojure.tools.build.api :as b]))
+
+
+(defn compile [_]
+  (b/javac
+    {:basis (b/create-basis {:project "deps.edn"})
+     :src-dirs ["java"]
+     :class-dir "target/classes"
+     :javac-opts ["-Xlint:all" "-source" "11" "-target" "11"]}))

--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources"]
+{:paths ["src" "resources" "target/classes"]
 
  :deps
  {blaze/async
@@ -40,8 +40,19 @@
   commons-codec/commons-codec
   {:mvn/version "1.15"}}
 
+ :deps/prep-lib
+ {:alias :build
+  :fn compile
+  :ensure "target/classes"}
+
  :aliases
- {:test
+ {:build
+  {:deps
+   {io.github.clojure/tools.build
+    {:git/tag "v0.9.4" :git/sha "76b78fe"}}
+   :ns-default build}
+
+  :test
   {:extra-paths ["test"]
 
    :extra-deps

--- a/modules/db/java/blaze/db/impl/index/resource_as_of/Key.java
+++ b/modules/db/java/blaze/db/impl/index/resource_as_of/Key.java
@@ -1,0 +1,36 @@
+package blaze.db.impl.index.resource_as_of;
+
+import com.google.protobuf.ByteString;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class Key {
+
+    public final int tid;
+    public final ByteString id;
+    public final long t;
+
+    public Key(int tid, ByteString id, long t) {
+        this.tid = tid;
+        this.id = requireNonNull(id);
+        this.t = t;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Key) {
+            Key other = ((Key) o);
+            return t == other.t && tid == other.tid && Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tid;
+        result = 31 * result + id.hashCode();
+        return 31 * result + Long.hashCode(t);
+    }
+}

--- a/modules/db/src/blaze/db/cache_collector.clj
+++ b/modules/db/src/blaze/db/cache_collector.clj
@@ -36,7 +36,10 @@
 
 
 (def ^:private mapper
-  (map (fn [[name cache]] [name (p/-stats cache) (p/-estimated-size cache)])))
+  (keep
+    (fn [[name cache]]
+      (when cache
+        [name (p/-stats cache) (p/-estimated-size cache)]))))
 
 
 (defmethod ig/pre-init-spec :blaze.db/cache-collector [_]

--- a/modules/db/src/blaze/db/cache_collector/spec.clj
+++ b/modules/db/src/blaze/db/cache_collector/spec.clj
@@ -5,4 +5,4 @@
 
 
 (s/def :blaze.db.cache-collector/caches
-  (s/map-of string? #(satisfies? p/StatsCache %)))
+  (s/map-of string? (s/nilable #(satisfies? p/StatsCache %))))

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -289,6 +289,12 @@
   (-clauses [_]))
 
 
+(defn resource-handle [rh-cache raoi t]
+  (if rh-cache
+    (rao/caching-resource-handle rh-cache raoi t)
+    (rao/non-caching-resource-handle raoi t)))
+
+
 (defn new-batch-db
   "Creates a new batch database.
 
@@ -304,7 +310,7 @@
       (let [raoi (kv/new-iterator snapshot :resource-as-of-index)]
         {:snapshot snapshot
          :raoi raoi
-         :resource-handle (rao/resource-handle rh-cache raoi t)
+         :resource-handle (resource-handle rh-cache raoi t)
          :svri (kv/new-iterator snapshot :search-param-value-index)
          :rsvi (kv/new-iterator snapshot :resource-value-index)
          :cri (kv/new-iterator snapshot :compartment-resource-type-index)

--- a/modules/db/src/blaze/db/impl/db.clj
+++ b/modules/db/src/blaze/db/impl/db.clj
@@ -2,7 +2,6 @@
   "Primary Database Implementation"
   (:require
     [blaze.db.impl.batch-db :as batch-db]
-    [blaze.db.impl.index.resource-as-of :as rao]
     [blaze.db.impl.macros :refer [with-open-coll]]
     [blaze.db.impl.protocols :as p]
     [blaze.db.kv :as kv])
@@ -14,14 +13,14 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 
-(deftype Db [node basis-t t]
+(deftype Db [node kv-store rh-cache basis-t t]
   p/Db
   (-node [_]
     node)
 
   (-as-of [_ t]
     (assert (<= ^long t ^long basis-t))
-    (Db. node basis-t t))
+    (Db. node kv-store rh-cache basis-t t))
 
   (-basis-t [_]
     basis-t)
@@ -34,10 +33,9 @@
   ;; ---- Instance-Level Functions --------------------------------------------
 
   (-resource-handle [_ tid id]
-    (let [{:keys [kv-store rh-cache]} node]
-      (with-open [snapshot (kv/new-snapshot kv-store)
-                  raoi (kv/new-iterator snapshot :resource-as-of-index)]
-        ((rao/resource-handle rh-cache raoi t) tid id))))
+    (with-open [snapshot (kv/new-snapshot kv-store)
+                raoi (kv/new-iterator snapshot :resource-as-of-index)]
+      ((batch-db/resource-handle rh-cache raoi t) tid id)))
 
 
 
@@ -206,4 +204,5 @@
 (defn db
   "Creates a database on `node` based on `t`."
   [node t]
-  (->Db node t t))
+  (let [{:keys [kv-store rh-cache]} node]
+    (->Db node kv-store rh-cache t t)))

--- a/modules/db/src/blaze/db/impl/index/resource_as_of.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_as_of.clj
@@ -10,6 +10,7 @@
     [blaze.db.kv :as kv]
     [blaze.fhir.hash :as hash])
   (:import
+    [blaze.db.impl.index.resource_as_of Key]
     [com.github.benmanes.caffeine.cache Cache]
     [com.google.common.primitives Ints]
     [java.util.function Function]))
@@ -415,25 +416,7 @@
         vb))))
 
 
-;; For performance reasons, we use that special Key class instead of a a simple
-;; triple vector
-(deftype Key [^long tid id ^long t]
-  Object
-  (equals [key x]
-    (or (identical? key x)
-        (and (instance? Key x)
-             (= tid (.-tid ^Key x))
-             (.equals id (.-id ^Key x))
-             (= t (.-t ^Key x)))))
-  (hashCode [_]
-    (-> tid
-        (unchecked-multiply-int 31)
-        (unchecked-add-int (.hashCode id))
-        (unchecked-multiply-int 31)
-        (unchecked-add-int t))))
-
-
-(defn resource-handle
+(defn caching-resource-handle
   "Returns a function which can be called with a `tid`, an `id` and an optional
   `t` which will lookup the resource handle in `raoi` using `rh-cache` as cache.
 
@@ -453,6 +436,24 @@
        (resource-handle tid id t))
       ([tid id t]
        (.get ^Cache rh-cache (Key. tid id t) rh)))))
+
+
+(defn non-caching-resource-handle
+  "Returns a function which can be called with a `tid`, an `id` and an optional
+  `t` which will lookup the resource handle in `raoi`.
+
+  The `t` is the default if `t` isn't given at the returned function.
+
+  The returned function can't be called concurrently."
+  [raoi t]
+  (let [tb (bb/allocate-direct max-key-size)
+        kb (bb/allocate-direct max-key-size)
+        vb (bb/allocate-direct value-size)]
+    (fn resource-handle
+      ([tid id]
+       (resource-handle tid id t))
+      ([tid id t]
+       (resource-handle** raoi tb kb vb tid id t)))))
 
 
 (defn num-of-instance-changes

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -472,7 +472,6 @@
   (s/keys
     :req-un
     [:blaze.db/tx-log
-     :blaze.db/resource-handle-cache
      :blaze.db/tx-cache
      ::indexer-executor
      :blaze.db/kv-store
@@ -480,7 +479,8 @@
      :blaze.db/resource-store
      :blaze.db/search-param-registry]
     :opt-un
-    [:blaze.db/enforce-referential-integrity]))
+    [:blaze.db/resource-handle-cache
+     :blaze.db/enforce-referential-integrity]))
 
 
 (def ^:private expected-kv-store-version 0)

--- a/modules/db/src/blaze/db/resource_handle_cache.clj
+++ b/modules/db/src/blaze/db/resource_handle_cache.clj
@@ -23,7 +23,8 @@
   [_ {:keys [max-size] :or {max-size 0}}]
   (log/info "Create resource handle cache with a size of" max-size
             "resource handles")
-  (-> (Caffeine/newBuilder)
-      (.maximumSize max-size)
-      (.recordStats)
-      (.build)))
+  (when (pos? max-size)
+    (-> (Caffeine/newBuilder)
+        (.maximumSize max-size)
+        (.recordStats)
+        (.build))))

--- a/modules/db/src/blaze/db/spec.clj
+++ b/modules/db/src/blaze/db/spec.clj
@@ -20,7 +20,7 @@
 
 
 (s/def :blaze.db/resource-handle-cache
-  cache?)
+  (s/nilable cache?))
 
 
 (defn loading-cache? [x]

--- a/modules/db/test/blaze/db/cache_collector_test.clj
+++ b/modules/db/test/blaze/db/cache_collector_test.clj
@@ -25,7 +25,7 @@
 
 (def system
   {:blaze.db/cache-collector
-   {:caches {"name-135224" cache}}})
+   {:caches {"name-135224" cache "name-093214" nil}}})
 
 
 (deftest init-test

--- a/modules/db/test/blaze/db/impl/index/resource_as_of_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_as_of_spec.clj
@@ -51,9 +51,15 @@
     (s/nilable :blaze.db/resource-handle)))
 
 
-(s/fdef rao/resource-handle
+(s/fdef rao/caching-resource-handle
   :args (s/cat :rh-cache :blaze.db/resource-handle-cache
                :raoi :blaze.db/kv-iterator
+               :t :blaze.db/t)
+  :ret ::resource-handle-fn)
+
+
+(s/fdef rao/non-caching-resource-handle
+  :args (s/cat :raoi :blaze.db/kv-iterator
                :t :blaze.db/t)
   :ret ::resource-handle-fn)
 

--- a/modules/db/test/blaze/db/node_test.clj
+++ b/modules/db/test/blaze/db/node_test.clj
@@ -116,13 +116,12 @@
       :key := :blaze.db/node
       :reason := ::ig/build-failed-spec
       [:explain ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :tx-log))
-      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :resource-handle-cache))
-      [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :tx-cache))
-      [:explain ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :indexer-executor))
-      [:explain ::s/problems 4 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
-      [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :resource-indexer))
-      [:explain ::s/problems 6 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
-      [:explain ::s/problems 7 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))))
+      [:explain ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :tx-cache))
+      [:explain ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :indexer-executor))
+      [:explain ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :kv-store))
+      [:explain ::s/problems 4 :pred] := `(fn ~'[%] (contains? ~'% :resource-indexer))
+      [:explain ::s/problems 5 :pred] := `(fn ~'[%] (contains? ~'% :resource-store))
+      [:explain ::s/problems 6 :pred] := `(fn ~'[%] (contains? ~'% :search-param-registry))))
 
   (testing "invalid tx-log"
     (given-thrown (ig/init (assoc-in system [:blaze.db/node :tx-log] ::invalid))

--- a/modules/db/test/blaze/db/resource_handle_cache_test.clj
+++ b/modules/db/test/blaze/db/resource_handle_cache_test.clj
@@ -18,11 +18,6 @@
 (test/use-fixtures :each tu/fixture)
 
 
-(def system
-  {:blaze.db/resource-handle-cache
-   {:max-size 100}})
-
-
 (deftest init-test
   (testing "invalid max-size"
     (given-thrown (ig/init {:blaze.db/resource-handle-cache nil})
@@ -38,5 +33,11 @@
       [:explain ::s/problems 0 :val] := ::invalid))
 
   (testing "success"
-    (with-system [{:blaze.db/keys [resource-handle-cache]} system]
-      (is (instance? Cache resource-handle-cache)))))
+    (with-system [{:blaze.db/keys [resource-handle-cache]}
+                  {:blaze.db/resource-handle-cache {:max-size 100}}]
+      (is (instance? Cache resource-handle-cache))))
+
+  (testing "produces no cache for :max-size of 0"
+    (with-system [{:blaze.db/keys [resource-handle-cache]}
+                  {:blaze.db/resource-handle-cache {:max-size 0}}]
+      (is (nil? resource-handle-cache)))))


### PR DESCRIPTION
Before, if one sets the max-size of the resource handle cache to zero, a cache was still created which results in a certain overhead on each lookup. Now this overhead is eliminated because no cache is created and the lookup is performed directly into the RocksDB index.