### PR TITLE
Fix Non-Stable Paging

### DIFF
--- a/.github/scripts/follow-next-link-after-write.sh
+++ b/.github/scripts/follow-next-link-after-write.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+#
+# This script fetches the first Patient bundle, adds a new Patient and expects
+# the total on the next page beeing still the same
+#
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+
+FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$BASE/Patient")"
+TOTAL="$(echo "$FIRST_PAGE" | jq -r .total)"
+NEXT_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "next") | .url')"
+
+curl -sfH 'Content-Type: application/fhir+json' -H 'Accept: application/fhir+json' -d "{\"resourceType\": \"Patient\"}" -o /dev/null "$BASE/Patient"
+
+SECOND_PAGE="$(curl -sH "Accept: application/fhir+json" "$NEXT_LINK")"
+
+test "second page total" "$(echo "$SECOND_PAGE" | jq -r .total)" "$TOTAL"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -602,6 +602,9 @@ jobs:
     - name: GraphQL Observation
       run: .github/scripts/graphql.sh Observation
 
+    - name: Paging uses a Stable Snapshot of the Database
+      run: .github/scripts/follow-next-link-after-write.sh
+
     - name: Create Patient
       run: .github/scripts/create-patient.sh
 
@@ -1427,6 +1430,9 @@ jobs:
 
     - name: GraphQL Observation
       run: .github/scripts/graphql.sh Observation
+
+    - name: Paging uses a Stable Snapshot of the Database
+      run: .github/scripts/follow-next-link-after-write.sh
 
     - name: Create Patient
       run: .github/scripts/create-patient.sh

--- a/modules/rest-util/src/blaze/handler/fhir/util_spec.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util_spec.clj
@@ -24,6 +24,11 @@
   :ret nat-int?)
 
 
+(s/fdef util/page-offset
+  :args (s/cat :query-params (s/nilable :ring.request/query-params))
+  :ret nat-int?)
+
+
 (s/fdef util/page-type
   :args (s/cat :query-params (s/nilable :ring.request/query-params))
   :ret (s/nilable :fhir.resource/type))

--- a/modules/rest-util/src/blaze/middleware/fhir/db.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/db.clj
@@ -20,12 +20,13 @@
   (format "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of %d ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.", timeout))
 
 
-(defn- db [node timeout {:keys [query-params] :as request}]
+(defn- db [node timeout {:keys [params] :as request}]
   (if-let [t (vid request)]
     (do-sync [db (d/sync node t)]
       (d/as-of db t))
-    (if-let [t (fhir-util/t query-params)]
-      (d/sync node t)
+    (if-let [t (fhir-util/t params)]
+      (do-sync [db (d/sync node t)]
+        (d/as-of db t))
       (-> (d/sync node)
           (ac/or-timeout! timeout TimeUnit/MILLISECONDS)
           (ac/exceptionally #(assoc % ::anom/message (timeout-msg timeout)))))))

--- a/modules/rest-util/test/blaze/middleware/fhir/db_test.clj
+++ b/modules/rest-util/test/blaze/middleware/fhir/db_test.clj
@@ -66,9 +66,14 @@
        (fn [node t]
          (assert (= ::node node))
          (assert (= 114429 t))
-         (ac/completed-future ::db))]
+         (ac/completed-future ::db))
+       d/as-of
+       (fn [db t]
+         (assert (= ::db db))
+         (assert (= 114429 t))
+         ::as-of-db)]
 
-      (is (= ::db @((db/wrap-db handler ::node) {:query-params {"__t" "114429"}})))))
+      (is (= ::as-of-db @((db/wrap-db handler ::node) {:params {"__t" "114429"}})))))
 
   (testing "uses sync for database value acquisition"
     (with-redefs


### PR DESCRIPTION
I was actually not using an as-of database for requests with a __t query param. So although the database was synced on t, as sync returns the newest database with at least t, we were operating on a to new database if writes happened in between. A simple as-of call to the database will do the trick to get a database with exactly t.