### PR TITLE
Ignore __t Query Param on Most Requests

### DIFF
--- a/.github/scripts/follow-patient-next-link-after-write.sh
+++ b/.github/scripts/follow-patient-next-link-after-write.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+#
+# This script fetches the first Patient bundle, adds a new Patient and expects
+# the total on the next page being still the same
+#
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+
+FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$BASE/Patient")"
+TOTAL="$(echo "$FIRST_PAGE" | jq -r .total)"
+SELF_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "self") | .url')"
+NEXT_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "next") | .url')"
+
+# create new patient
+curl -sfH 'Content-Type: application/fhir+json' -H 'Accept: application/fhir+json' -d "{\"resourceType\": \"Patient\"}" -o /dev/null "$BASE/Patient"
+
+FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$SELF_LINK")"
+SECOND_PAGE="$(curl -sH "Accept: application/fhir+json" "$NEXT_LINK")"
+
+test "first page total" "$(echo "$FIRST_PAGE" | jq -r .total)" "$TOTAL"
+test "second page total" "$(echo "$SECOND_PAGE" | jq -r .total)" "$TOTAL"

--- a/.github/scripts/follow-system-next-link-after-write.sh
+++ b/.github/scripts/follow-system-next-link-after-write.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 #
-# This script fetches the first Patient bundle, adds a new Patient and expects
-# the total on the next page beeing still the same
+# This script fetches the first system bundle, adds a new Patient and expects
+# the total on the next page being still the same
 #
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
@@ -10,12 +10,16 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 BASE="http://localhost:8080/fhir"
 
-FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$BASE/Patient")"
+FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$BASE")"
 TOTAL="$(echo "$FIRST_PAGE" | jq -r .total)"
+SELF_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "self") | .url')"
 NEXT_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "next") | .url')"
 
+# create new patient
 curl -sfH 'Content-Type: application/fhir+json' -H 'Accept: application/fhir+json' -d "{\"resourceType\": \"Patient\"}" -o /dev/null "$BASE/Patient"
 
+FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$SELF_LINK")"
 SECOND_PAGE="$(curl -sH "Accept: application/fhir+json" "$NEXT_LINK")"
 
+test "first page total" "$(echo "$FIRST_PAGE" | jq -r .total)" "$TOTAL"
 test "second page total" "$(echo "$SECOND_PAGE" | jq -r .total)" "$TOTAL"

--- a/.github/scripts/read-ignores-t.sh
+++ b/.github/scripts/read-ignores-t.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/util.sh"
+
+BASE="http://localhost:8080/fhir"
+
+# create a patient
+ID="$(uuidgen)"
+curl -sfXPUT -H 'Content-Type: application/fhir+json' -d "{\"resourceType\": \"Patient\", \"id\": \"$ID\"}" -o /dev/null "$BASE/Patient/$ID"
+
+# if the query param __t was respected, the patient should not exist
+curl -sfH 'Accept: application/fhir+json' "$BASE/Patient/$ID?__t=0" -o /dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -602,11 +602,17 @@ jobs:
     - name: GraphQL Observation
       run: .github/scripts/graphql.sh Observation
 
-    - name: Paging uses a Stable Snapshot of the Database
-      run: .github/scripts/follow-next-link-after-write.sh
+    - name: Paging uses a Stable Snapshot of the Database (Patient)
+      run: .github/scripts/follow-patient-next-link-after-write.sh
+
+    - name: Paging uses a Stable Snapshot of the Database (system)
+      run: .github/scripts/follow-system-next-link-after-write.sh
 
     - name: Create Patient
       run: .github/scripts/create-patient.sh
+
+    - name: Read Ignores T
+      run: .github/scripts/read-ignores-t.sh
 
   not-enforcing-referential-integrity-test:
     needs: build
@@ -1431,11 +1437,17 @@ jobs:
     - name: GraphQL Observation
       run: .github/scripts/graphql.sh Observation
 
-    - name: Paging uses a Stable Snapshot of the Database
-      run: .github/scripts/follow-next-link-after-write.sh
+    - name: Paging uses a Stable Snapshot of the Database (Patient)
+      run: .github/scripts/follow-patient-next-link-after-write.sh
+
+    - name: Paging uses a Stable Snapshot of the Database (system)
+      run: .github/scripts/follow-system-next-link-after-write.sh
 
     - name: Create Patient
       run: .github/scripts/create-patient.sh
+
+    - name: Read Ignores T
+      run: .github/scripts/read-ignores-t.sh
 
     - name: Docker Stats
       run: docker stats --no-stream

--- a/modules/anomaly/src/blaze/anomaly.clj
+++ b/modules/anomaly/src/blaze/anomaly.clj
@@ -32,6 +32,10 @@
   (identical? ::anom/fault (::anom/category x)))
 
 
+(defn busy? [x]
+  (identical? ::anom/busy (::anom/category x)))
+
+
 (defn- anomaly*
   ([category msg]
    (cond-> {::anom/category category} msg (assoc ::anom/message msg)))

--- a/modules/anomaly/src/blaze/anomaly_spec.clj
+++ b/modules/anomaly/src/blaze/anomaly_spec.clj
@@ -31,6 +31,11 @@
   :ret boolean?)
 
 
+(s/fdef ba/busy?
+  :args (s/cat :x any?)
+  :ret boolean?)
+
+
 (s/fdef ba/incorrect
   :args (s/cat :msg (s/nilable string?) :kvs (s/* (s/cat :k keyword? :v any?)))
   :ret ::anom/anomaly)

--- a/modules/anomaly/test/blaze/anomaly_test.clj
+++ b/modules/anomaly/test/blaze/anomaly_test.clj
@@ -73,6 +73,17 @@
     (is (not (ba/anomaly? nil)))))
 
 
+(deftest busy?-test
+  (testing "a busy anomaly has to have the right category"
+    (is (ba/busy? {::anom/category ::anom/busy})))
+
+  (testing "anomalies with other categories are no busy anomalies"
+    (is (not (ba/busy? {::anom/category ::anom/fault}))))
+
+  (testing "nil is no busy anomaly"
+    (is (not (ba/anomaly? nil)))))
+
+
 (deftest incorrect-test
   (testing "with nil message"
     (is (= (ba/incorrect nil) {::anom/category ::anom/incorrect})))

--- a/modules/interaction/.clj-kondo/config.edn
+++ b/modules/interaction/.clj-kondo/config.edn
@@ -9,6 +9,7 @@
   blaze.interaction.history.system-test/with-handler clojure.core/fn
   blaze.interaction.history.type-test/with-handler clojure.core/fn
   blaze.interaction.read-test/with-handler clojure.core/fn
+  blaze.interaction.read-test/with-vread-handler clojure.core/fn
   blaze.interaction.search-compartment-test/with-handler clojure.core/fn
   blaze.interaction.search-system-test/with-handler clojure.core/fn
   blaze.interaction.search-type-test/with-handler clojure.core/fn

--- a/modules/interaction/src/blaze/interaction/read.clj
+++ b/modules/interaction/src/blaze/interaction/read.clj
@@ -75,19 +75,12 @@
 
 
 (defn- wrap-invalid-id-vid [handler]
-  (fn [{{:keys [id vid]} :path-params :as request}]
+  (fn [{{:keys [id]} :path-params :as request}]
     (cond
       (not (re-matches #"[A-Za-z0-9\-\.]{1,64}" id))
       (ac/completed-future
         (ba/incorrect
           (format "Resource id `%s` is invalid." id)
-          :fhir/issue "value"
-          :fhir/operation-outcome "MSG_ID_INVALID"))
-
-      (and vid (not (re-matches #"\d+" vid)))
-      (ac/completed-future
-        (ba/incorrect
-          (format "Resource versionId `%s` is invalid." vid)
           :fhir/issue "value"
           :fhir/operation-outcome "MSG_ID_INVALID"))
 

--- a/modules/interaction/test/blaze/interaction/history/instance_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/instance_test.clj
@@ -99,7 +99,7 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# :blaze.interaction.history/instance} system]
        ~txs
-       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#)
+       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node# 100)
                                   wrap-error)]
          ~@body))))
 

--- a/modules/interaction/test/blaze/interaction/history/system_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/system_test.clj
@@ -101,7 +101,7 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# :blaze.interaction.history/system} system]
        ~txs
-       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#)
+       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node# 100)
                                   wrap-error)]
          ~@body))))
 

--- a/modules/interaction/test/blaze/interaction/history/type_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/type_test.clj
@@ -102,7 +102,7 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# :blaze.interaction.history/type} system]
        ~txs
-       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#)
+       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node# 100)
                                   wrap-error)]
          ~@body))))
 

--- a/modules/interaction/test/blaze/interaction/search_compartment_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_compartment_test.clj
@@ -107,7 +107,7 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# :blaze.interaction/search-compartment} system]
        ~txs
-       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#)
+       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node# 100)
                                   wrap-error)]
          ~@body))))
 

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -66,32 +66,32 @@
       {:name :Observation/type
        :conflicting true
        :fhir.resource/type "Observation"
-       :get {:middleware [[wrap-db node]]
+       :get {:middleware [[wrap-db node 100]]
              :handler (wrap-params search-type-handler)}
        :post create-handler}]
      ["/Observation/__page"
       {:name :Observation/page
        :conflicting true
        :fhir.resource/type "Observation"
-       :get {:middleware [[wrap-db node]]
+       :get {:middleware [[wrap-db node 100]]
              :handler (wrap-params search-type-handler)}}]
      ["/Patient"
       {:name :Patient/type
        :fhir.resource/type "Patient"
-       :get {:middleware [[wrap-db node]]
+       :get {:middleware [[wrap-db node 100]]
              :handler (wrap-params search-type-handler)}
        :post create-handler}]
      ["/Patient/__page"
       {:name :Patient/page
        :conflicting true
        :fhir.resource/type "Patient"
-       :get {:middleware [[wrap-db node]]
+       :get {:middleware [[wrap-db node 100]]
              :handler (wrap-params search-type-handler)}}]
      ["/Patient/{id}"
       {:name :Patient/instance
        :conflicting true
        :fhir.resource/type "Patient"
-       :get {:middleware [[wrap-db node]] :handler read-handler}
+       :get {:middleware [[wrap-db node 100]] :handler read-handler}
        :delete delete-handler
        :put update-handler}]
      ["/Patient/{id}/_history/{vid}"

--- a/modules/operation-graphql/test/blaze/fhir/operation/graphql_test.clj
+++ b/modules/operation-graphql/test/blaze/fhir/operation/graphql_test.clj
@@ -81,7 +81,7 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# ::graphql/handler} system]
        ~txs
-       (let [~handler-binding (-> handler# (wrap-db node#) wrap-error)]
+       (let [~handler-binding (-> handler# (wrap-db node# 100) wrap-error)]
          ~@body))))
 
 

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -180,7 +180,7 @@
     `(with-system-data [{node# :blaze.db/node
                          handler# ::evaluate-measure/handler} system]
        ~txs
-       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node#)
+       (let [~handler-binding (-> handler# wrap-defaults (wrap-db node# 100)
                                   wrap-error)]
          ~@body))))
 

--- a/modules/rest-api/src/blaze/rest_api/routes.clj
+++ b/modules/rest-api/src/blaze/rest_api/routes.clj
@@ -48,6 +48,21 @@
    :wrap db/wrap-db})
 
 
+(def ^:private wrap-search-db
+  {:name :search-db
+   :wrap db/wrap-search-db})
+
+
+(def ^:private wrap-snapshot-db
+  {:name :snapshot-db
+   :wrap db/wrap-snapshot-db})
+
+
+(def ^:private wrap-versioned-instance-db
+  {:name :versioned-instance-db
+   :wrap db/wrap-versioned-instance-db})
+
+
 (def ^:private wrap-ensure-form-body
   {:name :ensure-form-body
    :wrap ensure-form-body/wrap-ensure-form-body})
@@ -96,7 +111,7 @@
      [""
       (cond-> {:name (keyword name "type")}
         (contains? interactions :search-type)
-        (assoc :get {:middleware [[wrap-db node db-sync-timeout]]
+        (assoc :get {:middleware [[wrap-search-db node db-sync-timeout]]
                      :handler (-> interactions :search-type
                                   :blaze.rest-api.interaction/handler)})
         (contains? interactions :create)
@@ -120,10 +135,10 @@
       (cond-> {:name (keyword name "page") :conflicting true}
         (contains? interactions :search-type)
         (assoc
-          :get {:middleware [[wrap-db node db-sync-timeout]]
+          :get {:middleware [[wrap-snapshot-db node db-sync-timeout]]
                 :handler (-> interactions :search-type
                              :blaze.rest-api.interaction/handler)}
-          :post {:middleware [[wrap-db node db-sync-timeout]]
+          :post {:middleware [[wrap-snapshot-db node db-sync-timeout]]
                  :handler (-> interactions :search-type
                               :blaze.rest-api.interaction/handler)}))]
      ["/{id}"
@@ -154,7 +169,7 @@
        ["/{vid}"
         (cond-> {:name (keyword name "versioned-instance")}
           (contains? interactions :vread)
-          (assoc :get {:middleware [[wrap-db node db-sync-timeout]]
+          (assoc :get {:middleware [[wrap-versioned-instance-db node db-sync-timeout]]
                        :handler (-> interactions :vread
                                     :blaze.rest-api.interaction/handler)}))]]]]))
 
@@ -243,7 +258,7 @@
        [""
         (cond-> {}
           (some? search-system-handler)
-          (assoc :get {:middleware [[wrap-db node db-sync-timeout]]
+          (assoc :get {:middleware [[wrap-search-db node db-sync-timeout]]
                        :handler search-system-handler})
           (some? transaction-handler)
           (assoc :post {:middleware
@@ -261,9 +276,9 @@
         (cond-> {:name :page}
           (some? search-system-handler)
           (assoc
-            :get {:middleware [[wrap-db node db-sync-timeout]]
+            :get {:middleware [[wrap-snapshot-db node db-sync-timeout]]
                   :handler search-system-handler}
-            :post {:middleware [[wrap-db node db-sync-timeout]]
+            :post {:middleware [[wrap-snapshot-db node db-sync-timeout]]
                    :handler search-system-handler}))]]
       (into
         (mapcat (partial operation-system-handler-route context))

--- a/modules/rest-api/test/blaze/rest_api_test.clj
+++ b/modules/rest-api/test/blaze/rest_api_test.clj
@@ -148,18 +148,22 @@
                 (reitit/match-by-path (router []) path)
                 [:result request-method :data :middleware])
               (mapv (comp :name #(if (sequential? %) (first %) %)))))
-      "" :get [:params :output :error :forwarded :sync :db]
+      "" :get [:params :output :error :forwarded :sync :search-db]
       "" :post [:params :output :error :forwarded :sync :resource :wrap-batch-handler]
       "/_history" :get [:params :output :error :forwarded :sync :db]
-      "/Patient" :get [:params :output :error :forwarded :sync :db]
+      "/__page" :get [:params :output :error :forwarded :sync :snapshot-db]
+      "/__page" :post [:params :output :error :forwarded :sync :snapshot-db]
+      "/Patient" :get [:params :output :error :forwarded :sync :search-db]
       "/Patient" :post [:params :output :error :forwarded :sync :resource]
       "/Patient/_history" :get [:params :output :error :forwarded :sync :db]
       "/Patient/_search" :post [:params :output :error :forwarded :sync :ensure-form-body :db]
+      "/Patient/__page" :get [:params :output :error :forwarded :sync :snapshot-db]
+      "/Patient/__page" :post [:params :output :error :forwarded :sync :snapshot-db]
       "/Patient/0" :get [:params :output :error :forwarded :sync :db]
       "/Patient/0" :put [:params :output :error :forwarded :sync :resource]
       "/Patient/0" :delete [:params :output :error :forwarded :sync]
       "/Patient/0/_history" :get [:params :output :error :forwarded :sync :db]
-      "/Patient/0/_history/42" :get [:params :output :error :forwarded :sync :db]
+      "/Patient/0/_history/42" :get [:params :output :error :forwarded :sync :versioned-instance-db]
       "/Patient/0/Condition" :get [:params :output :error :forwarded :sync :db]
       "/Patient/0/Observation" :get [:params :output :error :forwarded :sync :db]
       "/$compact-db" :get [:params :output :error :forwarded :sync :db]
@@ -177,7 +181,7 @@
                   (reitit/match-by-path (router [:auth-backend]) path)
                   [:result request-method :data :middleware])
                 (mapv (comp :name #(if (sequential? %) (first %) %)))))
-        "" :get [:params :output :error :forwarded :sync :auth-guard :db]
+        "" :get [:params :output :error :forwarded :sync :auth-guard :search-db]
         "" :post [:params :output :error :forwarded :sync :auth-guard :resource :wrap-batch-handler]
         "/$compact-db" :get [:params :output :error :forwarded :sync :auth-guard :db]
         "/$compact-db" :post [:params :output :error :forwarded :sync :auth-guard :db :resource]

--- a/modules/rest-util/src/blaze/middleware/fhir/db.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/db.clj
@@ -3,7 +3,9 @@
 
   It uses the optional query param __t and vid from path to acquire the right
   database value."
+  (:refer-clojure :exclude [sync])
   (:require
+    [blaze.anomaly :as ba]
     [blaze.async.comp :as ac :refer [do-sync]]
     [blaze.db.api :as d]
     [blaze.handler.fhir.util :as fhir-util]
@@ -12,32 +14,84 @@
     [java.util.concurrent TimeUnit]))
 
 
-(defn- vid [{{:keys [vid]} :path-params}]
-  (some-> vid fhir-util/parse-nat-long))
-
-
 (defn- timeout-msg [timeout]
-  (format "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of %d ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.", timeout))
+  (format "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of %d ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often." timeout))
 
 
-(defn- db [node timeout {:keys [params] :as request}]
-  (if-let [t (vid request)]
-    (do-sync [db (d/sync node t)]
-      (d/as-of db t))
-    (if-let [t (fhir-util/t params)]
-      (do-sync [db (d/sync node t)]
-        (d/as-of db t))
-      (-> (d/sync node)
-          (ac/or-timeout! timeout TimeUnit/MILLISECONDS)
-          (ac/exceptionally #(assoc % ::anom/message (timeout-msg timeout)))))))
+(defn- timeout-t-msg [t timeout]
+  (format "Timeout while trying to acquire the database state with t=%d. The indexer has probably fallen behind. Please try to lower the transaction load or increase the timeout of %d ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often." t timeout))
+
+
+(defn- sync [node timeout]
+  (-> (d/sync node)
+      (ac/or-timeout! timeout TimeUnit/MILLISECONDS)
+      (ac/exceptionally #(cond-> % (ba/busy? %) (assoc ::anom/message (timeout-msg timeout))))))
 
 
 (defn wrap-db
-  ([handler node]
-   (wrap-db handler node 10000))
-  ([handler node timeout]
-   (fn [request]
-     (if (:blaze/db request)
-       (handler request)
-       (-> (db node timeout request)
-           (ac/then-compose #(handler (assoc request :blaze/db %))))))))
+  "Default database wrapping.
+
+  Always syncs on the latest known database state."
+  [handler node timeout]
+  (fn [request]
+    (if (:blaze/db request)
+      (handler request)
+      (-> (sync node timeout)
+          (ac/then-compose #(handler (assoc request :blaze/db %)))))))
+
+
+(defn- sync-t [node t timeout]
+  (-> (do-sync [db (d/sync node t)]
+        (d/as-of db t))
+      (ac/or-timeout! timeout TimeUnit/MILLISECONDS)
+      (ac/exceptionally #(cond-> % (ba/busy? %) (assoc ::anom/message (timeout-t-msg t timeout))))))
+
+
+(defn wrap-search-db
+  "Database wrapping for requests that like to either operate on the latest
+  known database state or a known database state.
+
+  Currently the `t` of the database state taken from the query or form param
+  `__t`."
+  [handler node timeout]
+  (fn [{:keys [params] :as request}]
+    (if (:blaze/db request)
+      (handler request)
+      (-> (if-let [t (fhir-util/t params)]
+            (sync-t node t timeout)
+            (sync node timeout))
+          (ac/then-compose #(handler (assoc request :blaze/db %)))))))
+
+
+(defn wrap-snapshot-db
+  "Database wrapping for requests that like to operate on a known database state.
+
+  Currently the `t` of the database state taken from the query or form param
+  `__t`."
+  [handler node timeout]
+  (fn [{:keys [params] :as request}]
+    (if (:blaze/db request)
+      (handler request)
+      (if-let [t (fhir-util/t params)]
+        (-> (sync-t node t timeout)
+            (ac/then-compose #(handler (assoc request :blaze/db %))))
+        (ac/completed-future
+          (ba/incorrect (format "Missing or invalid `__t` query param `%s`." (params "__t"))))))))
+
+
+(defn wrap-versioned-instance-db
+  "Database wrapping for versioned read requests.
+
+  The `t` of the database state is taken from the path param `vid`."
+  [handler node timeout]
+  (fn [{{:keys [vid]} :path-params :as request}]
+    (if (:blaze/db request)
+      (handler request)
+      (if-let [t (some-> vid fhir-util/parse-nat-long)]
+        (-> (sync-t node t timeout)
+            (ac/then-compose #(handler (assoc request :blaze/db %))))
+        (ac/completed-future
+          (ba/incorrect
+            (format "Resource versionId `%s` is invalid." vid)
+            :fhir/issue "value"
+            :fhir/operation-outcome "MSG_ID_INVALID"))))))

--- a/modules/rest-util/src/blaze/middleware/fhir/db_spec.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/db_spec.clj
@@ -1,8 +1,21 @@
 (ns blaze.middleware.fhir.db-spec
   (:require
+    [blaze.db.spec]
     [blaze.middleware.fhir.db :as db]
     [clojure.spec.alpha :as s]))
 
 
 (s/fdef db/wrap-db
-  :args (s/cat :handler ifn? :node :blaze.db/node :timeout (s/? pos-int?)))
+  :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))
+
+
+(s/fdef db/wrap-search-db
+  :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))
+
+
+(s/fdef db/wrap-snapshot-db
+  :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))
+
+
+(s/fdef db/wrap-versioned-instance-db
+  :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))

--- a/modules/rest-util/test/blaze/middleware/fhir/db_test.clj
+++ b/modules/rest-util/test/blaze/middleware/fhir/db_test.clj
@@ -3,8 +3,10 @@
   between the database value acquisition methods if one only sees the database
   value as result."
   (:require
+    [blaze.anomaly :as ba]
     [blaze.async.comp :as ac]
     [blaze.db.api :as d]
+    [blaze.db.api-spec]
     [blaze.middleware.fhir.db :as db]
     [blaze.middleware.fhir.db-spec]
     [blaze.test-util :refer [given-failed-future]]
@@ -21,6 +23,11 @@
 (defn- fixture [f]
   (st/instrument)
   (st/unstrument `db/wrap-db)
+  (st/unstrument `db/wrap-search-db)
+  (st/unstrument `db/wrap-snapshot-db)
+  (st/unstrument `db/wrap-versioned-instance-db)
+  (st/unstrument `d/sync)
+  (st/unstrument `d/as-of)
   (f)
   (st/unstrument))
 
@@ -28,37 +35,60 @@
 (test/use-fixtures :each fixture)
 
 
+(def timeout 100)
 (def handler (comp ac/completed-future :blaze/db))
 
 
 (deftest wrap-db-test
   (testing "uses existing database value"
-    (is (= ::db @((db/wrap-db handler ::node) {:blaze/db ::db}))))
+    (is (= ::db @((db/wrap-db handler ::node timeout) {:blaze/db ::db}))))
 
-  (testing "with invalid vid"
-    (doseq [invalid-vid ["a" "-1"]]
-      (with-redefs
-        [d/sync
-         (fn [node]
-           (assert (= ::node node))
-           (ac/completed-future ::db))]
-
-        (is (= ::db @((db/wrap-db handler ::node) {:path-params {:vid invalid-vid}}))))))
-
-  (testing "uses the vid for database value acquisition"
+  (testing "uses sync for database value acquisition"
     (with-redefs
       [d/sync
-       (fn [node t]
+       (fn [node]
          (assert (= ::node node))
-         (assert (= 114418 t))
-         (ac/completed-future ::db))
-       d/as-of
-       (fn [db t]
-         (assert (= ::db db))
-         (assert (= 114418 t))
-         ::as-of-db)]
+         (ac/completed-future ::db))]
 
-      (is (= ::as-of-db @((db/wrap-db handler ::node) {:path-params {:vid "114418"}})))))
+      (is (= ::db @((db/wrap-db handler ::node timeout) {})))))
+
+  (testing "fails on timeout"
+    (with-redefs
+      [d/sync
+       (fn [node]
+         (assert (= ::node node))
+         (ac/supply-async (constantly ::db) (ac/delayed-executor 1 TimeUnit/SECONDS)))]
+
+      (given-failed-future ((db/wrap-db handler ::node timeout) {})
+        ::anom/category := ::anom/busy
+        ::anom/message := "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of 100 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.")))
+
+  (testing "fails on other sync error"
+    (with-redefs
+      [d/sync
+       (fn [node]
+         (assert (= ::node node))
+         (ac/completed-future (ba/fault "msg-115845")))]
+
+      (given-failed-future ((db/wrap-db handler ::node timeout) {})
+        ::anom/category := ::anom/fault
+        ::anom/message := "msg-115845"))))
+
+
+(deftest wrap-search-db-test
+  (testing "uses existing database value"
+    (is (= ::db @((db/wrap-search-db handler ::node timeout) {:blaze/db ::db}))))
+
+  (testing "with missing or invalid __t"
+    (doseq [t [nil "a" "-1"]]
+      (testing "uses sync for database value acquisition"
+        (with-redefs
+          [d/sync
+           (fn [node]
+             (assert (= ::node node))
+             (ac/completed-future ::db))]
+
+          (is (= ::db @((db/wrap-search-db handler ::node timeout) {:params {"__t" t}})))))))
 
   (testing "uses __t for database value acquisition"
     (with-redefs
@@ -73,35 +103,154 @@
          (assert (= 114429 t))
          ::as-of-db)]
 
-      (is (= ::as-of-db @((db/wrap-db handler ::node) {:params {"__t" "114429"}})))))
+      (is (= ::as-of-db @((db/wrap-search-db handler ::node timeout) {:params {"__t" "114429"}})))))
 
-  (testing "uses sync for database value acquisition"
+  (testing "fails on timeout"
+    (testing "with t"
+      (with-redefs
+        [d/sync
+         (fn [node t]
+           (assert (= ::node node))
+           (assert (= 213937 t))
+           (ac/supply-async (constantly ::db) (ac/delayed-executor 1 TimeUnit/SECONDS)))]
+
+        (given-failed-future ((db/wrap-search-db handler ::node timeout) {:params {"__t" "213937"}})
+          ::anom/category := ::anom/busy
+          ::anom/message := "Timeout while trying to acquire the database state with t=213937. The indexer has probably fallen behind. Please try to lower the transaction load or increase the timeout of 100 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.")))
+
+    (testing "without t"
+      (with-redefs
+        [d/sync
+         (fn [node]
+           (assert (= ::node node))
+           (ac/supply-async (constantly ::db) (ac/delayed-executor 1 TimeUnit/SECONDS)))]
+
+        (given-failed-future ((db/wrap-search-db handler ::node timeout) {})
+          ::anom/category := ::anom/busy
+          ::anom/message := "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of 100 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often."))))
+
+  (testing "fails on other sync error"
+    (testing "with t"
+      (with-redefs
+        [d/sync
+         (fn [node t]
+           (assert (= ::node node))
+           (assert (= 114148 t))
+           (ac/completed-future (ba/fault "msg-120127")))]
+
+        (given-failed-future ((db/wrap-search-db handler ::node timeout) {:params {"__t" "114148"}})
+          ::anom/category := ::anom/fault
+          ::anom/message := "msg-120127")))
+
+    (testing "without t"
+      (with-redefs
+        [d/sync
+         (fn [node]
+           (assert (= ::node node))
+           (ac/completed-future (ba/fault "msg-115918")))]
+
+        (given-failed-future ((db/wrap-search-db handler ::node timeout) {})
+          ::anom/category := ::anom/fault
+          ::anom/message := "msg-115918")))))
+
+
+(deftest wrap-snapshot-db-test
+  (testing "uses existing database value"
+    (is (= ::db @((db/wrap-snapshot-db handler ::node timeout) {:blaze/db ::db}))))
+
+  (testing "with missing or invalid __t"
+    (doseq [t [nil "a" "-1"]]
+      (given-failed-future ((db/wrap-snapshot-db handler ::node timeout) {:params {"__t" t}})
+        ::anom/category := ::anom/incorrect
+        ::anom/message := (format "Missing or invalid `__t` query param `%s`." t))))
+
+  (testing "uses __t for database value acquisition"
     (with-redefs
       [d/sync
-       (fn [node]
+       (fn [node t]
          (assert (= ::node node))
-         (ac/completed-future ::db))]
+         (assert (= 114429 t))
+         (ac/completed-future ::db))
+       d/as-of
+       (fn [db t]
+         (assert (= ::db db))
+         (assert (= 114429 t))
+         ::as-of-db)]
 
-      (is (= ::db @((db/wrap-db handler ::node) {}))))
+      (is (= ::as-of-db @((db/wrap-snapshot-db handler ::node timeout) {:params {"__t" "114429"}})))))
 
-    (testing "fails on timeout"
-      (with-redefs
-        [d/sync
-         (fn [node]
-           (assert (= ::node node))
-           (ac/supply-async (constantly ::db) (ac/delayed-executor 3 TimeUnit/SECONDS)))]
+  (testing "fails on timeout"
+    (with-redefs
+      [d/sync
+       (fn [node t]
+         (assert (= ::node node))
+         (assert (= 114148 t))
+         (ac/supply-async (constantly ::db) (ac/delayed-executor 1 TimeUnit/SECONDS)))]
 
-        (given-failed-future ((db/wrap-db handler ::node 2000) {})
-          ::anom/category := ::anom/busy
-          ::anom/message := "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of 2000 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.")))
+      (given-failed-future ((db/wrap-snapshot-db handler ::node timeout) {:params {"__t" "114148"}})
+        ::anom/category := ::anom/busy
+        ::anom/message := "Timeout while trying to acquire the database state with t=114148. The indexer has probably fallen behind. Please try to lower the transaction load or increase the timeout of 100 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.")))
 
-    (testing "default timeout are 10 seconds"
-      (with-redefs
-        [d/sync
-         (fn [node]
-           (assert (= ::node node))
-           (ac/supply-async (constantly ::db) (ac/delayed-executor 11 TimeUnit/SECONDS)))]
+  (testing "fails on other sync error"
+    (with-redefs
+      [d/sync
+       (fn [node t]
+         (assert (= ::node node))
+         (assert (= 114148 t))
+         (ac/completed-future (ba/fault "msg-115945")))]
 
-        (given-failed-future ((db/wrap-db handler ::node) {})
-          ::anom/category := ::anom/busy
-          ::anom/message := "Timeout while trying to acquire the latest known database state. At least one known transaction hasn't been completed yet. Please try to lower the transaction load or increase the timeout of 10000 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.")))))
+      (given-failed-future ((db/wrap-snapshot-db handler ::node timeout) {:params {"__t" "114148"}})
+        ::anom/category := ::anom/fault
+        ::anom/message := "msg-115945"))))
+
+
+(deftest wrap-versioned-instance-db-test
+  (testing "uses existing database value"
+    (is (= ::db @((db/wrap-versioned-instance-db handler ::node timeout) {:blaze/db ::db}))))
+
+  (testing "with missing or invalid vid"
+    (doseq [vid [nil "a" "-1"]]
+      (given-failed-future ((db/wrap-versioned-instance-db handler ::node timeout) {:path-params {:vid vid}})
+        ::anom/category := ::anom/incorrect
+        ::anom/message := (format "Resource versionId `%s` is invalid." vid)
+        :fhir/issue := "value"
+        :fhir/operation-outcome := "MSG_ID_INVALID")))
+
+  (testing "uses the vid for database value acquisition"
+    (with-redefs
+      [d/sync
+       (fn [node t]
+         (assert (= ::node node))
+         (assert (= 114418 t))
+         (ac/completed-future ::db))
+       d/as-of
+       (fn [db t]
+         (assert (= ::db db))
+         (assert (= 114418 t))
+         ::as-of-db)]
+
+      (is (= ::as-of-db @((db/wrap-versioned-instance-db handler ::node timeout) {:path-params {:vid "114418"}})))))
+
+  (testing "fails on timeout"
+    (with-redefs
+      [d/sync
+       (fn [node t]
+         (assert (= ::node node))
+         (assert (= 213957 t))
+         (ac/supply-async (constantly ::db) (ac/delayed-executor 1 TimeUnit/SECONDS)))]
+
+      (given-failed-future ((db/wrap-versioned-instance-db handler ::node timeout) {:path-params {:vid "213957"}})
+        ::anom/category := ::anom/busy
+        ::anom/message := "Timeout while trying to acquire the database state with t=213957. The indexer has probably fallen behind. Please try to lower the transaction load or increase the timeout of 100 ms by setting DB_SYNC_TIMEOUT to a higher value if you see this often.")))
+
+  (testing "fails on other sync error"
+    (with-redefs
+      [d/sync
+       (fn [node t]
+         (assert (= ::node node))
+         (assert (= 120213 t))
+         (ac/completed-future (ba/fault "msg-120219")))]
+
+      (given-failed-future ((db/wrap-versioned-instance-db handler ::node timeout) {:path-params {:vid "120213"}})
+        ::anom/category := ::anom/fault
+        ::anom/message := "msg-120219"))))


### PR DESCRIPTION
Most requests should operate on the newest database state. So respecting the __t query param on all requests would expose an extensive API that we don't like to support. Now only the endpoints of paging and self links support the __t query param.