### PR TITLE
Update View On GitHub link in doc to Blaze repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
     link: /deployment/README
   - theme: alt
     text: View on GitHub
-    link: https://github.com/vuejs/vitepress
+    link: https://github.com/samply/blaze
 
 features:
 - title: Internal, fast CQL Evaluation Engine


### PR DESCRIPTION
When clicking "View on GitHub" in documentation page, the repo opened is [vitepress](https://github.com/vuejs/vitepress) instead of [blaze](https://github.com/samply/blaze)
