### PR TITLE
Fix Weight Calculation in Page Store

### DIFF
--- a/modules/page-store/src/blaze/page_store/local.clj
+++ b/modules/page-store/src/blaze/page_store/local.clj
@@ -55,7 +55,7 @@
   (->LocalPageStore
     secure-rng
     (-> (Caffeine/newBuilder)
-        (.maximumWeight (* 1024 1024 max-size-in-mb))
+        (.maximumWeight (bit-shift-left max-size-in-mb 20))
         (.weigher weigher)
         (.expireAfterAccess expire-duration)
         (.build))))

--- a/modules/page-store/src/blaze/page_store/weigh.clj
+++ b/modules/page-store/src/blaze/page_store/weigh.clj
@@ -20,7 +20,7 @@
   PersistentVector
   (-weigh [xs]
     (let [l (.count xs)
-          vector-weight (+ 240 (* (cond-> (quot l 2) (pos? (rem l 2)) inc) 8))]
+          vector-weight (+ 56 (* (cond-> (quot l 2) (pos? (rem l 2)) inc) 8))]
       (transduce (map -weigh) + vector-weight xs)))
   Keyword
   (-weigh [_]

--- a/modules/page-store/test/blaze/page_store/weigh_test.clj
+++ b/modules/page-store/test/blaze/page_store/weigh_test.clj
@@ -15,11 +15,16 @@
 
   (testing "Vector"
     (are [v size] (= size (w/weigh v))
-      [] 240
-      [:x] 248
-      [""] 288
-      (vec (repeat 2 :x)) 248
-      (vec (repeat 3 :x)) 256
-      (vec (repeat 3 "")) 376
-      (vec (repeat 4 :x)) 256
-      (vec (repeat 5 :x)) 264)))
+      [] 56
+      [:x] 64
+      [""] 104
+      (vec (repeat 2 :x)) 64
+      (vec (repeat 3 :x)) 72
+      (vec (repeat 3 "")) 192
+      (vec (repeat 4 :x)) 72
+      (vec (repeat 5 :x)) 80))
+
+  (testing "typical clauses"
+    (are [clauses size] (= size (w/weigh clauses))
+      [["code" "10509002"]] 224
+      [["code" "http://snomed.info/sct|10509002"]] 248)))


### PR DESCRIPTION
I did not take into account that the PersistentVector/EMPTY_NODE is shared between vectors. So the size is a lot smaller.