### PR TITLE
Increase Local Page Store Size

### DIFF
--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -866,7 +866,29 @@
                      (link-url body "next"))))
 
             (testing "the bundle contains one entry"
-              (is (= 1 (count (:entry body))))))))
+              (is (= 1 (count (:entry body)))))))
+
+        (testing "search for inactive patients"
+          (let [{:keys [body]}
+                @(handler
+                   {::reitit/match patient-match
+                    :params {"active" "false"}})]
+
+            (testing "the total is zero"
+              (is (zero? (type/value (:total body)))))
+
+            (testing "has a self link"
+              (is (= (str base-url context-path "/Patient?active=false&_count=50&__t=1")
+                     (link-url body "self"))))
+
+            (testing "has no first link"
+              (is (nil? (link-url body "first"))))
+
+            (testing "has no next link"
+              (is (nil? (link-url body "next"))))
+
+            (testing "the bundle contains no entry"
+              (is (zero? (count (:entry body))))))))
 
       (testing "on /_search request"
         (testing "search for active patients with _count=1"
@@ -892,7 +914,29 @@
                      (link-url body "next"))))
 
             (testing "the bundle contains one entry"
-              (is (= 1 (count (:entry body))))))))
+              (is (= 1 (count (:entry body)))))))
+
+        (testing "search for inactive patients"
+          (let [{:keys [body]}
+                @(handler
+                   {::reitit/match patient-search-match
+                    :params {"active" "false"}})]
+
+            (testing "the total is zero"
+              (is (zero? (type/value (:total body)))))
+
+            (testing "has a self link"
+              (is (= (str base-url context-path "/Patient?active=false&_count=50&__t=1")
+                     (link-url body "self"))))
+
+            (testing "has no first link"
+              (is (nil? (link-url body "first"))))
+
+            (testing "has no next link"
+              (is (nil? (link-url body "next"))))
+
+            (testing "the bundle contains no entry"
+              (is (zero? (count (:entry body))))))))
 
       (testing "following the self link"
         (let [{:keys [body]}

--- a/modules/page-store/src/blaze/page_store/local.clj
+++ b/modules/page-store/src/blaze/page_store/local.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.anomaly :as ba]
     [blaze.async.comp :as ac]
+    [blaze.metrics.core :as metrics]
     [blaze.page-store.local.token :as token]
     [blaze.page-store.protocols :as p]
     [blaze.page-store.spec]
@@ -21,17 +22,17 @@
   (format "Clauses of token `%s` not found." token))
 
 
-(defrecord LocalPageStore [secure-rng ^Cache db]
+(defrecord LocalPageStore [secure-rng ^Cache cache]
   p/PageStore
   (-get [_ token]
     (ac/completed-future
-      (or (.getIfPresent db token) (ba/not-found (not-found-msg token)))))
+      (or (.getIfPresent cache token) (ba/not-found (not-found-msg token)))))
 
   (-put [_ clauses]
     (if (empty? clauses)
       (ac/completed-future (ba/incorrect "Clauses should not be empty."))
       (let [token (token/generate secure-rng)]
-        (.put db token clauses)
+        (.put cache token clauses)
         (ac/completed-future token)))))
 
 
@@ -51,7 +52,8 @@
 (defmethod ig/init-key :blaze.page-store/local
   [_ {:keys [secure-rng max-size-in-mb expire-duration]
       :or {max-size-in-mb 10 expire-duration (time/hours 24)}}]
-  (log/info "Open local page store")
+  (log/info "Open local page store with a capacity of" max-size-in-mb
+            "MiB and an expire duration of" expire-duration)
   (->LocalPageStore
     secure-rng
     (-> (Caffeine/newBuilder)
@@ -62,3 +64,21 @@
 
 
 (derive :blaze.page-store/local :blaze/page-store)
+
+
+(defmethod ig/pre-init-spec :blaze.page-store.local/collector [_]
+  (s/keys :req-un [:blaze/page-store]))
+
+
+(defmethod ig/init-key :blaze.page-store.local/collector
+  [_ {:keys [page-store]}]
+  (metrics/collector
+    [(metrics/gauge-metric
+       "blaze_page_store_estimated_size"
+       "Returns the approximate number of tokens in the page store."
+       []
+       [{:label-values []
+         :value (.estimatedSize ^Cache (:cache page-store))}])]))
+
+
+(derive :blaze.page-store.local/collector :blaze.metrics/collector)

--- a/modules/page-store/src/blaze/page_store/spec.clj
+++ b/modules/page-store/src/blaze/page_store/spec.clj
@@ -6,8 +6,12 @@
     [java.util Random]))
 
 
+(defn page-store? [x]
+  (satisfies? p/PageStore x))
+
+
 (s/def :blaze/page-store
-  #(satisfies? p/PageStore %))
+  page-store?)
 
 
 (s/def :blaze.page-store/secure-rng

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -362,7 +362,10 @@
    ;; Can be referred by the super key :blaze.db/resource-store.
    ;;
    :blaze.page-store/local
-   {:secure-rng #blaze/ref :blaze/secure-rng}}
+   {:secure-rng #blaze/ref :blaze/secure-rng}
+
+   :blaze.page-store.local/collector
+   {:page-store #blaze/ref :blaze.page-store/local}}
 
   :standalone
   {
@@ -560,7 +563,11 @@
    ;; Can be referred by the super key :blaze.db/resource-store.
    ;;
    :blaze.page-store/local
-   {:secure-rng #blaze/ref :blaze/secure-rng}}
+   {:secure-rng #blaze/ref :blaze/secure-rng
+    :max-size-in-mb 100}
+
+   :blaze.page-store.local/collector
+   {:page-store #blaze/ref :blaze.page-store/local}}
 
   :distributed
   {

--- a/test/blaze/system_test.clj
+++ b/test/blaze/system_test.clj
@@ -253,7 +253,7 @@
     (with-system [{:blaze/keys [rest-api]} system]
       (given (call rest-api {:request-method :get :uri "/Patient"})
         :status := 200
-        [:headers "Link"] := "<http://localhost:8080/Patient?_count=50&__t=0>;rel=\"self\",<http://localhost:8080/Patient/__page?_count=50&__t=0>;rel=\"first\""
+        [:headers "Link"] := "<http://localhost:8080/Patient?_count=50&__t=0>;rel=\"self\""
         [:body fhir-spec/parse-json :resourceType] := "Bundle")))
 
   (testing "using POST"


### PR DESCRIPTION
We have also included the metric "blaze_page_store_estimated_size" to enable monitoring of the size. Additionally, we have decided to avoid generating tokens for searches that yield zero matches because such searches are fast and can result in a large number of useless tokens.