### PR TITLE
Add Support for Custom Search Parameters

### DIFF
--- a/.github/custom-search-parameters-test/create-patient.sh
+++ b/.github/custom-search-parameters-test/create-patient.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+BASE="http://localhost:8080/fhir"
+
+patient() {
+cat <<END
+{
+  "resourceType": "Patient",
+  "maritalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+        "code": "M"
+      }
+    ]
+  }
+}
+END
+}
+
+curl -fsH 'Content-Type: application/fhir+json' -d "$(patient)" -o /dev/null "$BASE/Patient"

--- a/.github/custom-search-parameters-test/custom-search-parameters.json
+++ b/.github/custom-search-parameters-test/custom-search-parameters.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://samply.github.io/blaze/fhir/SearchParameter/Patient-marital-status",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "marital-status",
+        "url": "https://samply.github.io/blaze/fhir/SearchParameter/Patient-marital-status",
+        "version": "0.1.0",
+        "name": "marital-status",
+        "status": "active",
+        "code": "marital-status",
+        "base": [
+          "Patient"
+        ],
+        "type": "token",
+        "expression": "Patient.maritalStatus"
+      }
+    }
+  ]
+}

--- a/.github/custom-search-parameters-test/docker-compose.yml
+++ b/.github/custom-search-parameters-test/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  blaze:
+    image: "blaze:latest"
+    environment:
+      DB_SEARCH_PARAM_BUNDLE: "/app/custom-search-parameters.json"
+      LOG_LEVEL: trace
+    ports:
+    - "8080:8080"
+    volumes:
+    - "${GITHUB_WORKSPACE}/.github/custom-search-parameters-test/custom-search-parameters.json:/app/custom-search-parameters.json:ro"
+    - "blaze-data:/app/data"
+volumes:
+  blaze-data:

--- a/.github/custom-search-parameters-test/search-patient.sh
+++ b/.github/custom-search-parameters-test/search-patient.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/../scripts/util.sh"
+
+BASE="http://localhost:8080/fhir"
+
+count() {
+  curl -sH 'Prefer: handling=strict' -H 'Accept: application/fhir+json' "$BASE/Patient?marital-status=M" | jq .total
+}
+
+test "number of patients" "$(count)" "1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -949,6 +949,38 @@ jobs:
     - name: Authenticated Request
       run: .github/scripts/authenticated-request.sh
 
+  custom-search-parameters-test:
+    needs: build
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+
+    - name: Download Blaze Image
+      uses: actions/download-artifact@v3
+      with:
+        name: blaze-image
+        path: /tmp
+
+    - name: Load Blaze Image
+      run: docker load --input /tmp/blaze.tar
+
+    - name: Run Keycloak and Blaze
+      run: docker-compose -f .github/custom-search-parameters-test/docker-compose.yml up -d
+
+    - name: Wait for Blaze
+      run: .github/scripts/wait-for-url.sh  http://localhost:8080/health
+
+    - name: Docker Logs Blaze
+      run: docker-compose -f .github/custom-search-parameters-test/docker-compose.yml logs blaze
+
+    - name: Create Patient
+      run: .github/custom-search-parameters-test/create-patient.sh
+
+    - name: Search Patient
+      run: .github/custom-search-parameters-test/search-patient.sh
+
   doc-copy-data-test:
     needs: build
     runs-on: ubuntu-22.04

--- a/docs/deployment/custom-search-parameters.json
+++ b/docs/deployment/custom-search-parameters.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "https://samply.github.io/blaze/fhir/SearchParameter/Patient-marital-status",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "marital-status",
+        "url": "https://samply.github.io/blaze/fhir/SearchParameter/Patient-marital-status",
+        "version": "0.1.0",
+        "name": "marital-status",
+        "status": "active",
+        "code": "marital-status",
+        "base": [
+          "Patient"
+        ],
+        "type": "token",
+        "expression": "Patient.maritalStatus"
+      }
+    }
+  ]
+}

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -17,17 +17,17 @@ docker run -d --name blaze -p 8080:8080 -v blaze-data:/app/data samply/blaze:0.2
 Blaze should log something like this:
 
 ```text
-2021-06-27T11:02:29.649Z ee086ef908c1 main INFO [blaze.system:173] - Set log level to: info
-2021-06-27T11:02:29.662Z ee086ef908c1 main INFO [blaze.system:43] - Try to read blaze.edn ...
-2021-06-27T11:02:29.679Z ee086ef908c1 main INFO [blaze.system:152] - Use storage variant standalone
-2021-06-27T11:02:29.680Z ee086ef908c1 main INFO [blaze.system:163] - Feature OpenID Authentication disabled
+2023-06-09T08:30:21.134Z b45689460ff3 main INFO [blaze.system:181] - Set log level to: info
+2023-06-09T08:30:21.155Z b45689460ff3 main INFO [blaze.system:44] - Try to read blaze.edn ...
+2023-06-09T08:30:21.173Z b45689460ff3 main INFO [blaze.system:160] - Use storage variant standalone
+2023-06-09T08:30:21.174Z b45689460ff3 main INFO [blaze.system:171] - Feature OpenID Authentication disabled
 ...
-2021-06-27T11:02:37.758Z ee086ef908c1 main INFO [blaze.system:230] - Start metrics server on port 8081
-2021-06-27T11:02:37.822Z ee086ef908c1 main INFO [blaze.system:218] - Start main server on port 8080
-2021-06-27T11:02:37.834Z ee086ef908c1 main INFO [blaze.core:64] - JVM version: 16.0.2
-2021-06-27T11:02:37.834Z ee086ef908c1 main INFO [blaze.core:65] - Maximum available memory: 1738 MiB
-2021-06-27T11:02:37.835Z ee086ef908c1 main INFO [blaze.core:66] - Number of available processors: 8
-2021-06-27T11:02:37.836Z ee086ef908c1 main INFO [blaze.core:67] - Successfully started Blaze version 0.20.6 in 8.2 seconds
+2023-06-09T08:30:30.079Z b45689460ff3 main INFO [blaze.server:33] - Start main server on port 8080
+2023-06-09T08:30:30.122Z b45689460ff3 main INFO [blaze.server:33] - Start metrics server on port 8081
+2023-06-09T08:30:30.126Z b45689460ff3 main INFO [blaze.core:67] - JVM version: 17.0.7
+2023-06-09T08:30:30.126Z b45689460ff3 main INFO [blaze.core:68] - Maximum available memory: 1738 MiB
+2023-06-09T08:30:30.126Z b45689460ff3 main INFO [blaze.core:69] - Number of available processors: 2
+2023-06-09T08:30:30.126Z b45689460ff3 main INFO [blaze.core:70] - Successfully started 🔥 Blaze version 0.20.6 in 9.0 seconds
 ```
 
 In order to test connectivity, query the health endpoint:
@@ -58,7 +58,6 @@ Blaze will be configured through environment variables which are documented [her
 A Docker Compose file looks like this:
 
 ```text
-version: '3.2'
 services:
   blaze:
     image: "samply/blaze:0.20"
@@ -68,6 +67,27 @@ services:
     ports:
     - "8080:8080"
     volumes:
+    - "blaze-data:/app/data"
+volumes:
+  blaze-data:
+```
+
+## Custom Search Parameters
+
+Per default, Blaze supports FHIR Search on all FHIR R4 search parameters. However Blaze can be configured to support custom search parameters by specifying the file name of a search parameter bundle in the environment variable `DB_SEARCH_PARAM_BUNDLE`. If such a bundle file name is specified, Blaze will index newly written resources using the search parameters defined in that file. Please be aware that Blaze will currently not reindex existing resources. So resources written before specifying a custom search parameter will not be indexed and so will not be found.
+
+### Example Config
+
+```text
+services:
+  blaze:
+    image: "samply/blaze:0.20"
+    environment:
+      DB_SEARCH_PARAM_BUNDLE: "/app/custom-search-parameters.json"
+    ports:
+    - "8080:8080"
+    volumes:
+    - "custom-search-parameters.json:/app/custom-search-parameters.json:ro"
     - "blaze-data:/app/data"
 volumes:
   blaze-data:

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -90,6 +90,7 @@ More information about distributed deployment are available [here](distributed.m
 | OPENID_PROVIDER_URL                     | —                          | v0.11  | —      | [OpenID Connect][4] provider URL to enable [authentication][5]                                 |
 | ENFORCE_REFERENTIAL_INTEGRITY           | true                       | v0.14  | —      | Enforce referential integrity on resource create, update and delete.                           |
 | DB_SYNC_TIMEOUT                         | 10000                      | v0.15  | —      | Timeout in milliseconds for all reading FHIR interactions acquiring the newest database state. |
+| DB_SEARCH_PARAM_BUNDLE                  | —                          | v0.21  | —      | Name of a custom search parameter bundle file.                                                 |
 
 ¹ Deprecated
 

--- a/modules/db-protocols/src/blaze/db/impl/protocols.clj
+++ b/modules/db-protocols/src/blaze/db/impl/protocols.clj
@@ -75,6 +75,14 @@
   (-clauses [query]))
 
 
+(defprotocol Pull
+  (-pull [pull resource-handle])
+
+  (-pull-content [pull resource-handle])
+
+  (-pull-many [pull resource-handles] [pull resource-handles elements]))
+
+
 (defprotocol SearchParam
   (-compile-value [search-param modifier value] "Can return an anomaly.")
   (-resource-handles
@@ -96,9 +104,8 @@
   (-index-value-compiler [_]))
 
 
-(defprotocol Pull
-  (-pull [pull resource-handle])
-
-  (-pull-content [pull resource-handle])
-
-  (-pull-many [pull resource-handles] [pull resource-handles elements]))
+(defprotocol SearchParamRegistry
+  (-get [_ code] [_ code type])
+  (-list-by-type [_ type])
+  (-list-by-target [_ target])
+  (-linked-compartments [_ resource]))

--- a/modules/db/.clj-kondo/config.edn
+++ b/modules/db/.clj-kondo/config.edn
@@ -27,6 +27,21 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.anomaly ba
+    blaze.async.comp ac
+    blaze.db.impl.protocols p
+    blaze.executors ex
+    buddy.auth auth
+    cognitect.anomalies anom
+    clojure.java.io io
+    clojure.spec.alpha s
+    clojure.string str
+    integrant.core ig
+    prometheus.alpha prom
+    taoensso.timbre log}}}
 
  :skip-comments true}

--- a/modules/db/src/blaze/db/search_param_registry/spec.clj
+++ b/modules/db/src/blaze/db/search_param_registry/spec.clj
@@ -1,12 +1,11 @@
 (ns blaze.db.search-param-registry.spec
   (:require
     [blaze.db.impl.protocols :as p]
-    [blaze.db.search-param-registry :as sr]
     [clojure.spec.alpha :as s]))
 
 
 (defn search-param-registry? [x]
-  (satisfies? sr/SearchParamRegistry x))
+  (satisfies? p/SearchParamRegistry x))
 
 
 (s/def :blaze.db/search-param-registry
@@ -19,3 +18,7 @@
 
 (s/def :blaze.db.search-param/modifier
   string?)
+
+
+(s/def :blaze.db.search-param-registry/extra-bundle-file
+  (s/nilable string?))

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -281,7 +281,8 @@
   ;; in FHIR R4.
   ;;
   :blaze.db/search-param-registry
-  {:structure-definition-repo #blaze/ref :blaze.fhir/structure-definition-repo}}
+  {:structure-definition-repo #blaze/ref :blaze.fhir/structure-definition-repo
+   :extra-bundle-file #blaze/cfg ["DB_SEARCH_PARAM_BUNDLE" string?]}}
 
  :storage
  {:in-memory


### PR DESCRIPTION
Using the environment variable `DB_SEARCH_PARAM_BUNDLE` it's possible to specify a bundle of custom search parameters which are used to index resources and made available via FHIR search.