### PR TITLE
Fix Comparison of Length Result not Possible in CQL

### DIFF
--- a/modules/cql/.clj-kondo/config.edn
+++ b/modules/cql/.clj-kondo/config.edn
@@ -9,9 +9,7 @@
   blaze.elm.compiler.macros/defnaryop clojure.core/defn
   blaze.elm.compiler.macros/defaggop clojure.core/defn
   blaze.elm.compiler.macros/defbinopp clojure.core/defn
-  blaze.elm.compiler.macros/defunopp clojure.core/defn
-  prometheus.alpha/defcounter clojure.core/def
-  prometheus.alpha/defhistogram clojure.core/def}
+  blaze.elm.compiler.macros/defunopp clojure.core/defn}
 
  :linters
  {;; because of macros in modules/cql/src/blaze/elm/compiler.clj
@@ -36,7 +34,19 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.anomaly ba
+    blaze.coll.core coll
+    blaze.db.api d
+    cognitect.anomalies anom
+    clojure.java.io io
+    clojure.spec.alpha s
+    clojure.string str
+    cuerdas.core c-str
+    jsonista.core j}}}
 
  :output
  {:exclude-files ["^test/data_readers.clj"]}

--- a/modules/cql/src/blaze/elm/compiler/string_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/string_operators.clj
@@ -61,7 +61,7 @@
 
 ;; 17.8. Length
 (defunop length [x]
-  (count x))
+  (long (count x)))
 
 
 ;; 17.9. Lower

--- a/modules/cql/test/blaze/cql_translator_test.clj
+++ b/modules/cql/test/blaze/cql_translator_test.clj
@@ -68,3 +68,8 @@
               define Error: (")
       ::anom/category := ::anom/incorrect
       ::anom/message := "Syntax error at <EOF>")))
+
+
+(comment
+  (translate "library \"schaedeldachfraktur\"\nusing FHIR version '4.0.0'\ninclude FHIRHelpers version '4.0.0'\n\ncodesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'\ncode \"Schädeldachfraktur\": 'S02.0' from icd10\n\ncontext Patient\n\ndefine InInitialPopulation:\n   Length([Condition: \"Schädeldachfraktur\"]) >= 2\n")
+  )

--- a/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
@@ -107,9 +107,12 @@
 ;; If the list is null the result is 0.
 (deftest compile-count-test
   (testing "Without path"
-    (are [source res] (= res (core/-eval (c/compile {} (elm/count source)) {} nil nil))
+    (are [source res] (identical? res (core/-eval (c/compile {} (elm/count source)) {} nil nil))
       #elm/list [#elm/integer "1"] 1
+      #elm/list [#elm/integer "1" {:type "Null"}] 1
       #elm/list [#elm/integer "1" #elm/integer "1"] 2
+      #elm/list [#elm/integer "1" {:type "Null"} #elm/integer "1"] 2
+      #elm/list [#elm/integer "1" #elm/integer "1" {:type "Null"}] 2
 
       #elm/list [{:type "Null"}] 0
       #elm/list [] 0

--- a/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
@@ -85,6 +85,14 @@
 
     (tu/testing-binary-null elm/equal #elm/integer "1"))
 
+  (testing "Long"
+    (are [x y res] (= res (tu/compile-binop elm/equal elm/long x y))
+      "1" "1" true
+      "1" "2" false
+      "2" "1" false)
+
+    (tu/testing-binary-null elm/equal #elm/long "1"))
+
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/equal elm/decimal x y))
       "1.1" "1.1" true
@@ -95,6 +103,11 @@
       "1.10" "1.1" true)
 
     (tu/testing-binary-null elm/equal #elm/decimal "1.1"))
+
+  (testing "Mixed Integer Long"
+    (are [x y res] (= res (c/compile {} (elm/equal [x y])))
+      #elm/integer "1" #elm/long "1" true
+      #elm/long "1" #elm/integer "1" true))
 
   (testing "Mixed Integer Decimal"
     (are [x y res] (= res (c/compile {} (elm/equal [x y])))
@@ -462,6 +475,18 @@
 
     (tu/testing-binary-null elm/greater #elm/integer "1"))
 
+  (testing "Long"
+    (are [x y res] (= res (tu/compile-binop elm/greater elm/long x y))
+      "2" "1" true
+      "1" "1" false)
+
+    (tu/testing-binary-null elm/greater #elm/long "1"))
+
+  (testing "Mixed Integer Long"
+    (are [x y res] (= res (c/compile {} (elm/greater [x y])))
+      #elm/integer "2" #elm/long "1" true
+      #elm/long "2" #elm/integer "1" true))
+
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/greater elm/decimal x y))
       "2.1" "1.1" true
@@ -566,6 +591,21 @@
       "1" "2" false)
 
     (tu/testing-binary-null elm/greater-or-equal #elm/integer "1"))
+  
+  (testing "Long"
+    (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/long x y))
+      "1" "1" true
+      "2" "1" true
+      "1" "2" false)
+
+    (tu/testing-binary-null elm/greater-or-equal #elm/long "1"))
+
+  (testing "Mixed Integer Long"
+    (are [x y res] (= res (c/compile {} (elm/greater-or-equal [x y])))
+      #elm/integer "1" #elm/long "1" true
+      #elm/integer "2" #elm/long "1" true
+      #elm/long "1" #elm/integer "1" true
+      #elm/long "2" #elm/integer "1" true))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/greater-or-equal elm/decimal x y))
@@ -676,6 +716,18 @@
       "1" "1" false)
 
     (tu/testing-binary-null elm/less #elm/integer "1"))
+  
+  (testing "Long"
+    (are [x y res] (= res (tu/compile-binop elm/less elm/long x y))
+      "1" "2" true
+      "1" "1" false)
+
+    (tu/testing-binary-null elm/less #elm/long "1"))
+
+  (testing "Mixed Integer Long"
+    (are [x y res] (= res (c/compile {} (elm/less [x y])))
+      #elm/integer "1" #elm/long "2" true
+      #elm/long "1" #elm/integer "2" true))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/less elm/decimal x y))
@@ -799,6 +851,21 @@
       "2" "1" false)
 
     (tu/testing-binary-null elm/less-or-equal #elm/integer "1"))
+  
+  (testing "Long"
+    (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/long x y))
+      "1" "1" true
+      "1" "2" true
+      "2" "1" false)
+
+    (tu/testing-binary-null elm/less-or-equal #elm/long "1"))
+
+  (testing "Mixed Integer Long"
+    (are [x y res] (= res (c/compile {} (elm/less-or-equal [x y])))
+      #elm/integer "1" #elm/long "1" true
+      #elm/integer "1" #elm/long "2" true
+      #elm/long "1" #elm/integer "1" true
+      #elm/long "1" #elm/integer "2" true))
 
   (testing "Decimal"
     (are [x y res] (= res (tu/compile-binop elm/less-or-equal elm/decimal x y))

--- a/modules/db-resource-store-cassandra/.clj-kondo/config.edn
+++ b/modules/db-resource-store-cassandra/.clj-kondo/config.edn
@@ -17,6 +17,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {cuerdas.core c-str}}}
 
  :skip-comments true}

--- a/modules/db-resource-store/.clj-kondo/config.edn
+++ b/modules/db-resource-store/.clj-kondo/config.edn
@@ -17,6 +17,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {cuerdas.core c-str}}}
 
  :skip-comments true}

--- a/modules/db/.clj-kondo/config.edn
+++ b/modules/db/.clj-kondo/config.edn
@@ -33,6 +33,7 @@
   {:aliases
    {blaze.anomaly ba
     blaze.async.comp ac
+    blaze.db.api d
     blaze.db.impl.protocols p
     blaze.executors ex
     buddy.auth auth

--- a/modules/interaction/.clj-kondo/config.edn
+++ b/modules/interaction/.clj-kondo/config.edn
@@ -31,6 +31,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.db.api d}}}
 
  :skip-comments true}

--- a/modules/operation-graphql/.clj-kondo/config.edn
+++ b/modules/operation-graphql/.clj-kondo/config.edn
@@ -17,6 +17,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.db.api d}}}
 
  :skip-comments true}

--- a/modules/operation-measure-evaluate-measure/.clj-kondo/config.edn
+++ b/modules/operation-measure-evaluate-measure/.clj-kondo/config.edn
@@ -21,6 +21,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.db.api d}}}
 
  :skip-comments true}

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -480,7 +480,8 @@
     "q45-histology" 1
     "q46-between-date" 1
     "q47-managing-organization" 1
-    "q48-concept" 2)
+    "q48-concept" 2
+    "q49-length" 1)
 
   (let [result (evaluate "q1" "subject-list")]
     (testing "MeasureReport is valid"
@@ -664,5 +665,5 @@
 
 (comment
   (log/set-level! :debug)
-  (evaluate "q48-concept")
+  (evaluate "q49-length")
   )

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q49-length.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q49-length.cql
@@ -1,0 +1,6 @@
+library "q49-length"
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+define InInitialPopulation:
+  Length([Observation]) > 1

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q49-length.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q49-length.json
@@ -1,0 +1,116 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "0"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "1"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "0",
+        "subject": {
+          "reference": "Patient/0"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "1",
+        "subject": {
+          "reference": "Patient/0"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "2",
+        "subject": {
+          "reference": "Patient/1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/2"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Measure",
+        "id": "0",
+        "url": "0",
+        "status": "active",
+        "subjectCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/resource-types",
+              "code": "Patient"
+            }
+          ]
+        },
+        "library": [
+          "0"
+        ],
+        "scoring": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+              "code": "cohort"
+            }
+          ]
+        },
+        "group": [
+          {
+            "population": [
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "initial-population"
+                    }
+                  ]
+                },
+                "criteria": {
+                  "language": "text/cql-identifier",
+                  "expression": "InInitialPopulation"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Measure/0"
+      }
+    }
+  ]
+}

--- a/modules/rest-util/.clj-kondo/config.edn
+++ b/modules/rest-util/.clj-kondo/config.edn
@@ -17,6 +17,10 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.db.api d}}}
 
  :skip-comments true}


### PR DESCRIPTION
The CQL Length function returned an integer instead of a long. However the comparison operators work only with longs. I fixed that by ensuring that Length returns a long.