### PR TITLE
Fix Evaluate Measure Generating Duplicate List IDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1589,6 +1589,7 @@ jobs:
     - missing-resource-content-test
     - distributed-test
     - jepsen-distributed-test
+    - custom-search-parameters-test
     runs-on: ubuntu-22.04
     permissions:
       packages: write

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -197,7 +197,7 @@
                                            (some? (seq stratifier))))
             {:keys [luids] :as evaluated-populations}
             (evaluate-populations context population)
-            evaluated-stratifiers
+            {:keys [luids] :as evaluated-stratifiers}
             (evaluate-stratifiers (assoc context :luids luids)
                                   evaluated-populations
                                   stratifier)]
@@ -211,6 +211,7 @@
 
        (seq (:result evaluated-stratifiers))
        (assoc :stratifier (:result evaluated-stratifiers)))
+     :luids luids
      :tx-ops
      (into (:tx-ops evaluated-populations)
            (:tx-ops evaluated-stratifiers))}))


### PR DESCRIPTION
I forgot to carry over the LUID's from Measure group to group.