### PR TITLE
Remove Shell in Docker Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ COPY target/blaze-0.21.0-standalone.jar /app/
 WORKDIR /app
 USER 1001
 
+ENV LD_PRELOAD="libjemalloc.so.2"
 ENV STORAGE="standalone"
 ENV INDEX_DB_DIR="/app/data/index"
 ENV TRANSACTION_DB_DIR="/app/data/transaction"
 ENV RESOURCE_DB_DIR="/app/data/resource"
 
-CMD ["sh", "-c", "LD_PRELOAD=/usr/lib/$(arch)-linux-gnu/libjemalloc.so.2 exec java -jar blaze-0.21.0-standalone.jar"]
+CMD ["java", "-jar",  "blaze-0.21.0-standalone.jar"]


### PR DESCRIPTION
We used a shell in the docker entrypoint in order to be able to specify the absolute path to libjemalloc.so.2. However that isn't necessary as documented in https://man7.org/linux/man-pages/man8/ld.so.8.html. So we switch back to a direct java -jar call in the entrypoint.

Note that this will not change the runtime behaviour of Blaze because in the shell, we used exec to break out of the shell and have the java process running as the only process in the container.

Closes: #1034