### PR TITLE
Update Netty to Resolve CVE-2023-34462

### DIFF
--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -11,7 +11,7 @@
 
   ;; current version of transitive dependency of com.datastax.oss/java-driver-core
   io.netty/netty-handler
-  {:mvn/version "4.1.93.Final"}}
+  {:mvn/version "4.1.94.Final"}}
 
  :aliases
  {:test


### PR DESCRIPTION
This vulnerability isn't relevant for Blaze because we use Netty only for client connections to Cassandra. The risk that Cassandra would work as an attack vector for DOS attacks agains Blaze is considered very low.

So this security fix doesn't demand an immediate release of a security fix version of Blaze. Also not marked as `security` for that reason.