### PR TITLE
Implement Form for Every Expression

### DIFF
--- a/modules/cql/.clj-kondo/config.edn
+++ b/modules/cql/.clj-kondo/config.edn
@@ -40,6 +40,7 @@
   {:aliases
    {blaze.anomaly ba
     blaze.coll.core coll
+    blaze.cql-translator t
     blaze.db.api d
     blaze.elm.compiler c
     blaze.elm.compiler.external-data ed

--- a/modules/cql/src/blaze/cql_translator_spec.clj
+++ b/modules/cql/src/blaze/cql_translator_spec.clj
@@ -1,12 +1,12 @@
 (ns blaze.cql-translator-spec
   (:require
     [blaze.anomaly-spec]
-    [blaze.cql-translator :as cql-translator]
+    [blaze.cql-translator :as t]
     [blaze.elm.spec]
     [clojure.spec.alpha :as s]
     [cognitect.anomalies :as anom]))
 
 
-(s/fdef cql-translator/translate
+(s/fdef t/translate
   :args (s/cat :cql string?)
   :ret (s/or :library :elm/library :anomaly ::anom/anomaly))

--- a/modules/cql/src/blaze/elm/code.clj
+++ b/modules/cql/src/blaze/elm/code.clj
@@ -1,6 +1,7 @@
 (ns blaze.elm.code
   "Implementation of the code type."
   (:require
+    [blaze.elm.compiler.core :as core]
     [blaze.elm.concept :as concept]
     [blaze.elm.protocols :as p]))
 
@@ -21,7 +22,15 @@
 
   p/Descendents
   (descendents [_]
-    [code nil system version]))
+    [code nil system version])
+
+  core/Expression
+  (-static [_]
+    true)
+  (-eval [this _ _ _]
+    this)
+  (-form [_]
+    `(~'code ~system ~version ~code)))
 
 
 (defn to-code

--- a/modules/cql/src/blaze/elm/compiler/arithmetic_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/arithmetic_operators.clj
@@ -43,9 +43,15 @@
   (p/floor x))
 
 
+;; TODO: 16.7. HighBoundary
+
+
 ;; 16.8. Log
 (defbinop log [x base]
   (p/log x base))
+
+
+;; TODO: 16.9. LowBoundary
 
 
 ;; 16.10. Ln
@@ -123,6 +129,9 @@
   (p/power x exp))
 
 
+;; TODO: 16.17. Precision
+
+
 ;; 16.18. Predecessor
 (defunop predecessor [x]
   (p/predecessor x))
@@ -136,6 +145,8 @@
     (if (and (core/static? operand) (core/static? precision))
       (p/round operand precision)
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (p/round (core/-eval operand context resource scope)
                    (core/-eval precision context resource scope)))

--- a/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
@@ -20,6 +20,8 @@
     (when-let [date (core/compile* context date)]
       (let [chrono-precision (some-> precision core/to-chrono-unit)]
         (reify core/Expression
+          (-static [_]
+            false)
           (-eval [_ context resource scope]
             (p/duration-between
               (core/-eval birth-date context resource scope)

--- a/modules/cql/src/blaze/elm/compiler/conditional_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/conditional_operators.clj
@@ -9,47 +9,49 @@
 
 
 ;; 15.1. Case
-(defrecord ComparandCaseExpression [comparand items else]
-  core/Expression
-  (-eval [_ context resource scope]
-    (let [comparand (core/-eval comparand context resource scope)]
-      (loop [[{:keys [when then]} & next-items] items]
-        (if (p/equal comparand (core/-eval when context resource scope))
-          (core/-eval then context resource scope)
-          (if (empty? next-items)
-            (core/-eval else context resource scope)
-            (recur next-items)))))))
-
-
-(defrecord MultiConditionalCaseExpression [items else]
-  core/Expression
-  (-eval [_ context resource scope]
-    (loop [[{:keys [when then]} & next-items] items]
-      (if (core/-eval when context resource scope)
-        (core/-eval then context resource scope)
-        (if (empty? next-items)
-          (core/-eval else context resource scope)
-          (recur next-items))))))
-
-
 (defmethod core/compile* :elm.compiler.type/case
   [context {:keys [comparand else] items :caseItem}]
   (let [comparand (some->> comparand (core/compile* context))
         items
-        (mapv
+        (map
           (fn [{:keys [when then]}]
-            {:when (core/compile* context when)
-             :then (core/compile* context then)})
+            [(core/compile* context when)
+             (core/compile* context then)])
           items)
         else (core/compile* context else)]
     (if comparand
-      (->ComparandCaseExpression comparand items else)
-      (->MultiConditionalCaseExpression items else))))
+      (reify core/Expression
+        (-static [_]
+          false)
+        (-eval [_ context resource scope]
+          (let [comparand (core/-eval comparand context resource scope)]
+            (loop [[[when then] & next-items] items]
+              (if (p/equal comparand (core/-eval when context resource scope))
+                (core/-eval then context resource scope)
+                (if (empty? next-items)
+                  (core/-eval else context resource scope)
+                  (recur next-items))))))
+        (-form [_]
+          `(~'case ~(core/-form comparand) ~@(map core/-form (flatten items)) ~else)))
+      (reify core/Expression
+        (-static [_]
+          false)
+        (-eval [_ context resource scope]
+          (loop [[[when then] & next-items] items]
+            (if (core/-eval when context resource scope)
+              (core/-eval then context resource scope)
+              (if (empty? next-items)
+                (core/-eval else context resource scope)
+                (recur next-items)))))
+        (-form [_]
+          `(~'case ~@(map core/-form (flatten items)) ~else))))))
 
 
 ;; 15.2. If
 (defrecord IfExpression [condition then else]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (if (core/-eval condition context resource scope)
       (core/-eval then context resource scope)

--- a/modules/cql/src/blaze/elm/compiler/core.clj
+++ b/modules/cql/src/blaze/elm/compiler/core.clj
@@ -12,6 +12,7 @@
 
 
 (defprotocol Expression
+  (-static [expression])
   (-eval [expression context resource scope]
     "Evaluates `expression` on `resource` using `context` and optional `scope`
     for scoped expressions inside queries.")
@@ -24,12 +25,16 @@
 
 (extend-protocol Expression
   nil
+  (-static [_]
+    true)
   (-eval [expr _ _ _]
     expr)
   (-form [_]
     'nil)
 
   Object
+  (-static [_]
+    true)
   (-eval [expr _ _ _]
     expr)
   (-form [expr]
@@ -37,7 +42,7 @@
 
 
 (defn static? [x]
-  (not (instance? blaze.elm.compiler.core.Expression x)))
+  (-static x))
 
 
 (defmulti compile*

--- a/modules/cql/src/blaze/elm/compiler/function.clj
+++ b/modules/cql/src/blaze/elm/compiler/function.clj
@@ -5,6 +5,8 @@
 
 (defn arity-n [name fn-expr operand-names operands]
   (reify core/Expression
+    (-static [_]
+      false)
     (-eval [_ context resource scope]
       (let [values (map #(core/-eval % context resource scope) operands)]
         (core/-eval fn-expr context resource (merge scope (zipmap operand-names values)))))

--- a/modules/cql/src/blaze/elm/compiler/interval_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/interval_operators.clj
@@ -22,6 +22,8 @@
   [type low high low-closed-expression high-closed-expression low-closed
    high-closed]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (let [low (core/-eval low context resource scope)
           high (core/-eval high context resource scope)

--- a/modules/cql/src/blaze/elm/compiler/logical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/logical_operators.clj
@@ -11,6 +11,8 @@
 ;; 13.1. And
 (defn- nil-and-expr [x]
   (reify core/Expression
+    (-static [_]
+      false)
     (-eval [_ context resource scope]
       (when (false? (core/-eval x context resource scope))
         false))
@@ -37,6 +39,8 @@
     false false
     nil (nil-and-expr a)
     (reify core/Expression
+      (-static [_]
+        false)
       (-eval [_ context resource scope]
         (let [a (core/-eval a context resource scope)]
           (if (false? a)
@@ -74,6 +78,8 @@
 ;; 13.4. Or
 (defn- nil-or-expr [x]
   (reify core/Expression
+    (-static [_]
+      false)
     (-eval [_ context resource scope]
       (when (true? (core/-eval x context resource scope))
         true))
@@ -100,6 +106,8 @@
     false a
     nil (nil-or-expr a)
     (reify core/Expression
+      (-static [_]
+        false)
       (-eval [_ context resource scope]
         (let [a (core/-eval a context resource scope)]
           (if (true? a)
@@ -130,6 +138,8 @@
   (condp identical? b
     true
     (reify core/Expression
+      (-static [_]
+        false)
       (-eval [_ context resource scope]
         (let [a (core/-eval a context resource scope)]
           (when (some? a)
@@ -139,6 +149,8 @@
     false a
     nil nil
     (reify core/Expression
+      (-static [_]
+        false)
       (-eval [_ context resource scope]
         (when-some [a (core/-eval a context resource scope)]
           (when-some [b (core/-eval b context resource scope)]

--- a/modules/cql/src/blaze/elm/compiler/nullological_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/nullological_operators.clj
@@ -28,6 +28,8 @@
       (if (= "List" (:type operand))
         (let [operand (core/compile* context operand)]
           (reify core/Expression
+            (-static [_]
+              false)
             (-eval [_ context resource scope]
               (reduce
                 (fn [_ elem]
@@ -38,10 +40,14 @@
                 (core/-eval operand context resource scope)))))
         (let [operand (core/compile* context operand)]
           (reify core/Expression
+            (-static [_]
+              false)
             (-eval [_ context resource scope]
               (core/-eval operand context resource scope))))))
     (let [operands (mapv #(core/compile* context %) operands)]
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (reduce
             (fn [_ operand]

--- a/modules/cql/src/blaze/elm/compiler/parameters.clj
+++ b/modules/cql/src/blaze/elm/compiler/parameters.clj
@@ -22,6 +22,8 @@
 
 (defrecord ParameterRef [name]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ {:keys [parameters] :as context} _ _]
     (let [value (get parameters name ::not-found)]
       (if (identical? ::not-found value)

--- a/modules/cql/src/blaze/elm/compiler/queries.clj
+++ b/modules/cql/src/blaze/elm/compiler/queries.clj
@@ -137,6 +137,8 @@
 
 (defrecord EductionQueryExpression [xform-factory source]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (coll/eduction
       (-create xform-factory context resource scope)
@@ -151,6 +153,8 @@
 
 (defrecord IntoVectorQueryExpression [xform-factory source]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (into
       []
@@ -200,6 +204,8 @@
 
 (defrecord SortQueryExpression [source sort-by-item]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     ;; TODO: build a comparator of all sort by items
     (->> (vec (core/-eval source context resource scope))
@@ -217,6 +223,8 @@
 
 (defrecord XformSortQueryExpression [xform-factory source sort-by-item]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     ;; TODO: build a comparator of all sort by items
     (->> (into
@@ -302,6 +310,8 @@
 ;; 10.3. AliasRef
 (defrecord AliasRefExpression [key]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ _ _ scopes]
     (get scopes key))
   (-form [_]

--- a/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
+++ b/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
@@ -31,6 +31,8 @@
 
 (defrecord ExpressionRef [name]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ {:keys [expression-defs] :as context} resource _]
     (if-let [{:keys [expression]} (get expression-defs name)]
       (core/-eval expression context resource nil)
@@ -70,6 +72,8 @@
         ;; Unfiltered context. So we map the referenced expression over all
         ;; concrete resources.
         (reify core/Expression
+          (-static [_]
+            false)
           (-eval [_ {:keys [db expression-defs] :as context} _ _]
             (if-some [{:keys [expression]} (get expression-defs name)]
               (mapv
@@ -104,6 +108,8 @@
 
 (defrecord ToQuantityFunctionExpression [operand]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (-to-quantity (core/-eval operand context resource scope)))
   (-form [_]
@@ -112,13 +118,19 @@
 
 (defrecord ToCodeFunctionExpression [operand]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (let [{:keys [system version code]} (core/-eval operand context resource scope)]
-      (code/to-code (type/value system) (type/value version) (type/value code)))))
+      (code/to-code (type/value system) (type/value version) (type/value code))))
+  (-form [_]
+    `(~'call "ToCode" ~(core/-form operand))))
 
 
 (defrecord ToDateFunctionExpression [operand]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (type/value (core/-eval operand context resource scope)))
   (-form [_]
@@ -127,6 +139,8 @@
 
 (defrecord ToDateTimeFunctionExpression [operand]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ {:keys [now] :as context} resource scope]
     (p/to-date-time (type/value (core/-eval operand context resource scope)) now))
   (-form [_]
@@ -135,6 +149,8 @@
 
 (defrecord ToStringFunctionExpression [operand]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (some-> (type/value (core/-eval operand context resource scope)) str))
   (-form [_]
@@ -158,6 +174,8 @@
 
 (defrecord ToIntervalFunctionExpression [operand]
   core/Expression
+  (-static [_]
+    false)
   (-eval [_ context resource scope]
     (-to-interval (core/-eval operand context resource scope) context))
   (-form [_]
@@ -210,6 +228,8 @@
 (defmethod core/compile* :elm.compiler.type/operand-ref
   [_ {:keys [name]}]
   (reify core/Expression
+    (-static [_]
+      false)
     (-eval [_ _ _ scope]
       (scope name))
     (-form [_]

--- a/modules/cql/src/blaze/elm/compiler/string_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/string_operators.clj
@@ -21,14 +21,22 @@
         separator (some->> separator (core/compile* context))]
     (if separator
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (when-let [source (core/-eval source context resource scope)]
             (string/combine (core/-eval separator context resource scope)
-                            source))))
+                            source)))
+        (-form [_]
+          (list 'combine (core/-form source) (core/-form separator))))
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (when-let [source (core/-eval source context resource scope)]
-            (string/combine source)))))))
+            (string/combine source)))
+        (-form [_]
+          (list 'combine (core/-form source)))))))
 
 
 ;; 17.2. Concatenate
@@ -53,10 +61,14 @@
   (let [pattern (core/compile* context pattern)
         string (core/compile* context string)]
     (reify core/Expression
+      (-static [_]
+        false)
       (-eval [_ context resource scope]
         (when-let [^String pattern (core/-eval pattern context resource scope)]
           (when-let [^String string (core/-eval string context resource scope)]
-            (.lastIndexOf string pattern)))))))
+            (.lastIndexOf string pattern))))
+      (-form [_]
+        (list 'last-position-of (core/-form pattern) (core/-form string))))))
 
 
 ;; 17.8. Length
@@ -81,10 +93,14 @@
   (let [pattern (core/compile* context pattern)
         string (core/compile* context string)]
     (reify core/Expression
+      (-static [_]
+        false)
       (-eval [_ context resource scope]
         (when-let [^String pattern (core/-eval pattern context resource scope)]
           (when-let [^String string (core/-eval string context resource scope)]
-            (.indexOf string pattern)))))))
+            (.indexOf string pattern))))
+      (-form [_]
+        (list 'position-of (core/-form pattern) (core/-form string))))))
 
 
 ;; 17.13. ReplaceMatches
@@ -100,6 +116,8 @@
         separator (some->> separator (core/compile* context))]
     (if separator
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (when-let [string (core/-eval string context resource scope)]
             (if (= "" string)
@@ -121,11 +139,17 @@
                         (conj result (str (.append acc char))))))
                   ;; TODO: implement split with more than one char.
                   (throw (Exception. "TODO: implement split with separators longer than one char.")))
-                [string])))))
+                [string]))))
+        (-form [_]
+          (list 'split (core/-form string) (core/-form separator))))
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (when-let [string (core/-eval string context resource scope)]
-            [string]))))))
+            [string]))
+        (-form [_]
+          (list 'split (core/-form string)))))))
 
 
 ;; 17.16. StartsWith
@@ -142,18 +166,27 @@
         length (some->> length (core/compile* context))]
     (if length
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (when-let [^String string (core/-eval string context resource scope)]
             (when-let [start-index (core/-eval start-index context resource scope)]
               (when (and (<= 0 start-index) (< start-index (count string)))
                 (subs string start-index (min (+ start-index length)
-                                              (count string))))))))
+                                              (count string)))))))
+        (-form [_]
+          (list 'substring (core/-form string) (core/-form start-index)
+                (core/-form length))))
       (reify core/Expression
+        (-static [_]
+          false)
         (-eval [_ context resource scope]
           (when-let [^String string (core/-eval string context resource scope)]
             (when-let [start-index (core/-eval start-index context resource scope)]
               (when (and (<= 0 start-index) (< start-index (count string)))
-                (subs string start-index)))))))))
+                (subs string start-index)))))
+        (-form [_]
+          (list 'substring (core/-form string) (core/-form start-index)))))))
 
 
 ;; 17.18. Upper

--- a/modules/cql/src/blaze/elm/expression/spec.clj
+++ b/modules/cql/src/blaze/elm/expression/spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.db.api-spec]
     [blaze.elm.compiler :as-alias c]
+    [blaze.elm.expression :as-alias expr]
     [blaze.elm.spec]
     [clojure.spec.alpha :as s]
     [java-time.api :as time]))
@@ -15,6 +16,6 @@
   (s/map-of :elm/name ::c/expression))
 
 
-(s/def :blaze.elm.expression/context
+(s/def ::expr/context
   (s/keys :req-un [:blaze.db/db ::now]
           :opt-un [::c/expression-defs ::parameters]))

--- a/modules/cql/src/blaze/elm/quantity.clj
+++ b/modules/cql/src/blaze/elm/quantity.clj
@@ -5,6 +5,7 @@
   https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.anomaly :as ba :refer [throw-anom]]
+    [blaze.elm.compiler.core :as core]
     [blaze.elm.protocols :as p]
     [cuerdas.core :as c-str])
   (:import
@@ -71,6 +72,16 @@
   "Creates a quantity with numerical value and string unit."
   [value unit]
   (Quantities/getQuantity ^Number value ^Unit (parse-unit unit)))
+
+
+(extend-protocol core/Expression
+  Quantity
+  (-static [_]
+    true)
+  (-eval [quantity _ _ _]
+    quantity)
+  (-form [quantity]
+    `(~'quantity ~(.getValue quantity) ~(format-unit (.getUnit quantity)))))
 
 
 (defprotocol QuantityDivide

--- a/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/aggregate_operators_test.clj
@@ -7,6 +7,7 @@
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.aggregate-operators]
     [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
     [blaze.elm.compiler.test-util :as tu]
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
@@ -48,7 +49,11 @@
 
       #elm/list [{:type "Null"}] true
       #elm/list [] true
-      {:type "Null"} true)))
+      {:type "Null"} true))
+
+  (tu/testing-unary-dynamic elm/all-true)
+
+  (tu/testing-unary-form elm/all-true))
 
 
 ;; 21.2. AnyTrue
@@ -70,7 +75,11 @@
 
       #elm/list [{:type "Null"}] false
       #elm/list [] false
-      {:type "Null"} false)))
+      {:type "Null"} false))
+
+  (tu/testing-unary-dynamic elm/any-true)
+
+  (tu/testing-unary-form elm/any-true))
 
 
 ;; 21.3. Avg
@@ -92,7 +101,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/avg)
+
+  (tu/testing-unary-form elm/avg))
 
 
 ;; 21.4. Count
@@ -116,7 +129,11 @@
 
       #elm/list [{:type "Null"}] 0
       #elm/list [] 0
-      {:type "Null"} 0)))
+      {:type "Null"} 0))
+
+  (tu/testing-unary-dynamic elm/count)
+
+  (tu/testing-unary-form elm/count))
 
 
 ;; 21.5. GeometricMean
@@ -139,7 +156,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/geometric-mean)
+
+  (tu/testing-unary-form elm/geometric-mean))
 
 
 ;; 21.6. Product
@@ -162,7 +183,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/product)
+
+  (tu/testing-unary-form elm/product))
 
 
 ;; 21.7. Max
@@ -186,7 +211,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/max)
+
+  (tu/testing-unary-form elm/max))
 
 
 ;; 21.8. Median
@@ -209,7 +238,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/median)
+
+  (tu/testing-unary-form elm/median))
 
 
 ;; 21.9. Min
@@ -233,7 +266,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/min)
+
+  (tu/testing-unary-form elm/min))
 
 
 ;; 21.10. Mode
@@ -256,7 +293,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/mode)
+
+  (tu/testing-unary-form elm/mode))
 
 
 ;; 21.11. PopulationVariance
@@ -277,7 +318,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/population-variance)
+
+  (tu/testing-unary-form elm/population-variance))
 
 
 ;; 21.12. PopulationStdDev
@@ -298,7 +343,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/population-std-dev)
+
+  (tu/testing-unary-form elm/population-std-dev))
 
 
 ;; 21.13. Sum
@@ -320,7 +369,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/sum)
+
+  (tu/testing-unary-form elm/sum))
 
 
 ;; 21.14. StdDev
@@ -341,7 +394,11 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/std-dev)
+
+  (tu/testing-unary-form elm/std-dev))
 
 
 ;; 21.15. Variance
@@ -362,4 +419,8 @@
 
       #elm/list [{:type "Null"}] nil
       #elm/list [] nil
-      {:type "Null"} nil)))
+      {:type "Null"} nil))
+
+  (tu/testing-unary-dynamic elm/variance)
+
+  (tu/testing-unary-form elm/variance))

--- a/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/arithmetic_operators_test.clj
@@ -8,6 +8,7 @@
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.arithmetic-operators-spec]
     [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
     [blaze.elm.compiler.test-util :as tu]
     [blaze.elm.date-time :as date-time]
     [blaze.elm.date-time-spec]
@@ -86,7 +87,14 @@
         [0M "m"] (quantity/quantity 0M "m")
         [1M "m"] (quantity/quantity 1M "m"))))
 
+  (testing "Dynamic"
+    (are [elm res] (= res (tu/dynamic-compile-eval (elm/abs elm)))
+      #elm/parameter-ref "1" 1
+      #elm/parameter-ref "-1" 1))
+
   (tu/testing-unary-null elm/abs)
+
+  (tu/testing-unary-dynamic elm/abs)
 
   (tu/testing-unary-form elm/abs))
 
@@ -362,6 +370,8 @@
       #elm/time "00:00:00" #elm/quantity [1 "minute"] (date-time/local-time 0 1 0)
       #elm/time "00:00:00" #elm/quantity [1 "second"] (date-time/local-time 0 0 1)))
 
+  (tu/testing-binary-dynamic elm/add)
+
   (tu/testing-binary-form elm/add))
 
 
@@ -377,6 +387,8 @@
     #elm/decimal "1.1" 2)
 
   (tu/testing-unary-null elm/ceiling)
+
+  (tu/testing-unary-dynamic elm/ceiling)
 
   (tu/testing-unary-form elm/ceiling))
 
@@ -468,6 +480,8 @@
         (let [elm (elm/equal [(elm/multiply [(elm/divide [decimal decimal]) decimal]) decimal])]
           (true? (core/-eval (c/compile {} elm) {} nil nil))))))
 
+  (tu/testing-binary-dynamic elm/divide)
+
   (tu/testing-binary-form elm/divide))
 
 
@@ -482,6 +496,8 @@
     #elm/decimal "0" 1M)
 
   (tu/testing-unary-null elm/exp)
+
+  (tu/testing-unary-dynamic elm/exp)
 
   (tu/testing-unary-form elm/exp))
 
@@ -498,6 +514,8 @@
     #elm/decimal "1.1" 1)
 
   (tu/testing-unary-null elm/floor)
+
+  (tu/testing-unary-dynamic elm/floor)
 
   (tu/testing-unary-form elm/floor))
 
@@ -543,6 +561,8 @@
 
     (tu/testing-binary-null elm/log #elm/decimal "1.1"))
 
+  (tu/testing-binary-dynamic elm/log)
+
   (tu/testing-binary-form elm/log))
 
 
@@ -586,6 +606,8 @@
     #elm/decimal "-1" nil)
 
   (tu/testing-unary-null elm/ln)
+
+  (tu/testing-unary-dynamic elm/ln)
 
   (tu/testing-unary-form elm/ln))
 
@@ -714,6 +736,8 @@
       #elm/integer "1" #elm/integer "0" nil
       #elm/decimal "1" #elm/decimal "0" nil))
 
+  (tu/testing-binary-dynamic elm/modulo)
+
   (tu/testing-binary-form elm/modulo))
 
 
@@ -757,6 +781,8 @@
 
     (tu/testing-binary-null elm/multiply #elm/quantity [1]))
 
+  (tu/testing-binary-dynamic elm/multiply)
+
   (tu/testing-binary-form elm/multiply))
 
 
@@ -786,6 +812,8 @@
       #elm/quantity [1M "m"] (quantity/quantity -1M "m")))
 
   (tu/testing-unary-null elm/negate)
+
+  (tu/testing-unary-dynamic elm/negate)
 
   (tu/testing-unary-form elm/negate))
 
@@ -820,6 +848,8 @@
       #elm/decimal "2.5" #elm/integer "2" 6.25M
       #elm/decimal "10" #elm/integer "2" 100M
       #elm/decimal "10" #elm/integer "2" 100M))
+
+  (tu/testing-binary-dynamic elm/power)
 
   (tu/testing-binary-form elm/power))
 
@@ -905,6 +935,8 @@
 
   (tu/testing-unary-null elm/predecessor)
 
+  (tu/testing-unary-dynamic elm/predecessor)
+
   (tu/testing-unary-form elm/predecessor))
 
 
@@ -954,14 +986,16 @@
             eval-ctx {:parameters {"x" nil}}]
         (is (nil? (core/-eval expr eval-ctx nil nil))))))
 
-  (testing "form"
-    (let [compile-ctx {:library {:parameters {:def [{:name "x"}]}}}]
-      (are [elm form] (= form (core/-form (c/compile compile-ctx elm)))
-        #elm/round [#elm/parameter-ref "x"]
-        '(round (param-ref "x"))
 
-        #elm/round [#elm/parameter-ref "x" #elm/integer "3"]
-        '(round (param-ref "x") 3)))))
+  (tu/testing-unary-null elm/round)
+
+  (tu/testing-unary-dynamic elm/round)
+
+  (tu/testing-unary-form elm/round)
+
+  (tu/testing-binary-dynamic elm/round)
+
+  (tu/testing-binary-form elm/round))
 
 
 ;; 16.20. Subtract
@@ -1181,6 +1215,8 @@
       #elm/time "00:00:00" #elm/quantity [1 "minute"] (date-time/local-time 23 59 0)
       #elm/time "00:00:00" #elm/quantity [1 "second"] (date-time/local-time 23 59 59)))
 
+  (tu/testing-binary-dynamic elm/subtract)
+
   (tu/testing-binary-form elm/subtract))
 
 
@@ -1252,6 +1288,8 @@
 
   (tu/testing-unary-null elm/successor)
 
+  (tu/testing-unary-dynamic elm/successor)
+
   (tu/testing-unary-form elm/successor))
 
 
@@ -1267,6 +1305,8 @@
       #elm/decimal "1.1" 1))
 
   (tu/testing-unary-null elm/truncate)
+
+  (tu/testing-unary-dynamic elm/truncate)
 
   (tu/testing-unary-form elm/truncate))
 
@@ -1328,5 +1368,7 @@
 
     (tu/testing-binary-null elm/truncated-divide #elm/integer "1"
                             #elm/decimal "1.1"))
+
+  (tu/testing-binary-dynamic elm/truncated-divide)
 
   (tu/testing-binary-form elm/truncated-divide))

--- a/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_operators_test.clj
@@ -7,6 +7,7 @@
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.clinical-operators]
     [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
     [blaze.elm.compiler.test-util :as tu]
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
@@ -76,6 +77,8 @@
 
   (tu/testing-binary-null elm/calculate-age-at #elm/date"2018")
   (tu/testing-binary-null elm/calculate-age-at #elm/date-time"2018-01-01")
+
+  (tu/testing-binary-dynamic elm/calculate-age-at)
 
   (tu/testing-binary-precision-form elm/calculate-age-at "year" "month" "day"))
 

--- a/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/clinical_values_test.clj
@@ -9,7 +9,8 @@
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.clinical-values]
     [blaze.elm.compiler.core :as core]
-    [blaze.elm.compiler.test-util :as tu]
+    [blaze.elm.compiler.core-spec]
+    [blaze.elm.compiler.test-util :as tu :refer [has-form]]
     [blaze.elm.concept-spec]
     [blaze.elm.date-time :as date-time]
     [blaze.elm.literal]
@@ -51,11 +52,16 @@
     (let [context
           {:library
            {:codeSystems
-            {:def [{:name "sys-def-115852" :id "system-115910"}]}}}]
-      (given (c/compile context #elm/code ["sys-def-115852" "code-115927"])
+            {:def [{:name "sys-def-115852" :id "system-115910"}]}}}
+          expr (c/compile context #elm/code ["sys-def-115852" "code-115927"])]
+
+      (given expr
         type := Code
         :system := "system-115910"
-        :code := "code-115927")))
+        :code := "code-115927")
+
+      (testing "form"
+        (has-form expr '(code "system-115910" nil "code-115927")))))
 
   (testing "with version"
     (let [context
@@ -64,12 +70,17 @@
             {:def
              [{:name "sys-def-120434"
                :id "system-120411"
-               :version "version-120408"}]}}}]
-      (given (c/compile context #elm/code ["sys-def-120434" "code-120416"])
+               :version "version-120408"}]}}}
+          expr (c/compile context #elm/code ["sys-def-120434" "code-120416"])]
+
+      (given expr
         type := Code
         :system := "system-120411"
         :version := "version-120408"
-        :code := "code-120416")))
+        :code := "code-120416")
+
+      (testing "form"
+        (has-form expr '(code "system-120411" "version-120408" "code-120416")))))
 
   (testing "missing code system"
     (let [context {:library {:codeSystems {:def []}}}]
@@ -298,6 +309,12 @@
       #elm/quantity [2 "milliseconds"] (date-time/period 0 0 2)
       #elm/quantity [1 "s"] (quantity/quantity 1 "s")
       #elm/quantity [1 "cm2"] (quantity/quantity 1 "cm2")))
+
+  (testing "form"
+    (are [elm res] (= res (c/form (c/compile {} elm)))
+      #elm/quantity [1] '(quantity 1 "1")
+      #elm/quantity [1 "s"] '(quantity 1 "s")
+      #elm/quantity [2 "cm2"] '(quantity 2 "cm2")))
 
   (testing "Periods"
     (satisfies-prop 100

--- a/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/comparison_operators_test.clj
@@ -7,6 +7,7 @@
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.comparison-operators]
     [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
     [blaze.elm.compiler.test-util :as tu]
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
@@ -260,6 +261,8 @@
 
     (tu/testing-binary-null elm/equal (tu/code "a" "0")))
 
+  (tu/testing-binary-dynamic elm/equal)
+
   (tu/testing-binary-form elm/equal))
 
 
@@ -439,6 +442,8 @@
       {:type "Null"} (tu/code "a" "0") false
       (tu/code "a" "0") {:type "Null"} false))
 
+  (tu/testing-binary-dynamic elm/equivalent)
+
   (tu/testing-binary-form elm/equivalent))
 
 
@@ -554,6 +559,8 @@
       "00:00:00" "00:00:00" false)
 
     (tu/testing-binary-null elm/greater #elm/time "00:00:00"))
+
+  (tu/testing-binary-dynamic elm/greater)
 
   (tu/testing-binary-form elm/greater))
 
@@ -682,6 +689,8 @@
       [1 "m"] [101 "cm"] false)
 
     (tu/testing-binary-null elm/greater-or-equal #elm/quantity [1]))
+
+  (tu/testing-binary-dynamic elm/greater-or-equal)
 
   (tu/testing-binary-form elm/greater-or-equal))
 
@@ -815,6 +824,8 @@
 
     (tu/testing-binary-null elm/less #elm/quantity [1]))
 
+  (tu/testing-binary-dynamic elm/less)
+
   (tu/testing-binary-form elm/less))
 
 
@@ -935,6 +946,8 @@
       [101 "cm"] [1 "m"] false)
 
     (tu/testing-binary-null elm/less-or-equal #elm/quantity [1]))
+
+  (tu/testing-binary-dynamic elm/less-or-equal)
 
   (tu/testing-binary-form elm/less-or-equal))
 

--- a/modules/cql/test/blaze/elm/compiler/conditional_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/conditional_operators_test.clj
@@ -5,10 +5,11 @@
   https://cql.hl7.org/04-logicalspecification.html."
   (:require
     [blaze.elm.compiler :as c]
-    [blaze.elm.compiler.test-util :as tu]
+    [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.test-util :as tu :refer [has-form]]
     [blaze.elm.literal-spec]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [are deftest testing]]))
+    [clojure.test :as test :refer [are deftest is testing]]))
 
 
 (st/instrument)
@@ -23,6 +24,106 @@
 
 
 (test/use-fixtures :each fixture)
+
+
+;; 15.1. Case
+;;
+;; The Case operator allows for multiple conditional expressions to be chained
+;; together in a single expression, rather than having to nest multiple If
+;; operators. In addition, the comparand operand provides a variant on the case
+;; that allows a single value to be compared in each conditional.
+;;
+;; If a comparand is not provided, the type of each when element of the
+;; caseItems within the Case is expected to be boolean. If a comparand is
+;; provided, the type of each when element of the caseItems within the Case is
+;; expected to be of the same type as the comparand. An else element must always
+;; be provided.
+;;
+;; The static type of the then argument within the first caseItem determines the
+;; type of the result, and the then argument of each subsequent caseItem and the
+;; else argument must be of that same type.
+(deftest compile-case-test
+  ;; Case is only implemented dynamically
+  (testing "Dynamic"
+    (testing "multi-conditional"
+      (are [when res] (= res (tu/dynamic-compile-eval
+                               {:type "Case"
+                                :caseItem
+                                [{:when when
+                                  :then #elm/integer "1"}]
+                                :else #elm/integer "2"}))
+
+        #elm/parameter-ref "true" 1
+        #elm/parameter-ref "false" 2
+        #elm/parameter-ref "nil" 2))
+
+    (testing "comparand-based"
+      (are [comparand res] (= res (tu/dynamic-compile-eval
+                                    {:type "Case"
+                                     :comparand comparand
+                                     :caseItem
+                                     [{:when #elm/string "a"
+                                       :then #elm/integer "1"}]
+                                     :else #elm/integer "2"}))
+
+        #elm/parameter-ref "a" 1
+        #elm/parameter-ref "b" 2
+        #elm/parameter-ref "nil" 2)))
+
+  (testing "form"
+    (testing "Static"
+      (testing "multi-conditional"
+        (let [expr (c/compile {} {:type "Case"
+                                  :caseItem
+                                  [{:when #elm/boolean "true"
+                                    :then #elm/integer "1"}]
+                                  :else #elm/integer "2"})]
+          (has-form expr '(case true 1 2))))
+
+      (testing "comparand-based"
+        (let [expr (c/compile {} {:type "Case"
+                                  :comparand #elm/string "a"
+                                  :caseItem
+                                  [{:when #elm/string "b"
+                                    :then #elm/integer "1"}]
+                                  :else #elm/integer "2"})]
+          (has-form expr '(case "a" "b" 1 2)))))
+
+    (testing "Dynamic"
+      (testing "multi-conditional"
+        (let [expr (tu/dynamic-compile
+                     {:type "Case"
+                      :caseItem
+                      [{:when #elm/parameter-ref "true"
+                        :then #elm/integer "1"}]
+                      :else #elm/integer "2"})]
+          (has-form expr '(case (param-ref "true") 1 2))))
+
+      (testing "comparand-based"
+        (let [expr (tu/dynamic-compile
+                     {:type "Case"
+                      :comparand #elm/parameter-ref "a"
+                      :caseItem
+                      [{:when #elm/parameter-ref "b"
+                        :then #elm/integer "1"}]
+                      :else #elm/integer "2"})]
+          (has-form expr '(case (param-ref "a") (param-ref "b") 1 2))))))
+
+  (testing "expression is dynamic"
+    (testing "multi-conditional"
+      (is (false? (core/-static (tu/dynamic-compile {:type "Case"
+                                                     :caseItem
+                                                     [{:when #elm/parameter-ref "true"
+                                                       :then #elm/parameter-ref "1"}]
+                                                     :else #elm/parameter-ref "2"})))))
+
+    (testing "comparand-based"
+      (is (false? (core/-static (tu/dynamic-compile {:type "Case"
+                                                     :comparand #elm/parameter-ref "a"
+                                                     :caseItem
+                                                     [{:when #elm/parameter-ref "b"
+                                                       :then #elm/parameter-ref "1"}]
+                                                     :else #elm/parameter-ref "2"})))))))
 
 
 ;; 15.2. If
@@ -43,4 +144,9 @@
     (are [elm res] (= res (tu/dynamic-compile-eval elm))
       #elm/if [#elm/parameter-ref "true" #elm/integer "1" #elm/integer "2"] 1
       #elm/if [#elm/parameter-ref "false" #elm/integer "1" #elm/integer "2"] 2
-      #elm/if [#elm/parameter-ref "nil" #elm/integer "1" #elm/integer "2"] 2)))
+      #elm/if [#elm/parameter-ref "nil" #elm/integer "1" #elm/integer "2"] 2))
+
+  (testing "expression is dynamic"
+    (is (false? (core/-static (tu/dynamic-compile #elm/if [#elm/parameter-ref "x"
+                                                           #elm/parameter-ref "y"
+                                                           #elm/parameter-ref "z"]))))))

--- a/modules/cql/test/blaze/elm/compiler/core_spec.clj
+++ b/modules/cql/test/blaze/elm/compiler/core_spec.clj
@@ -1,0 +1,15 @@
+(ns blaze.elm.compiler.core-spec
+  (:require
+    [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
+    [clojure.spec.alpha :as s]))
+
+
+(s/fdef core/expr?
+  :args (s/cat :x any?)
+  :ret boolean?)
+
+
+(s/fdef core/static?
+  :args (s/cat :x any?)
+  :ret boolean?)

--- a/modules/cql/test/blaze/elm/compiler/nullological_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/nullological_operators_test.clj
@@ -6,6 +6,7 @@
   (:require
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
     [blaze.elm.compiler.test-util :as tu]
     [blaze.elm.literal :as elm]
     [blaze.elm.literal-spec]
@@ -50,7 +51,13 @@
     [#elm/integer "2"] 2
     [#elm/list []] nil
     [{:type "Null"} #elm/list [#elm/string "a"]] ["a"]
-    [#elm/list [{:type "Null"} #elm/string "a"]] "a"))
+    [#elm/list [{:type "Null"} #elm/string "a"]] "a")
+
+  (testing "expression is dynamic"
+    (are [elm] (false? (core/-static (tu/dynamic-compile (elm/coalesce elm))))
+      []
+      [{:type "Null"}]
+      [#elm/list []])))
 
 
 ;; 14.3. IsFalse
@@ -70,6 +77,8 @@
       #elm/parameter-ref "true" false
       #elm/parameter-ref "false" true
       #elm/parameter-ref "nil" false))
+
+  (tu/testing-unary-dynamic elm/is-false)
 
   (tu/testing-unary-form elm/is-false))
 
@@ -92,6 +101,8 @@
       #elm/parameter-ref "false" false
       #elm/parameter-ref "nil" true))
 
+  (tu/testing-unary-dynamic elm/is-null)
+
   (tu/testing-unary-form elm/is-null))
 
 
@@ -112,5 +123,7 @@
       #elm/parameter-ref "true" true
       #elm/parameter-ref "false" false
       #elm/parameter-ref "nil" false))
+
+  (tu/testing-unary-dynamic elm/is-true)
 
   (tu/testing-unary-form elm/is-true))

--- a/modules/cql/test/blaze/elm/compiler/parameters_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/parameters_test.clj
@@ -8,8 +8,9 @@
     [blaze.elm.code-spec]
     [blaze.elm.compiler :as c]
     [blaze.elm.compiler.core :as core]
+    [blaze.elm.compiler.core-spec]
     [blaze.elm.compiler.parameters :refer [->ParameterRef]]
-    [blaze.elm.compiler.test-util :as tu]
+    [blaze.elm.compiler.test-util :as tu :refer [has-form]]
     [blaze.elm.literal]
     [blaze.elm.literal-spec]
     [clojure.spec.test.alpha :as st]
@@ -47,7 +48,7 @@
       (is (= (->ParameterRef "parameter-def-101820") expr))
 
       (testing "form"
-        (is (= '(param-ref "parameter-def-101820") (core/-form expr))))))
+        (has-form expr '(param-ref "parameter-def-101820")))))
 
   (testing "definition not found"
     (let [context {:library {}}]

--- a/modules/cql/test/blaze/elm/compiler/simple_values_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/simple_values_test.clj
@@ -36,12 +36,12 @@
 ;; the boolean value true or the string "antithrombotic".
 (deftest compile-literal-test
   (testing "Boolean Literal"
-    (are [elm res] (= res (c/compile {} elm))
+    (are [elm res] (let [expr (c/compile {} elm)] (= res expr (c/form expr)))
       #elm/boolean "true" true
       #elm/boolean "false" false))
 
   (testing "Decimal Literal"
-    (are [elm res] (= res (c/compile {} elm))
+    (are [elm res] (let [expr (c/compile {} elm)] (= res expr (c/form expr)))
       #elm/decimal "-1" -1M
       #elm/decimal "0" 0M
       #elm/decimal "1" 1M
@@ -62,7 +62,7 @@
         ::anom/message := "Incorrect decimal literal `x`.")))
 
   (testing "Long Literal"
-    (are [elm res] (= res (c/compile {} elm))
+    (are [elm res] (let [expr (c/compile {} elm)] (= res expr (c/form expr)))
       #elm/long "-1" -1
       #elm/long "0" 0
       #elm/long "1" 1)
@@ -73,7 +73,7 @@
         ::anom/message := "Incorrect long literal `x`.")))
 
   (testing "Integer Literal"
-    (are [elm res] (= res (c/compile {} elm))
+    (are [elm res] (let [expr (c/compile {} elm)] (= res expr (c/form expr)))
       #elm/integer "-1" -1
       #elm/integer "0" 0
       #elm/integer "1" 1)

--- a/modules/cql/test/blaze/elm/literal.clj
+++ b/modules/cql/test/blaze/elm/literal.clj
@@ -1,6 +1,6 @@
 (ns blaze.elm.literal
   (:refer-clojure
-    :exclude [abs and boolean count distinct first flatten list long max min not or
+    :exclude [abs and boolean count distinct first flatten last list long max min not or
               time])
   (:require
     [blaze.elm.spec]
@@ -262,6 +262,7 @@
    :element elements})
 
 
+;; 15.2. If
 (defn if-expr [[condition then else]]
   {:type "If" :condition condition :then then :else else})
 
@@ -355,12 +356,13 @@
 
 
 ;; 16.19. Round
-(defn round [[operand precision]]
-  (cond->
-    {:type "Round"
-     :operand operand}
-    precision
-    (assoc :precision precision)))
+(defn round [arg]
+  (let [[operand precision] (if (sequential? arg) arg [arg])]
+    (cond->
+      {:type "Round"
+       :operand operand}
+      precision
+      (assoc :precision precision))))
 
 
 ;; 16.20. Subtract
@@ -402,6 +404,13 @@
    :operand ops})
 
 
+;; 17.7. LastPositionOf
+(defn last-position-of [[pattern s]]
+  {:type "LastPositionOf"
+   :pattern pattern
+   :string s})
+
+
 ;; 17.8. Length
 (defn length [x]
   {:type "Length"
@@ -417,6 +426,19 @@
 ;; 17.10. Matches
 (defn matches [ops]
   {:type "Matches"
+   :operand ops})
+
+
+;; 17.12. PositionOf
+(defn position-of [[pattern s]]
+  {:type "PositionOf"
+   :pattern pattern
+   :string s})
+
+
+;; 17.13. ReplaceMatches
+(defn replace-matches [ops]
+  {:type "ReplaceMatches"
    :operand ops})
 
 
@@ -533,6 +555,11 @@
         minute (assoc :minute minute)
         second (assoc :second second)
         millisecond (assoc :millisecond millisecond)))))
+
+
+;; 18.21. TimeOfDay
+(def time-of-day
+  {:type "TimeOfDay"})
 
 
 ;; 18.22. Today
@@ -716,7 +743,7 @@
 
 ;; 20.3. Current
 (defn current [scope]
-  {:type "Current" :scope scope})
+  (cond-> {:type "Current"} scope (assoc :scope scope)))
 
 
 ;; 20.4. Distinct
@@ -737,6 +764,16 @@
 ;; 20.11. Flatten
 (defn flatten [list]
   {:type "Flatten" :operand list})
+
+
+;; 20.16. IndexOf
+(defn index-of [[source element]]
+  {:type "IndexOf" :source source :element element})
+
+
+;; 20.18. Last
+(defn last [source]
+  {:type "Last" :source source})
 
 
 ;; 20.25. SingletonFrom

--- a/modules/cql/test/blaze/elm/literal_spec.clj
+++ b/modules/cql/test/blaze/elm/literal_spec.clj
@@ -247,8 +247,9 @@
 
 
 (s/fdef elm/round
-  :args (s/cat :ops (s/spec (s/cat :x :elm/expression
-                                   :precision (s/? :elm/expression))))
+  :args (s/cat :ops (s/alt :single :elm/expression
+                           :multi (s/spec (s/cat :x :elm/expression
+                                                 :precision (s/? :elm/expression)))))
   :ret :elm/expression)
 
 
@@ -413,7 +414,7 @@
 
 ;; 20.3. Current
 (s/fdef elm/current
-  :args (s/cat :scope string?)
+  :args (s/cat :scope (s/nilable string?))
   :ret :elm/expression)
 
 

--- a/modules/cql/test/data_readers.clj
+++ b/modules/cql/test/data_readers.clj
@@ -67,11 +67,28 @@
  elm/interval blaze.elm.literal/interval
  elm/contains blaze.elm.literal/contains
  elm/intersect blaze.elm.literal/intersect
+ elm/point-from blaze.elm.literal/point-from
  elm/current blaze.elm.literal/current
  elm/distinct blaze.elm.literal/distinct
  elm/exists blaze.elm.literal/exists
  elm/first blaze.elm.literal/first
+ elm/last blaze.elm.literal/last
  elm/singleton-from blaze.elm.literal/singleton-from
+ elm/all-true blaze.elm.literal/all-true
+ elm/any-true blaze.elm.literal/any-true
+ elm/avg blaze.elm.literal/avg
+ elm/count blaze.elm.literal/count
+ elm/geometric-mean blaze.elm.literal/geometric-mean
+ elm/product blaze.elm.literal/product
+ elm/max blaze.elm.literal/max
+ elm/median blaze.elm.literal/median
+ elm/min blaze.elm.literal/min
+ elm/mode blaze.elm.literal/mode
+ elm/population-variance blaze.elm.literal/population-variance
+ elm/population-std-dev blaze.elm.literal/population-std-dev
+ elm/sum blaze.elm.literal/sum
+ elm/std-dev blaze.elm.literal/std-dev
+ elm/variance blaze.elm.literal/variance
  elm/as blaze.elm.literal/as
  elm/can-convert-quantity blaze.elm.literal/can-convert-quantity
  elm/convert-quantity blaze.elm.literal/convert-quantity


### PR DESCRIPTION
Before form was only implemented for some expressions. Also added an explicit -static method to expressions and removed the records because we have form now.