### PR TITLE
Revert to Official Lacinia Dependency

### DIFF
--- a/modules/operation-graphql/deps.edn
+++ b/modules/operation-graphql/deps.edn
@@ -9,8 +9,7 @@
   {:local/root "../spec"}
 
   com.walmartlabs/lacinia
-  {:git/url "https://github.com/alexanderkiel/lacinia.git"
-   :git/sha "d3aa6a7a4b452521f5f311683cc996e782f1f59d"}
+  {:mvn/version "1.2.1"}
 
   org.antlr/antlr4
   {:mvn/version "4.10.1"


### PR DESCRIPTION
I had replaced the ordered-map in Lacinia with array-map because of performance reasons. Having the official dependency is currently more important than improved performance.