### PR TITLE
Improve Jepsen Test Runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -919,7 +919,7 @@ jobs:
       run: .github/scripts/check-capability-statement.sh
 
     - name: Jepsen Register Test
-      run: make -C modules/jepsen register-test
+      run: make -C modules/jepsen register-test-fast
 
   openid-auth-test:
     needs: build
@@ -1603,7 +1603,7 @@ jobs:
       run: .github/scripts/check-capability-statement.sh
 
     - name: Jepsen Register Test
-      run: make -C modules/jepsen register-test
+      run: make -C modules/jepsen register-test-slow
 
     - name: Docker Stats
       run: docker stats --no-stream

--- a/modules/jepsen/Makefile
+++ b/modules/jepsen/Makefile
@@ -10,8 +10,11 @@ test: prep
 test-coverage:
 	true
 
-register-test: prep
+register-test-fast: prep
 	clojure -M:register test --concurrency 16 --time-limit 60 -n localhost:8080 --delta-time 0.01
+
+register-test-slow: prep
+	clojure -M:register test --concurrency 16 --time-limit 60 -n localhost:8080 --delta-time 0.1
 
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target store


### PR DESCRIPTION
The distributed test takes currently up to 30 minutes. This is too long. I've provided a test which runs in fast succession (delta-time=0.01) and one that runs slower (delta-time=0.1) and so produces less output that has to be analyzed.