### PR TITLE
Fix Empty Results in Certain Reverse Chaining FHIR Search Queries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -446,6 +446,12 @@ jobs:
     - name: Download MedicationRequest Resources - Including Medications
       run: blazectl --no-progress --server http://localhost:8080/fhir download MedicationRequest -q '_include=MedicationRequest:medication' -o MedicationRequest.ndjson
 
+    - name: Download male Patient Resources having inpatient Encounters in 2010
+      run: .github/scripts/download-resources-query.sh Patient "gender=male&_has:Encounter:patient:class=IMP&_has:Encounter:patient:date=2010" 8
+
+    - name: Download female Patient Resources having inpatient Encounters in 2010
+      run: .github/scripts/download-resources-query.sh Patient "gender=female&_has:Encounter:patient:class=IMP&_has:Encounter:patient:date=2010" 11
+
     - name: Download Observations using _elements=subject
       run: .github/scripts/download-observations-elements.sh
 
@@ -1344,6 +1350,12 @@ jobs:
 
     - name: Download MedicationRequest Resources - Including Medications
       run: blazectl --no-progress --server http://localhost:8080/fhir download MedicationRequest -q '_include=MedicationRequest:medication' -o MedicationRequest.ndjson
+
+    - name: Download male Patient Resources having inpatient Encounters in 2010
+      run: .github/scripts/download-resources-query.sh Patient "gender=male&_has:Encounter:patient:class=IMP&_has:Encounter:patient:date=2010" 8
+
+    - name: Download female Patient Resources having inpatient Encounters in 2010
+      run: .github/scripts/download-resources-query.sh Patient "gender=female&_has:Encounter:patient:class=IMP&_has:Encounter:patient:date=2010" 11
 
     - name: Download Observations using _elements=subject
       run: .github/scripts/download-observations-elements.sh

--- a/modules/db-protocols/src/blaze/db/impl/protocols.clj
+++ b/modules/db-protocols/src/blaze/db/impl/protocols.clj
@@ -88,7 +88,10 @@
   (-resource-handles
     [search-param context tid modifier compiled-value]
     [search-param context tid modifier compiled-value start-id]
-    "Returns a reducible collection.")
+    "Returns a reducible collection.
+
+    Changes the state of `context`. Consuming the collection requires exclusive
+    access to `context`.")
   (-sorted-resource-handles
     [search-param context tid direction]
     [search-param context tid direction start-id]

--- a/modules/db/src/blaze/db/impl/index.clj
+++ b/modules/db/src/blaze/db/impl/index.clj
@@ -8,7 +8,9 @@
     [blaze.db.impl.search-param.util :as u]))
 
 
-(defn- other-clauses-filter [context clauses]
+(defn- other-clauses-filter
+  "Changes the state of `context`. Requires exclusive access to `context`."
+  [context clauses]
   (filter
     (fn [resource-handle]
       (loop [[[search-param modifier _ values] & clauses] clauses]

--- a/modules/db/src/blaze/db/impl/search_param.clj
+++ b/modules/db/src/blaze/db/impl/search_param.clj
@@ -40,7 +40,10 @@
 (defn resource-handles
   "Returns a reducible collection of distinct resource handles.
 
-  Concatenates resource handles of each value in compiled `values`."
+  Concatenates resource handles of each value in compiled `values`.
+
+  Changes the state of `context`. Consuming the collection requires exclusive
+  access to `context`."
   ([search-param context tid modifier values]
    (if (= 1 (count values))
      (p/-resource-handles search-param context tid modifier (first values))
@@ -100,7 +103,9 @@
     (compartment-keys search-param context compartment tid compiled-values)))
 
 
-(defn matches? [search-param context resource-handle modifier compiled-values]
+(defn matches?
+  "Changes the state of `context`. Requires exclusive access to `context`."
+  [search-param context resource-handle modifier compiled-values]
   (p/-matches? search-param context resource-handle modifier compiled-values))
 
 

--- a/modules/db/src/blaze/db/impl/search_param/token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/token.clj
@@ -146,8 +146,8 @@
   "Returns a reducible collection of [id hash-prefix] tuples starting at
   `start-id` (optional).
 
-  Changes the state of `iter`. Consuming the collection requires exclusive
-  access to `iter`. Doesn't close `iter`."
+  Changes the state of `context`. Consuming the collection requires exclusive
+  access to `context`."
   ([{:keys [svri]} c-hash tid value]
    (sp-vr/prefix-keys! svri c-hash tid value value))
   ([{:keys [svri]} c-hash tid value start-id]

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -1150,7 +1150,11 @@
       [[[:put {:fhir/type :fhir/Patient :id "0"
                :active true}]
         [:put {:fhir/type :fhir/Patient :id "1"
-               :active true}]
+               :active false}]
+        [:put {:fhir/type :fhir/Patient :id "2"
+               :active false}]
+        [:put {:fhir/type :fhir/Patient :id "3"
+               :active false}]
         [:put {:fhir/type :fhir/Observation :id "0"
                :subject
                #fhir/Reference
@@ -1166,7 +1170,7 @@
                        {:value 130M
                         :code #fhir/code"mm[Hg]"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
-        [:put {:fhir/type :fhir/Observation :id "O1"
+        [:put {:fhir/type :fhir/Observation :id "1"
                :subject
                #fhir/Reference
                        {:reference "Patient/0"}
@@ -1181,7 +1185,7 @@
                        {:value 150M
                         :code #fhir/code"mm[Hg]"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]
-        [:put {:fhir/type :fhir/Observation :id "O2"
+        [:put {:fhir/type :fhir/Observation :id "2"
                :subject
                #fhir/Reference
                        {:reference "Patient/1"}
@@ -1194,6 +1198,21 @@
                :value
                #fhir/Quantity
                        {:value 100M
+                        :code #fhir/code"mm[Hg]"
+                        :system #fhir/uri"http://unitsofmeasure.org"}}]
+        [:put {:fhir/type :fhir/Observation :id "3"
+               :subject
+               #fhir/Reference
+                       {:reference "Patient/3"}
+               :code
+               #fhir/CodeableConcept
+                       {:coding
+                        [#fhir/Coding
+                                {:system #fhir/uri"http://loinc.org"
+                                 :code #fhir/code"8480-6"}]}
+               :value
+               #fhir/Quantity
+                       {:value 10M
                         :code #fhir/code"mm[Hg]"
                         :system #fhir/uri"http://unitsofmeasure.org"}}]]]
 
@@ -1227,11 +1246,11 @@
 
       (testing "as second clause"
         (testing "select the Patient with > 130 mm[Hg]"
-          (let [clauses [["active" "true"]
-                         ["_has:Observation:patient:code-value-quantity" "8480-6$ge130"]]]
+          (let [clauses [["active" "false"]
+                         ["_has:Observation:patient:code-value-quantity" "8480-6$10"]]]
             (given (pull-type-query node "Patient" clauses)
               count := 1
-              [0 :id] := "0")))))
+              [0 :id] := "3")))))
 
     (testing "errors"
       (testing "missing modifier"


### PR DESCRIPTION
This issue solved the problem of using iterators concurrently by defensively open new ones for the `resource-handles` function in `blaze.db.impl.search-param.has`. This is more like a hot fix while the sustainable solution would be to resolve #1217.

Closes: #1215