### PR TITLE
Remove funcool/cuerdas Dependency

### DIFF
--- a/modules/cql/.clj-kondo/config.edn
+++ b/modules/cql/.clj-kondo/config.edn
@@ -50,7 +50,6 @@
     clojure.java.io io
     clojure.spec.alpha s
     clojure.string str
-    cuerdas.core c-str
     jsonista.core j}}}
 
  :output

--- a/modules/cql/src/blaze/elm/quantity.clj
+++ b/modules/cql/src/blaze/elm/quantity.clj
@@ -7,7 +7,7 @@
     [blaze.anomaly :as ba :refer [throw-anom]]
     [blaze.elm.compiler.core :as core]
     [blaze.elm.protocols :as p]
-    [cuerdas.core :as c-str])
+    [clojure.string :as str])
   (:import
     [com.google.common.base CharMatcher]
     [javax.measure Quantity UnconvertibleException Unit]
@@ -43,11 +43,11 @@
 
 
 (defn- replace-exp [s n]
-  (c-str/replace s (str "10*" n) (apply str "1" (repeat n \0))))
+  (str/replace s (str "10*" n) (apply str "1" (repeat n \0))))
 
 
 (defn- hack-replace-unsupported [s]
-  (reduce replace-exp s (range 1 13)))
+  (reduce replace-exp s (reverse (range 1 13))))
 
 
 (let [mem (volatile! {})]

--- a/modules/db-resource-store-cassandra/.clj-kondo/config.edn
+++ b/modules/db-resource-store-cassandra/.clj-kondo/config.edn
@@ -21,7 +21,7 @@
 
   :consistent-alias
   {:aliases
-   {cognitect.anomalies anom
-    cuerdas.core c-str}}}
+   {clojure.string str
+    cognitect.anomalies anom}}}
 
  :skip-comments true}

--- a/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
+++ b/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
@@ -17,9 +17,9 @@
     [blaze.test-util :as tu :refer [given-thrown]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
+    [clojure.string :as str]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
-    [cuerdas.core :as c-str]
     [integrant.core :as ig]
     [jsonista.core :as j]
     [taoensso.timbre :as log])
@@ -47,7 +47,7 @@
 
 (defn hash [s]
   (assert (= 1 (count s)))
-  (hash/from-hex (c-str/repeat s 64)))
+  (hash/from-hex (str/join (repeat 64 s))))
 
 
 (def bound-get-statement (reify BoundStatement))

--- a/modules/db-resource-store/.clj-kondo/config.edn
+++ b/modules/db-resource-store/.clj-kondo/config.edn
@@ -21,7 +21,7 @@
 
   :consistent-alias
   {:aliases
-   {cognitect.anomalies anom
-    cuerdas.core c-str}}}
+   {clojure.string str
+    cognitect.anomalies anom}}}
 
  :skip-comments true}

--- a/modules/db-resource-store/test/blaze/db/resource_store/kv_test.clj
+++ b/modules/db-resource-store/test/blaze/db/resource_store/kv_test.clj
@@ -19,9 +19,9 @@
     [blaze.test-util :as tu :refer [given-thrown]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
+    [clojure.string :as str]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
-    [cuerdas.core :as c-str]
     [integrant.core :as ig]
     [jsonista.core :as j]
     [taoensso.timbre :as log])
@@ -42,7 +42,7 @@
    (hash "0"))
   ([s]
    (assert (= 1 (count s)))
-   (hash/from-hex (c-str/repeat s 64))))
+   (hash/from-hex (str/join (repeat 64 s)))))
 
 
 (defn- invalid-content

--- a/modules/db/test-perf/blaze/db/impl/index/resource_handle_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/impl/index/resource_handle_test_perf.clj
@@ -4,8 +4,8 @@
     [blaze.db.impl.index.resource-handle :as rh]
     [blaze.test-util :as tu]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [are deftest testing]]
-    [cuerdas.core :as c-str])
+    [clojure.string :as str]
+    [clojure.test :as test :refer [are deftest testing]])
   (:import
     [org.openjdk.jol.info GraphLayout]))
 
@@ -22,7 +22,7 @@
 
 
 (defn- resource-handle [id-size]
-  (rh/resource-handle 0 (c-str/repeat "0" id-size) 0 (bb/allocate 40)))
+  (rh/resource-handle 0 (str/join (repeat id-size "0")) 0 (bb/allocate 40)))
 
 
 (deftest resource-handle-test

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -32,11 +32,11 @@
     [clojure.test.check.generators :as gen]
     [clojure.test.check.properties :as prop]
     [cognitect.anomalies :as anom]
-    [cuerdas.core :refer [pascal]]
     [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log])
   (:import
+    [com.google.common.base CaseFormat]
     [java.time Instant]
     [java.util.concurrent TimeUnit]))
 
@@ -163,6 +163,10 @@
   (gen/such-that unique-ids? (gen/vector (create-tx-op resource-gen) 1 max-ops)))
 
 
+(defn- kebab->pascal [s]
+  (.to CaseFormat/LOWER_HYPHEN CaseFormat/UPPER_CAMEL s))
+
+
 (deftest transact-test
   (testing "create"
     (testing "one Patient"
@@ -206,7 +210,7 @@
               [tx-ops]
 
               (= (count tx-ops)
-                 (count @(d/pull-many node (d/type-list (d/db node) (pascal (name gen))))))))))))
+                 (count @(d/pull-many node (d/type-list (d/db node) (kebab->pascal (name gen))))))))))))
 
   (testing "conditional create"
     (testing "one Patient"

--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -25,9 +25,6 @@
   com.taoensso/timbre
   {:mvn/version "5.2.1"}
 
-  funcool/cuerdas
-  {:mvn/version "2022.06.16-403"}
-
   metosin/jsonista
   {:mvn/version "0.3.8"}
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -6,11 +6,11 @@
     [blaze.fhir.spec.impl.util :as u]
     [blaze.fhir.spec.impl.xml :as xml]
     [blaze.fhir.spec.type :as type]
+    [blaze.fhir.spec.type.string-util :as su]
     [clojure.alpha.spec :as s]
     [clojure.data.xml.name :as xml-name]
     [clojure.data.xml.node :as xml-node]
-    [clojure.string :as str]
-    [cuerdas.core :as c-str])
+    [clojure.string :as str])
   (:import
     [com.github.benmanes.caffeine.cache CacheLoader Caffeine LoadingCache]
     [java.net URLEncoder]
@@ -117,7 +117,7 @@
 
 (defn- key-name [last-path-part {:keys [code]}]
   (if (str/ends-with? last-path-part "[x]")
-    (str/replace last-path-part "[x]" (c-str/capital code))
+    (str/replace last-path-part "[x]" (su/capital code))
     last-path-part))
 
 
@@ -147,7 +147,7 @@
 
 
 (defn- choice-spec-def* [modifier path code min max]
-  {:key (path-parts->key' (str "fhir." (name modifier)) (split-path (str/replace path "[x]" (c-str/capital code))))
+  {:key (path-parts->key' (str "fhir." (name modifier)) (split-path (str/replace path "[x]" (su/capital code))))
    :modifier modifier
    :min min
    :max max
@@ -392,7 +392,7 @@
       (.build
         (reify CacheLoader
           (load [_ [key type]]
-            (keyword (str (name key) (c-str/capital (name type)))))))))
+            (keyword (str (name key) (su/capital (name type)))))))))
 
 
 (defn- choice-type-key [key type]
@@ -479,7 +479,7 @@
          :fhir.json/HumanName
          :fhir.json/Address
          :fhir.json/Reference)
-       (json-object-spec-form (c-str/kebab path-part) child-spec-defs)
+       (json-object-spec-form (su/pascal->kebab path-part) child-spec-defs)
        :fhir.json.Bundle.entry/search
        (json-object-spec-form "bundle-entry-search" child-spec-defs)
        (conj (seq (remap-choice-conformer-forms child-spec-defs))
@@ -656,7 +656,7 @@
          :fhir.cbor/HumanName
          :fhir.cbor/Address
          :fhir.cbor/Reference)
-       (cbor-object-spec-form (c-str/kebab path-part) child-spec-defs)
+       (cbor-object-spec-form (su/pascal->kebab path-part) child-spec-defs)
        :fhir.cbor.Bundle.entry/search
        (cbor-object-spec-form "bundle-entry-search" child-spec-defs)
        (conj (seq (remap-choice-conformer-forms child-spec-defs))
@@ -771,7 +771,7 @@
 
 (defn- xml-spec-form [name {:keys [element]}]
   (let [regex (type-regex (value-type element))
-        constructor (str "xml->" (c-str/capital name))]
+        constructor (str "xml->" (su/capital name))]
     (case name
       "xhtml" `(s/and xml/element? (s/conformer type/xml->Xhtml type/to-xml))
       (xml/primitive-xml-form regex (symbol "blaze.fhir.spec.type" constructor)))))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/macros.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/macros.clj
@@ -3,10 +3,10 @@
     [blaze.fhir.spec.impl.intern :as intern]
     [blaze.fhir.spec.type.json :as json]
     [blaze.fhir.spec.type.protocols :as p]
+    [blaze.fhir.spec.type.string-util :as su]
     [blaze.fhir.spec.type.system :as system]
     [clojure.data.xml.node :as xml-node]
-    [clojure.string :as str]
-    [cuerdas.core :refer [capital kebab]])
+    [clojure.string :as str])
   (:import
     [com.fasterxml.jackson.core JsonGenerator SerializableString]
     [com.fasterxml.jackson.core.io JsonStringEncoder]
@@ -304,7 +304,7 @@
 
 (defn- field-name [field-sym]
   (if (:polymorph (meta field-sym))
-    `(json/field-name (str ~(str field-sym) (capital (name (blaze.fhir.spec.type/type ~field-sym)))))
+    `(json/field-name (str ~(str field-sym) (su/capital (name (blaze.fhir.spec.type/type ~field-sym)))))
     (json/field-name (str field-sym))))
 
 
@@ -372,9 +372,9 @@
                        fields)
                    (persistent!)))))
 
-       (def ~(symbol (kebab name))
+       (def ~(symbol (su/pascal->kebab (str name)))
          (let [intern# (intern/intern-value ~(symbol (str "map->" name)))]
-           (fn ~(symbol (kebab name)) [{:keys [~@fields] :as ~m-sym}]
+           (fn ~(symbol (su/pascal->kebab (str name))) [{:keys [~@fields] :as ~m-sym}]
              (if ~interned
                (intern# ~m-sym)
                (~(symbol (str name ".")) ~@fields)))))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/string_util.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/string_util.clj
@@ -1,0 +1,16 @@
+(ns blaze.fhir.spec.type.string-util
+  (:require
+    [clojure.string :as str])
+  (:import
+    [com.google.common.base CaseFormat]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn capital [s]
+  (str (str/upper-case (subs s 0 1)) (subs s 1)))
+
+
+(defn pascal->kebab [s]
+  (.to CaseFormat/UPPER_CAMEL CaseFormat/LOWER_HYPHEN s))

--- a/modules/fhir-structure/test-perf/blaze/fhir/spec/type_test_mem.clj
+++ b/modules/fhir-structure/test-perf/blaze/fhir/spec/type_test_mem.clj
@@ -2,10 +2,10 @@
   (:require
     [blaze.fhir.spec.memory :as mem]
     [blaze.fhir.spec.type :as type]
-    [clojure.test :refer [are deftest is testing]]
-    [cuerdas.core :as c-str]
+    [blaze.test-util]
     [clojure.alpha.spec :as s2]
-    [blaze.test-util])
+    [clojure.string :as str]
+    [clojure.test :refer [are deftest is testing]])
   (:import
     [java.time Instant ZoneOffset]))
 
@@ -19,8 +19,8 @@
     #fhir/string"" 40
     #fhir/string"a" 48
     #fhir/string{:value "a"} 48
-    (type/string (c-str/repeat "a" 8)) 48
-    (type/string (c-str/repeat "a" 9)) 56
+    (type/string (str/join (repeat 8 "a"))) 48
+    (type/string (str/join (repeat 9 "a"))) 56
     #fhir/string{:id "0" :value "foo"} 136
 
     #fhir/decimal 1.1M 40

--- a/modules/fhir-test-util/src/blaze/fhir/spec/generators.clj
+++ b/modules/fhir-test-util/src/blaze/fhir/spec/generators.clj
@@ -4,8 +4,9 @@
     [blaze.fhir.spec.type :as type]
     [blaze.fhir.spec.type.system :as system]
     [clojure.string :as str]
-    [clojure.test.check.generators :as gen]
-    [cuerdas.core :refer [pascal]]))
+    [clojure.test.check.generators :as gen])
+  (:import
+    [com.google.common.base CaseFormat]))
 
 
 (set! *warn-on-reflection* true)
@@ -469,6 +470,10 @@
        (fhir-type :fhir.Bundle/entry)))
 
 
+(defn- kebab->pascal [s]
+  (.to CaseFormat/LOWER_HYPHEN CaseFormat/UPPER_CAMEL s))
+
+
 (defmacro def-resource-gen [type [& fields]]
   (let [fields (partition 2 fields)
         field-syms (map first fields)]
@@ -476,7 +481,7 @@
                      :or ~(into {} (map vec) fields)}]
        (->> (gen/tuple ~@field-syms)
             (to-map [~@(map keyword field-syms)])
-            (fhir-type ~(keyword "fhir" (pascal type)))))))
+            (fhir-type ~(keyword "fhir" (kebab->pascal (str type))))))))
 
 
 (def-resource-gen patient

--- a/modules/interaction/.clj-kondo/config.edn
+++ b/modules/interaction/.clj-kondo/config.edn
@@ -39,8 +39,8 @@
     blaze.db.kv kv
     blaze.test-util tu
     blaze.util u
+    clojure.string str
     cognitect.anomalies anom
-    cuerdas.core c-str
     ring.util.response ring}}}
 
  :skip-comments true}

--- a/modules/interaction/test/blaze/interaction/search/nav_test.clj
+++ b/modules/interaction/test/blaze/interaction/search/nav_test.clj
@@ -6,8 +6,8 @@
     [blaze.page-store.protocols :as p]
     [blaze.test-util :as tu]
     [clojure.spec.test.alpha :as st]
-    [clojure.test :as test :refer [deftest is testing]]
-    [cuerdas.core :as c-str]))
+    [clojure.string :as str]
+    [clojure.test :as test :refer [deftest is testing]]))
 
 
 (st/instrument)
@@ -186,7 +186,7 @@
   (reify p/PageStore
     (-put [_ clauses]
       (assert (= clauses-1 clauses))
-      (ac/completed-future (c-str/repeat "A" 32)))))
+      (ac/completed-future (str/join (repeat 32 "A"))))))
 
 
 (deftest token-url-test

--- a/modules/interaction/test/blaze/interaction/search/params_test.clj
+++ b/modules/interaction/test/blaze/interaction/search/params_test.clj
@@ -8,9 +8,9 @@
     [blaze.page-store.protocols :as p]
     [blaze.test-util :as tu]
     [clojure.spec.test.alpha :as st]
+    [clojure.string :as str]
     [clojure.test :as test :refer [deftest testing]]
     [cognitect.anomalies :as anom]
-    [cuerdas.core :as c-str]
     [juxt.iota :refer [given]]))
 
 
@@ -49,22 +49,22 @@
     (given @(params/decode
               (reify p/PageStore
                 (-get [_ token]
-                  (assert (= (c-str/repeat "A" 32) token))
+                  (assert (= (str/join (repeat 32 "A")) token))
                   (ac/completed-future [["foo" "bar"]])))
               :blaze.preference.handling/strict
-              {"__token" (c-str/repeat "A" 32)})
+              {"__token" (str/join (repeat 32 "A"))})
       :clauses := [["foo" "bar"]]
-      :token := (c-str/repeat "A" 32)))
+      :token := (str/join (repeat 32 "A"))))
 
   (testing "token not found"
     (given-failed-future
       (params/decode
         (reify p/PageStore
           (-get [_ token]
-            (assert (= (c-str/repeat "A" 32) token))
+            (assert (= (str/join (repeat 32 "A")) token))
             (ac/completed-future (ba/not-found "Not Found"))))
         :blaze.preference.handling/strict
-        {"__token" (c-str/repeat "A" 32)})
+        {"__token" (str/join (repeat 32 "A"))})
       ::anom/category := ::anom/not-found
       :http/status := nil))
 

--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -23,7 +23,6 @@
     [clojure.spec.test.alpha :as st]
     [clojure.string :as str]
     [clojure.test :as test :refer [deftest is testing]]
-    [cuerdas.core :as c-str]
     [integrant.core :as ig]
     [java-time.api :as time]
     [juxt.iota :refer [given]]
@@ -564,7 +563,7 @@
         (let [{:keys [status body]}
               @(handler
                  {::reitit/match patient-page-match
-                  :params {"__t" "0" "__token" (c-str/repeat "A" 32)}})]
+                  :params {"__t" "0" "__token" (str/join (repeat 32 "A"))}})]
 
           (is (= 404 status))
 
@@ -573,7 +572,7 @@
             [:issue 0 :severity] := #fhir/code"error"
             [:issue 0 :code] := #fhir/code"not-found"
             [:issue 0 :diagnostics] := (format "Clauses of token `%s` not found."
-                                               (c-str/repeat "A" 32)))))))
+                                               (str/join (repeat 32 "A"))))))))
 
   (testing "with one patient"
     (with-handler [handler]

--- a/modules/page-store-cassandra/test/blaze/page_store/cassandra/codec_test.clj
+++ b/modules/page-store-cassandra/test/blaze/page_store/cassandra/codec_test.clj
@@ -5,9 +5,9 @@
     [blaze.test-util :as tu :refer [satisfies-prop]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
+    [clojure.string :as str]
     [clojure.test :as test :refer [deftest]]
-    [clojure.test.check.properties :as prop]
-    [cuerdas.core :as c-str]))
+    [clojure.test.check.properties :as prop]))
 
 
 (st/instrument)
@@ -16,7 +16,7 @@
 (test/use-fixtures :each tu/fixture)
 
 
-(def token (c-str/repeat "A" 32))
+(def token (str/join (repeat 32 "A")))
 
 
 (deftest encode-decode-test

--- a/modules/page-store-cassandra/test/blaze/page_store/cassandra_test.clj
+++ b/modules/page-store-cassandra/test/blaze/page_store/cassandra_test.clj
@@ -14,8 +14,8 @@
     [blaze.test-util :as tu :refer [given-thrown]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
+    [clojure.string :as str]
     [clojure.test :as test :refer [deftest is testing]]
-    [cuerdas.core :as c-str]
     [integrant.core :as ig]
     [taoensso.timbre :as log])
   (:import
@@ -61,7 +61,7 @@
 
 
 (def clauses [["active" "true"]])
-(def token (str (c-str/repeat "A" 31) "B"))
+(def token (str (str/join (repeat 31 "A")) "B"))
 
 
 (deftest put-test

--- a/modules/page-store/test/blaze/page_store/local_test.clj
+++ b/modules/page-store/test/blaze/page_store/local_test.clj
@@ -12,9 +12,9 @@
     [blaze.test-util :as tu :refer [given-thrown]]
     [clojure.spec.alpha :as s]
     [clojure.spec.test.alpha :as st]
+    [clojure.string :as str]
     [clojure.test :as test :refer [deftest is testing]]
     [cognitect.anomalies :as anom]
-    [cuerdas.core :as c-str]
     [integrant.core :as ig]
     [juxt.iota :refer [given]]
     [taoensso.timbre :as log]))
@@ -33,7 +33,7 @@
    :blaze.page-store.local/collector {:page-store (ig/ref :blaze.page-store/local)}})
 
 
-(def token (str (c-str/repeat "A" 31) "B"))
+(def token (str (str/join (repeat 31 "A")) "B"))
 
 
 (deftest init-test
@@ -68,9 +68,9 @@
       (is (= [["active" "true"]] @(page-store/get store token))))
 
     (testing "not-found"
-      (given-failed-future (page-store/get store (c-str/repeat "B" 32))
+      (given-failed-future (page-store/get store (str/join (repeat 32 "B")))
         ::anom/category := ::anom/not-found
-        ::anom/message := (format "Clauses of token `%s` not found." (c-str/repeat "B" 32))))))
+        ::anom/message := (format "Clauses of token `%s` not found." (str/join (repeat 32 "B")))))))
 
 
 (deftest put-test

--- a/modules/page-store/test/blaze/page_store/weigh_test.clj
+++ b/modules/page-store/test/blaze/page_store/weigh_test.clj
@@ -1,8 +1,8 @@
 (ns blaze.page-store.weigh-test
   (:require
     [blaze.page-store.weigh :as w]
-    [clojure.test :refer [are deftest testing]]
-    [cuerdas.core :as c-str]))
+    [clojure.string :as str]
+    [clojure.test :refer [are deftest testing]]))
 
 
 (deftest weigh-test
@@ -10,8 +10,8 @@
     (are [s size] (= size (w/weigh s))
       "" 40
       "a" 48
-      (c-str/repeat "a" 8) 48
-      (c-str/repeat "a" 9) 56))
+      (str/join (repeat 8 "a")) 48
+      (str/join (repeat 9 "a")) 56))
 
   (testing "Vector"
     (are [v size] (= size (w/weigh v))


### PR DESCRIPTION
We only used cuerdas for some basic string manipulation that is also possible with a combination of clojure/string and Guava CaseFormat.

Removing the cuerdas dependency will result in less maintenance work regarding updates, a smaller Docker image footprint and attack vector.