### PR TITLE
Simplify with-open-coll Macro and coll/eduction

### DIFF
--- a/modules/coll/src/blaze/coll/core.clj
+++ b/modules/coll/src/blaze/coll/core.clj
@@ -1,7 +1,7 @@
 (ns blaze.coll.core
   (:refer-clojure :exclude [count eduction empty? first nth some])
   (:import
-    [clojure.lang Counted Indexed IReduceInit Seqable Sequential]))
+    [clojure.lang Counted Indexed IReduceInit Sequential]))
 
 
 (set! *warn-on-reflection* true)
@@ -30,16 +30,13 @@
 
 
 (defn eduction
-  "Like `clojure.core/eduction` but faster."
+  "Like `clojure.core/eduction` but implements Counted instead of Iterable."
   [xform coll]
   (reify
     Sequential
     IReduceInit
     (reduce [_ f init]
       (transduce xform (completing f) init coll))
-    Seqable
-    (seq [coll]
-      (.seq ^Seqable (persistent! (.reduce coll conj! (transient [])))))
     Counted
     (count [coll]
       (.reduce coll inc-rf 0))))
@@ -47,7 +44,7 @@
 
 (defn count
   "Like `clojure.core/count` but works only for non-nil collections
-  implementing `clojure.lang.Countet` like vectors."
+  implementing `clojure.lang.Counted` like vectors."
   {:inline
    (fn [coll]
      `(.count ~(with-meta coll {:tag `Counted})))}

--- a/modules/coll/src/blaze/coll/core_spec.clj
+++ b/modules/coll/src/blaze/coll/core_spec.clj
@@ -11,6 +11,11 @@
   :ret any?)
 
 
+(s/fdef coll/some
+  :args (s/cat :pred ifn? :coll (s/nilable #(instance? IReduceInit %)))
+  :ret any?)
+
+
 (s/fdef coll/empty?
   :args (s/cat :coll (s/nilable #(instance? IReduceInit %)))
   :ret boolean?)
@@ -22,7 +27,7 @@
 
 
 (s/fdef coll/count
-  :args (s/cat :coll #(instance? IReduceInit %))
+  :args (s/cat :coll counted?)
   :ret nat-int?)
 
 

--- a/modules/coll/src/blaze/coll/spec.clj
+++ b/modules/coll/src/blaze/coll/spec.clj
@@ -1,0 +1,7 @@
+(ns blaze.coll.spec
+  (:import
+    [clojure.lang IReduceInit]))
+
+
+(defn coll-of [_pred]
+  #(instance? IReduceInit %))

--- a/modules/coll/test/blaze/coll/core_test.clj
+++ b/modules/coll/test/blaze/coll/core_test.clj
@@ -69,9 +69,6 @@
   (testing "eductions can be reduced"
     (is (= [2 3] (reduce conj [] (coll/eduction (map inc) [1 2])))))
 
-  (testing "eductions are seqable"
-    (is (= (list 2 3) (seq (coll/eduction (map inc) [1 2])))))
-
   (testing "eductions are counted"
     (is (= 2 (count (coll/eduction identity [1 2]))))))
 

--- a/modules/db/.clj-kondo/config.edn
+++ b/modules/db/.clj-kondo/config.edn
@@ -33,6 +33,7 @@
   {:aliases
    {blaze.anomaly ba
     blaze.async.comp ac
+    blaze.coll.spec cs
     blaze.db.api d
     blaze.db.kv kv
     blaze.db.impl.protocols p

--- a/modules/db/src/blaze/db/api_spec.clj
+++ b/modules/db/src/blaze/db/api_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.async.comp :as ac]
     [blaze.async.comp-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.api :as d]
     [blaze.db.search-param-registry-spec]
     [blaze.db.spec]
@@ -63,7 +64,7 @@
 (s/fdef d/type-list
   :args (s/cat :db :blaze.db/db :type :fhir.resource/type
                :start-id (s/? :blaze.resource/id))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/type-total
@@ -75,7 +76,7 @@
   :args (s/cat :db :blaze.db/db :type :fhir.resource/type
                :clauses :blaze.db.query/clauses
                :start-id (s/? :blaze.resource/id))
-  :ret (s/or :result (s/coll-of :blaze.db/resource-handle :kind sequential?)
+  :ret (s/or :result (cs/coll-of :blaze.db/resource-handle)
              :anomaly ::anom/anomaly))
 
 
@@ -101,7 +102,7 @@
           :db :blaze.db/db
           :start (s/? (s/cat :start-type :fhir.resource/type
                              :start-id :blaze.resource/id)))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/system-total
@@ -112,7 +113,7 @@
 (s/fdef d/system-query
   :args (s/cat :db :blaze.db/db
                :clauses :blaze.db.query/clauses)
-  :ret (s/or :result (s/coll-of :blaze.db/resource-handle :kind sequential?)
+  :ret (s/or :result (cs/coll-of :blaze.db/resource-handle)
              :anomaly ::anom/anomaly))
 
 
@@ -131,7 +132,7 @@
                :id :blaze.resource/id
                :type :fhir.resource/type
                :start-id (s/? :blaze.resource/id))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/compartment-query
@@ -140,7 +141,7 @@
                :id :blaze.resource/id
                :type :fhir.resource/type
                :clauses :blaze.db.query/clauses)
-  :ret (s/or :result (s/coll-of :blaze.db/resource-handle :kind sequential?)
+  :ret (s/or :result (cs/coll-of :blaze.db/resource-handle)
              :anomaly ::anom/anomaly))
 
 
@@ -157,7 +158,7 @@
 
 (s/fdef d/execute-query
   :args (s/cat :db :blaze.db/db :query :blaze.db/query :args (s/* any?))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/query-clauses
@@ -174,7 +175,7 @@
                :id :blaze.resource/id
                :start-t (s/? (s/nilable :blaze.db/t))
                :since (s/? (s/nilable inst?)))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/total-num-of-instance-changes
@@ -194,7 +195,7 @@
                :start-t (s/? (s/nilable :blaze.db/t))
                :start-id (s/? (s/nilable :blaze.resource/id))
                :since (s/? (s/nilable inst?)))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/total-num-of-type-changes
@@ -220,7 +221,7 @@
                         (s/? (s/cat
                                :start-id (s/nilable :blaze.resource/id)
                                :since (s/? (s/nilable inst?)))))))))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/total-num-of-system-changes
@@ -231,13 +232,13 @@
 (s/fdef d/include
   :args (s/cat :db :blaze.db/db :resource-handle :blaze.db/resource-handle
                :code string? :type (s/? :fhir.resource/type))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef d/rev-include
   :args (s/cat :db :blaze.db/db :resource-handle :blaze.db/resource-handle
                :source-type (s/? :fhir.resource/type) :code (s/? string?))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 
@@ -265,7 +266,6 @@
 
 (s/fdef d/pull-many
   :args (s/cat :node-or-db (s/or :node :blaze.db/node :db :blaze.db/db)
-               :resource-handles (s/coll-of :blaze.db/resource-handle
-                                            :kind sequential?)
+               :resource-handles (cs/coll-of :blaze.db/resource-handle)
                :elements (s/? (s/coll-of keyword?)))
   :ret ac/completable-future?)

--- a/modules/db/src/blaze/db/impl/macros.clj
+++ b/modules/db/src/blaze/db/impl/macros.clj
@@ -1,9 +1,6 @@
 (ns blaze.db.impl.macros
   (:import
-    [clojure.lang Counted IReduceInit Seqable Sequential]))
-
-
-(defn inc-rf [sum _] (inc ^long sum))
+    [clojure.lang IReduceInit Sequential]))
 
 
 (defmacro with-open-coll
@@ -15,10 +12,4 @@
      IReduceInit
      (reduce [_ rf# init#]
        (with-open ~bindings
-         (reduce rf# init# ~coll)))
-     Seqable
-     (seq [this#]
-       (.seq ^Seqable (persistent! (.reduce this# conj! (transient [])))))
-     Counted
-     (count [this#]
-       (.reduce this# inc-rf 0))))
+         (reduce rf# init# ~coll)))))

--- a/modules/db/src/blaze/db/impl/search_param/chained.clj
+++ b/modules/db/src/blaze/db/impl/search_param/chained.clj
@@ -53,7 +53,7 @@
       (count (p/-resource-handles this context tid modifier compiled-value))))
 
   (-matches? [_ context resource-handle modifier compiled-values]
-    (some
+    (coll/some
       #(p/-matches? search-param context % modifier compiled-values)
       (index/targets! context resource-handle
                       (codec/c-hash (:code ref-search-param)) ref-tid))))

--- a/modules/db/test/blaze/db/impl/index/compartment/resource_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/compartment/resource_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.byte-string-spec]
     [blaze.coll.core-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.impl.codec.spec]
     [blaze.db.impl.index.compartment.resource :as cr]
     [blaze.db.impl.iterators-spec]
@@ -15,7 +16,7 @@
                :compartment :blaze.db/compartment
                :tid :blaze.db/tid
                :start-id (s/? :blaze.db/id-byte-string))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef cr/index-entry

--- a/modules/db/test/blaze/db/impl/index/resource_as_of_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_as_of_spec.clj
@@ -1,6 +1,7 @@
 (ns blaze.db.impl.index.resource-as-of-spec
   (:require
     [blaze.byte-string-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.impl.batch-db.spec]
     [blaze.db.impl.codec-spec]
     [blaze.db.impl.index.resource-as-of :as rao]
@@ -21,14 +22,14 @@
   :args (s/cat :context :blaze.db.impl.batch-db/context
                :tid :blaze.db/tid
                :start-id (s/? :blaze.db/id-byte-string))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef rao/system-list
   :args (s/cat :context :blaze.db.impl.batch-db/context
                :start (s/? (s/cat :start-tid :blaze.db/tid
                                   :start-id :blaze.db/id-byte-string)))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef rao/instance-history
@@ -37,7 +38,7 @@
                :id :blaze.db/id-byte-string
                :start-t :blaze.db/t
                :end-t :blaze.db/t)
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/def ::resource-handle-fn

--- a/modules/db/test/blaze/db/impl/index/system_as_of_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/system_as_of_spec.clj
@@ -1,6 +1,7 @@
 (ns blaze.db.impl.index.system-as-of-spec
   (:require
     [blaze.byte-string-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.impl.codec-spec]
     [blaze.db.impl.index.resource-handle-spec]
     [blaze.db.impl.index.system-as-of :as sao]
@@ -17,4 +18,4 @@
                :start-tid (s/nilable :blaze.db/tid)
                :start-id (s/nilable :blaze.db/id-byte-string)
                :end-t :blaze.db/t)
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))

--- a/modules/db/test/blaze/db/impl/index/type_as_of_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/type_as_of_spec.clj
@@ -1,6 +1,7 @@
 (ns blaze.db.impl.index.type-as-of-spec
   (:require
     [blaze.byte-string-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.impl.codec-spec]
     [blaze.db.impl.index.resource-handle-spec]
     [blaze.db.impl.index.type-as-of :as tao]
@@ -16,4 +17,4 @@
                :start-t :blaze.db/t
                :start-id (s/nilable :blaze.db/id-byte-string)
                :end-t :blaze.db/t)
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))

--- a/modules/db/test/blaze/db/impl/index_spec.clj
+++ b/modules/db/test/blaze/db/impl/index_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.async.comp :as ac]
     [blaze.byte-string-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.impl.batch-db.spec]
     [blaze.db.impl.codec-spec]
     [blaze.db.impl.index :as index]
@@ -28,7 +29,7 @@
                :tid :blaze.db/tid
                :clauses :blaze.db.index.query/clauses
                :start-id (s/? :blaze.db/id-byte-string))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef index/type-query-total
@@ -41,7 +42,7 @@
 (s/fdef index/system-query
   :args (s/cat :context :blaze.db.impl.batch-db/context
                :clauses :blaze.db.index.query/clauses)
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef index/compartment-query
@@ -49,7 +50,7 @@
                :compartment :blaze.db/compartment
                :tid :blaze.db/tid
                :clauses :blaze.db.index.query/clauses)
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef index/targets!
@@ -57,4 +58,4 @@
                :resource-handle :blaze.db/resource-handle
                :code :blaze.db/c-hash
                :target-tid (s/? :blaze.db/tid))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))

--- a/modules/db/test/blaze/db/impl/iterators_test.clj
+++ b/modules/db/test/blaze/db/impl/iterators_test.clj
@@ -47,7 +47,7 @@
       (with-open [snapshot (kv/new-snapshot kv-store)
                   iter (kv/new-iterator snapshot)]
         (is (= [[0x00] [0x01]]
-               (into [] (i/keys! iter decode-1 (bs/from-hex "00"))))))))
+               (vec (i/keys! iter decode-1 (bs/from-hex "00"))))))))
 
   (testing "too small ByteBuffer will be replaced with a larger one"
     (with-system [{kv-store ::kv/mem} config]
@@ -59,7 +59,7 @@
       (with-open [snapshot (kv/new-snapshot kv-store)
                   iter (kv/new-iterator snapshot)]
         (is (= [[0x00] [0x00 0x01]]
-               (into [] (i/keys! iter decode-1 (bs/from-hex "00")))))))
+               (vec (i/keys! iter decode-1 (bs/from-hex "00")))))))
 
     (testing "new ByteBuffer is bigger than a two times increase"
       (with-system [{kv-store ::kv/mem} config]
@@ -71,4 +71,4 @@
         (with-open [snapshot (kv/new-snapshot kv-store)
                     iter (kv/new-iterator snapshot)]
           (is (= [[0x00] [0x00 0x01 0x02]]
-                 (into [] (i/keys! iter decode-1 (bs/from-hex "00"))))))))))
+                 (vec (i/keys! iter decode-1 (bs/from-hex "00"))))))))))

--- a/modules/db/test/blaze/db/impl/search_param/composite_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite_test.clj
@@ -128,6 +128,10 @@
   (transduce (halt-when ba/anomaly?) conj coll))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "Observation code-value-quantity"
@@ -150,7 +154,7 @@
             [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]
              [_ k6] [_ k7] [_ k8] [_ k9] [_ k10] [_ k11]
              [_ k12] [_ k13] [_ k14] [_ k15] [_ k16] [_ k17]]
-            (search-param/index-entries
+            (index-entries
               (code-value-quantity-param search-param-registry)
               [] hash observation)]
 

--- a/modules/db/test/blaze/db/impl/search_param/date_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/date_test.clj
@@ -80,6 +80,10 @@
       Instant/ofEpochSecond))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "Patient"
@@ -89,7 +93,7 @@
                        :birthDate #fhir/date"2020-02-04"}
               hash (hash/generate patient)
               [[_ k0]]
-              (search-param/index-entries
+              (index-entries
                 (birth-date-param search-param-registry) [] hash patient)]
 
           (testing "the entry is about both bounds of `2020-02-04`"
@@ -108,7 +112,7 @@
                :deceased #fhir/dateTime"2019-11-17T00:14:29+01:00"}
               hash (hash/generate patient)
               [[_ k0]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "death-date" "Patient")
                 [] hash patient)]
 
@@ -131,7 +135,7 @@
                         :end #fhir/dateTime"2019-11-17T00:44:29+01:00"}}
               hash (hash/generate encounter)
               [[_ k0]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "date" "Encounter")
                 [] hash encounter)]
 
@@ -153,7 +157,7 @@
                          {:end #fhir/dateTime"2019-11-17"}}
                 hash (hash/generate encounter)
                 [[_ k0]]
-                (search-param/index-entries
+                (index-entries
                   (sr/get search-param-registry "date" "Encounter")
                   [] hash encounter)]
 
@@ -175,7 +179,7 @@
                          {:start #fhir/dateTime"2019-11-17T00:14:29+01:00"}}
                 hash (hash/generate encounter)
                 [[_ k0]]
-                (search-param/index-entries
+                (index-entries
                   (sr/get search-param-registry "date" "Encounter")
                   [] hash encounter)]
 
@@ -196,7 +200,7 @@
                        :issued #fhir/instant"2019-11-17T00:14:29.917+01:00"}
               hash (hash/generate patient)
               [[_ k0]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "issued" "DiagnosticReport")
                 [] hash patient)]
 

--- a/modules/db/test/blaze/db/impl/search_param/number_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/number_test.clj
@@ -83,6 +83,10 @@
         ::anom/message := "Unsupported prefix `ne` in search parameter `probability`."))))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "RiskAssessment probability"
@@ -94,7 +98,7 @@
                :probability 0.9M}]}
             hash (hash/generate risk-assessment)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "probability" "RiskAssessment")
               [] hash risk-assessment)]
 
@@ -123,7 +127,7 @@
                :start #fhir/integer 1}]}
             hash (hash/generate risk-assessment)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "variant-start" "MolecularSequence")
               [] hash risk-assessment)]
 

--- a/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
@@ -131,6 +131,10 @@
         ::anom/message := "Unsupported prefix `ne` in search parameter `value-quantity`."))))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "Observation value-quantity"
@@ -146,7 +150,7 @@
                         :system #fhir/uri"http://unitsofmeasure.org"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "value-quantity" "Observation")
                 [] hash observation)]
 
@@ -209,7 +213,7 @@
                         :unit #fhir/string"mmHg"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "value-quantity" "Observation")
                 [] hash observation)]
 
@@ -257,7 +261,7 @@
                         :code #fhir/code"mm[Hg]"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "value-quantity" "Observation")
                 [] hash observation)]
 
@@ -305,7 +309,7 @@
                         :code #fhir/code"mm[Hg]"}}
               hash (hash/generate observation)
               [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "value-quantity" "Observation")
                 [] hash observation)]
 
@@ -368,7 +372,7 @@
                         :system #fhir/uri"http://unitsofmeasure.org"}}
               hash (hash/generate observation)]
 
-          (is (empty? (search-param/index-entries
+          (is (empty? (index-entries
                         (sr/get search-param-registry "value-quantity" "Observation")
                         [] hash observation)))))
 
@@ -379,7 +383,7 @@
                :status #fhir/code"final"}
               hash (hash/generate observation)]
 
-          (is (empty? (search-param/index-entries
+          (is (empty? (index-entries
                         (sr/get search-param-registry "value-quantity" "Observation")
                         [] hash observation))))))
 

--- a/modules/db/test/blaze/db/impl/search_param/string_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/string_test.clj
@@ -48,6 +48,10 @@
       :c-hash := (codec/c-hash "phonetic"))))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "Patient phonetic"
@@ -57,7 +61,7 @@
                        :name [#fhir/HumanName{}]}
               hash (hash/generate patient)]
 
-          (is (empty? (search-param/index-entries
+          (is (empty? (index-entries
                         (phonetic-param search-param-registry) [] hash
                         patient)))))
 
@@ -67,7 +71,7 @@
                        :name [#fhir/HumanName{:family "Õ"}]}
               hash (hash/generate patient)]
 
-          (is (empty? (search-param/index-entries
+          (is (empty? (index-entries
                         (phonetic-param search-param-registry) [] hash
                         patient)))))
 
@@ -76,7 +80,7 @@
                      :name [#fhir/HumanName{:family "family-102508"}]}
             hash (hash/generate patient)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (phonetic-param search-param-registry) [] hash patient)]
 
         (testing "SearchParamValueResource key"
@@ -103,7 +107,7 @@
                                     :city "city-105431"}]}
             hash (hash/generate patient)
             [[_ k0] [_ k1] [_ k2] [_ k3]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "address" "Patient")
               [] hash patient)]
 
@@ -147,7 +151,7 @@
                       :description #fhir/markdown"desc-121328"}
             hash (hash/generate resource)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "description" "ActivityDefinition")
               [] hash resource)]
 

--- a/modules/db/test/blaze/db/impl/search_param/token_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/token_test.clj
@@ -48,6 +48,10 @@
       :c-hash := (codec/c-hash "code"))))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "Observation _id"
@@ -56,7 +60,7 @@
              :id "id-161849"}
             hash (hash/generate observation)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "_id" "Observation")
               [] hash observation)]
 
@@ -88,7 +92,7 @@
                        :code #fhir/code"code-171327"}]}}
             hash (hash/generate observation)
             [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-            (search-param/index-entries
+            (index-entries
               (code-param search-param-registry) [] hash observation)]
 
         (testing "first SearchParamValueResource key is about `code`"
@@ -150,7 +154,7 @@
                       {:code #fhir/code"code-134035"}]}}
             hash (hash/generate observation)
             [[_ k0] [_ k1] [_ k2] [_ k3]]
-            (search-param/index-entries
+            (index-entries
               (code-param search-param-registry) [] hash observation)]
 
         (testing "first SearchParamValueResource key is about `code`"
@@ -196,7 +200,7 @@
                       {:system #fhir/uri"system-171339"}]}}
             hash (hash/generate observation)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (code-param search-param-registry) [] hash observation)]
 
         (testing "first SearchParamValueResource key is about `system|`"
@@ -222,7 +226,7 @@
                :active active}
               hash (hash/generate patient)
               [[_ k0] [_ k1]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "active" "Patient")
                 [] hash patient)]
 
@@ -247,7 +251,7 @@
               {:fhir/type :fhir/Patient :id "id-122929"
                :active #fhir/boolean{:id "foo"}}
               hash (hash/generate patient)]
-          (is (empty? (search-param/index-entries
+          (is (empty? (index-entries
                         (sr/get search-param-registry "active" "Patient")
                         [] hash patient))))))
 
@@ -260,7 +264,7 @@
                   :value "value-123005"}]}
             hash (hash/generate patient)
             [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "identifier" "Patient")
               [] hash patient)]
 
@@ -320,7 +324,7 @@
                  {:value "value-140132"}]}
             hash (hash/generate patient)
             [[_ k0] [_ k1] [_ k2] [_ k3]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "identifier" "Patient")
               [] hash patient)]
 
@@ -364,7 +368,7 @@
                  {:system #fhir/uri"system-140316"}]}
             hash (hash/generate patient)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "identifier" "Patient")
               [] hash patient)]
 
@@ -389,7 +393,7 @@
         (let [patient {:fhir/type :fhir/Patient :id "id-142629"}
               hash (hash/generate patient)
               [[_ k0] [_ k1]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "deceased" "Patient")
                 [] hash patient)]
 
@@ -415,7 +419,7 @@
                        :deceased true}
               hash (hash/generate patient)
               [[_ k0] [_ k1]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "deceased" "Patient")
                 [] hash patient)]
 
@@ -442,7 +446,7 @@
                :deceased #fhir/dateTime"2019-11-17T00:14:29+01:00"}
               hash (hash/generate patient)
               [[_ k0] [_ k1]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "deceased" "Patient")
                 [] hash patient)]
 
@@ -475,7 +479,7 @@
                                  :code #fhir/code"code-103812"}]}}}
             hash (hash/generate specimen)
             [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "bodysite" "Specimen")
               [] hash specimen)]
 
@@ -536,7 +540,7 @@
                   :code #fhir/code"AMB"}}
             hash (hash/generate specimen)
             [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "class" "Encounter")
               [] hash specimen)]
 
@@ -596,7 +600,7 @@
                         :uid #fhir/id"1.2.840.99999999.1.59354388.1582528879516"}]}
             hash (hash/generate specimen)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "series" "ImagingStudy")
               [] hash specimen)]
 
@@ -622,7 +626,7 @@
                       :version "version-122621"}
             hash (hash/generate resource)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "version" "CodeSystem")
               [] hash resource)]
 
@@ -665,7 +669,7 @@
 
 
 (defn compartment-ids [search-param resource]
-  (into [] (search-param/compartment-ids search-param resource)))
+  (vec (search-param/compartment-ids search-param resource)))
 
 
 (deftest compartment-ids-test

--- a/modules/db/test/blaze/db/impl/search_param_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [blaze.async.comp :as ac]
     [blaze.byte-string-spec]
+    [blaze.coll.spec :as cs]
     [blaze.db.impl.batch-db.spec]
     [blaze.db.impl.codec-spec]
     [blaze.db.impl.index.compartment.search-param-value-resource-spec]
@@ -42,7 +43,7 @@
                :modifier (s/nilable :blaze.db.search-param/modifier)
                :values (s/coll-of some? :min-count 1)
                :start-id (s/? :blaze.db/id-byte-string))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef search-param/sorted-resource-handles
@@ -51,7 +52,7 @@
                :tid :blaze.db/tid
                :direction :blaze.db.query/sort-direction
                :start-id (s/? :blaze.db/id-byte-string))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef search-param/count-resource-handles
@@ -69,7 +70,7 @@
                :compartment :blaze.db/compartment
                :tid :blaze.db/tid
                :compiled-values (s/coll-of some? :min-count 1))
-  :ret (s/coll-of :blaze.db/resource-handle :kind sequential?))
+  :ret (cs/coll-of :blaze.db/resource-handle))
 
 
 (s/fdef search-param/matches?
@@ -92,5 +93,5 @@
                :linked-compartments (s/nilable (s/coll-of (s/tuple string? string?)))
                :hash :blaze.resource/hash
                :resource :blaze/resource)
-  :ret (s/or :entries (s/coll-of :blaze.db.kv/put-entry-w-cf :kind sequential?)
+  :ret (s/or :entries (cs/coll-of :blaze.db.kv/put-entry-w-cf)
              :anomaly ::anom/anomaly))

--- a/modules/db/test/blaze/db/impl/search_param_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param_test.clj
@@ -55,6 +55,10 @@
         (codec-date/encode-upper-bound #system/date-time"2020-10-30")))))
 
 
+(defn- index-entries [search-param linked-compartments hash resource]
+  (vec (search-param/index-entries search-param linked-compartments hash resource)))
+
+
 (deftest index-entries-test
   (with-system [{:blaze.db/keys [search-param-registry]} config]
     (testing "Patient _profile"
@@ -63,7 +67,7 @@
              :meta #fhir/Meta{:profile [#fhir/canonical"profile-uri-141443"]}}
             hash (hash/generate patient)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "_profile" "Patient")
               [] hash patient)]
 
@@ -89,7 +93,7 @@
             hash (hash/generate specimen)]
         (is
           (empty?
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "patient" "Specimen")
               [] hash specimen)))))
 
@@ -99,7 +103,7 @@
                       :url #fhir/uri"url-111854"}
             hash (hash/generate resource)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sr/get search-param-registry "url" "ActivityDefinition")
               [] hash resource)]
 
@@ -127,7 +131,7 @@
                           :item #fhir/Reference{:reference "Patient/0"}}]}
               hash (hash/generate resource)
               [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "item" "List")
                 [] hash resource)]
 
@@ -193,7 +197,7 @@
                                             :value "value-122931"}}}]}
               hash (hash/generate resource)
               [[_ k0] [_ k1] [_ k2] [_ k3] [_ k4] [_ k5]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "item" "List")
                 [] hash resource)]
 
@@ -254,7 +258,7 @@
                                   {:reference "http://foo.com/bar-141221"}}]}
               hash (hash/generate resource)
               [[_ k0] [_ k1]]
-              (search-param/index-entries
+              (index-entries
                 (sr/get search-param-registry "item" "List")
                 [] hash resource)]
 
@@ -280,7 +284,7 @@
                                    :rank #fhir/positiveInt 94656}]}
             hash (hash/generate resource)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sc/search-param
                 {}
                 {:type "number"
@@ -312,7 +316,7 @@
                       :priority #fhir/unsignedInt 102229}
             hash (hash/generate resource)
             [[_ k0] [_ k1]]
-            (search-param/index-entries
+            (index-entries
               (sc/search-param
                 {}
                 {:type "number"

--- a/modules/interaction/src/blaze/interaction/create.clj
+++ b/modules/interaction/src/blaze/interaction/create.clj
@@ -5,6 +5,7 @@
   (:require
     [blaze.anomaly :as ba :refer [if-ok]]
     [blaze.async.comp :as ac]
+    [blaze.coll.core :as coll]
     [blaze.db.api :as d]
     [blaze.db.spec]
     [blaze.fhir.response.create :as response]
@@ -77,7 +78,7 @@
                 (if-let [handle (d/resource-handle db-after type id)]
                   (response/build-response
                     (response-context request db-after) tx-op nil handle)
-                  (let [handle (first (d/type-query db-after type conditional-clauses))]
+                  (let [handle (coll/first (d/type-query db-after type conditional-clauses))]
                     (response/build-response
                       (response-context request db-after) tx-op handle handle)))))
             (ac/exceptionally

--- a/modules/interaction/src/blaze/interaction/history/instance.clj
+++ b/modules/interaction/src/blaze/interaction/history/instance.clj
@@ -33,7 +33,7 @@
         self-link (partial link context query-params "self")
         next-link (partial link context query-params "next")]
     ;; we need take here again because we take page-size + 1 above
-    (-> (d/pull-many db (take page-size paged-version-handles))
+    (-> (d/pull-many db (into [] (take page-size) paged-version-handles))
         (ac/exceptionally
           #(assoc %
              ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/history/system.clj
+++ b/modules/interaction/src/blaze/interaction/history/system.clj
@@ -38,7 +38,7 @@
         self-link (partial link context query-params "self")
         next-link (partial link context query-params "next")]
     ;; we need take here again because we take page-size + 1 above
-    (-> (d/pull-many db (take page-size paged-version-handles))
+    (-> (d/pull-many db (into [] (take page-size) paged-version-handles))
         (ac/exceptionally
           #(assoc %
              ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/history/type.clj
+++ b/modules/interaction/src/blaze/interaction/history/type.clj
@@ -35,7 +35,7 @@
         self-link (partial link context query-params "self")
         next-link (partial link context query-params "next")]
     ;; we need take here again because we take page-size + 1 above
-    (-> (d/pull-many db (take page-size paged-version-handles))
+    (-> (d/pull-many db (into [] (take page-size) paged-version-handles))
         (ac/exceptionally
           #(assoc %
              ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -5,6 +5,7 @@
   (:require
     [blaze.anomaly :as ba :refer [if-ok when-ok]]
     [blaze.async.comp :as ac :refer [do-sync]]
+    [blaze.coll.core :as coll]
     [blaze.db.api :as d]
     [blaze.fhir.spec :as fhir-spec]
     [blaze.fhir.spec.type :as type]
@@ -322,7 +323,7 @@
         (ac/completed-future (created-entry context type handle)))
       (let [if-none-exist (-> entry :request :ifNoneExist)
             clauses (conditional-clauses if-none-exist)
-            handle (first (d/type-query db type clauses))]
+            handle (coll/first (d/type-query db type clauses))]
         (if (identical? :blaze.preference.return/representation return-preference)
           (do-sync [resource (pull db handle)]
             (assoc (noop-entry db handle) :resource resource))
@@ -351,7 +352,7 @@
    _
    {{:fhir/keys [type] :keys [id]} :resource :keys [tx-op]}]
   (let [type (name type)
-        [new-handle old-handle] (take 2 (d/instance-history db type id))]
+        [new-handle old-handle] (into [] (take 2) (d/instance-history db type id))]
     (if (identical? :blaze.preference.return/representation return-preference)
       (do-sync [resource (pull db new-handle)]
         (assoc (update-entry context type tx-op old-handle new-handle) :resource resource))

--- a/modules/interaction/src/blaze/interaction/update.clj
+++ b/modules/interaction/src/blaze/interaction/update.clj
@@ -79,7 +79,7 @@
     (-> (d/transact node [tx-op])
         (ac/then-compose
           (fn [db-after]
-            (let [[new-handle old-handle] (take 2 (d/instance-history db-after (name type) id))]
+            (let [[new-handle old-handle] (into [] (take 2) (d/instance-history db-after (name type) id))]
               (response/build-response
                 (response-context request db-after)
                 tx-op

--- a/modules/interaction/test/blaze/interaction/search/include_spec.clj
+++ b/modules/interaction/test/blaze/interaction/search/include_spec.clj
@@ -1,5 +1,6 @@
 (ns blaze.interaction.search.include-spec
   (:require
+    [blaze.coll.spec :as cs]
     [blaze.db.spec]
     [blaze.interaction.search.include :as include]
     [blaze.interaction.search.spec]
@@ -9,5 +10,4 @@
 (s/fdef include/add-includes
   :args (s/cat :db :blaze.db/db
                :include-defs :blaze.interaction.search/include-defs
-               :resource-handles (s/coll-of :blaze.db/resource-handle
-                                            :kind sequential?)))
+               :resource-handles (cs/coll-of :blaze.db/resource-handle)))

--- a/modules/kv/.clj-kondo/config.edn
+++ b/modules/kv/.clj-kondo/config.edn
@@ -16,6 +16,11 @@
   {:level :warning}
 
   :warn-on-reflection
-  {:level :warning :warn-only-on-interop true}}
+  {:level :warning :warn-only-on-interop true}
+
+  :consistent-alias
+  {:aliases
+   {blaze.coll.spec cs
+    taoensso.timbre log}}}
 
  :skip-comments true}

--- a/modules/kv/deps.edn
+++ b/modules/kv/deps.edn
@@ -2,6 +2,9 @@
  {blaze/byte-buffer
   {:local/root "../byte-buffer"}
 
+  blaze/coll
+  {:local/root "../coll"}
+
   blaze/module-base
   {:local/root "../module-base"}}
 

--- a/modules/kv/src/blaze/db/kv_spec.clj
+++ b/modules/kv/src/blaze/db/kv_spec.clj
@@ -1,6 +1,7 @@
 (ns blaze.db.kv-spec
   (:require
     [blaze.byte-buffer :as bb]
+    [blaze.coll.spec :as cs]
     [blaze.db.kv :as kv]
     [blaze.db.kv.spec]
     [clojure.spec.alpha :as s]))
@@ -104,7 +105,7 @@
     :entries
     (s/cat
       :kv-store :blaze.db/kv-store
-      :entries (s/coll-of :blaze.db.kv/put-entry :kind sequential?))
+      :entries (cs/coll-of :blaze.db.kv/put-entry))
     :kv
     (s/cat :kv-store :blaze.db/kv-store :key bytes? :value bytes?)))
 
@@ -115,4 +116,4 @@
 
 (s/fdef kv/write!
   :args (s/cat :kv-store :blaze.db/kv-store
-               :entries (s/coll-of ::kv/write-entry :kind sequential?)))
+               :entries (cs/coll-of ::kv/write-entry)))

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb/impl_spec.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb/impl_spec.clj
@@ -1,5 +1,6 @@
 (ns blaze.db.kv.rocksdb.impl-spec
   (:require
+    [blaze.coll.spec :as cs]
     [blaze.db.kv.rocksdb :as-alias rocksdb]
     [blaze.db.kv.rocksdb.impl :as impl]
     [blaze.db.kv.rocksdb.impl.spec]
@@ -24,7 +25,7 @@
 (s/fdef impl/put-wb!
   :args (s/cat :cfhs (s/map-of keyword? ::impl/column-family-handle)
                :wb ::impl/write-batch
-               :entries (s/coll-of :blaze.db.kv/put-entry :kind sequential?)))
+               :entries (cs/coll-of :blaze.db.kv/put-entry)))
 
 
 (s/fdef impl/delete-wb!
@@ -34,4 +35,4 @@
 (s/fdef impl/write-wb!
   :args (s/cat :cfhs (s/map-of keyword? ::impl/column-family-handle)
                :wb ::impl/write-batch
-               :entries (s/coll-of :blaze.db.kv/write-entry :kind sequential?)))
+               :entries (cs/coll-of :blaze.db.kv/write-entry)))


### PR DESCRIPTION
Both the with-open-coll macro and the coll/eduction function implemented Seqable, the with-open-coll macro also Counted. Both interfaces were only used in tests or could be replaced by IReduceInit handling functions in production. Not implementing both interfaces saves a lot of test efforts, especially for the with-open-coll macro because all the forms have to be tested for each occurrence of the macro.

The only disadvantage is that the collections now only implement IReduceInit or both IReduceInit and Counted in case of coll/eduction, which means that they can't be used in places were sequences are needed. However this is also a performance advantage because the sequence abstraction implemented in the with-open-coll macro always consumed the full collection. That means that a (take 2 coll) would consume the whole coll were a (into [] (take 2) coll) would only consume the first two elements. Now that (take 2 coll) will no longer work, the more efficient variant is enforced.