### PR TITLE
Fix Operation $everything return Duplicate Entries

### DIFF
--- a/.github/scripts/patient-everything.sh
+++ b/.github/scripts/patient-everything.sh
@@ -8,7 +8,10 @@ PATIENT_IDENTIFIER="X79746011X"
 PATIENT_ID=$(curl -s "$BASE/Patient?identifier=$PATIENT_IDENTIFIER" | jq -r '.entry[0].resource.id')
 BUNDLE=$(curl -s "$BASE/Patient/$PATIENT_ID/\$everything")
 ACTUAL_SIZE=$(echo "$BUNDLE" | jq -r .total)
+IDS="$(echo "$BUNDLE" | jq -r '.entry[].resource.id')"
 
-test "size" "$ACTUAL_SIZE" "3424"
+test "size" "$ACTUAL_SIZE" "3329"
+
+test "no duplicates" "$(echo "$IDS" | sort -u | wc -l | xargs)" "$(echo "$IDS" | wc -l | xargs)"
 
 test "type counts" "$(echo "$BUNDLE" | jq -r '.entry | group_by(.resource.resourceType)[] | [.[0].resource.resourceType, length] | @csv')" "$(cat "$SCRIPT_DIR/patient-everything/$PATIENT_IDENTIFIER-type-counts.csv")"

--- a/.github/scripts/patient-everything/X79746011X-type-counts.csv
+++ b/.github/scripts/patient-everything/X79746011X-type-counts.csv
@@ -1,5 +1,5 @@
 "CarePlan",5
-"CareTeam",10
+"CareTeam",5
 "Claim",176
 "Condition",15
 "DiagnosticReport",231
@@ -8,7 +8,7 @@
 "ExplanationOfBenefit",78
 "ImagingStudy",45
 "Immunization",13
-"MedicationAdministration",180
+"MedicationAdministration",90
 "MedicationRequest",98
 "Observation",2265
 "Patient",1

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -138,8 +138,11 @@
   (-rev-include [db resource-handle]
     (coll/eduction
      (mapcat
-      (fn [[source-type code]]
-        (p/-rev-include db resource-handle source-type code)))
+      (fn [[source-type codes]]
+        (coll/eduction
+         (comp (mapcat (partial p/-rev-include db resource-handle source-type))
+               (distinct))
+         codes)))
      (sr/compartment-resources (:search-param-registry node)
                                (name (type/type resource-handle)))))
 

--- a/modules/db/src/blaze/db/search_param_registry.clj
+++ b/modules/db/src/blaze/db/search_param_registry.clj
@@ -40,10 +40,10 @@
   (p/-linked-compartments search-param-registry resource))
 
 (defn compartment-resources
-  "Returns a seq of [type code] tuples of resources in compartment of `type`.
+  "Returns a seq of `[type codes]` tuples of resources in compartment of `type`.
 
   Example:
-  * [\"Observation\" \"subject\"] and others for \"Patient\""
+  * `[\"Observation\" [\"subject\" \"performer\"]]` and others for \"Patient\""
   [search-param-registry type]
   (p/-compartment-resources search-param-registry type))
 
@@ -135,9 +135,10 @@
   {def-code
    (into
     []
-    (mapcat
+    (keep
      (fn [{res-type :code param-codes :param}]
-       (coll/eduction (map (partial vector res-type)) param-codes)))
+       (when param-codes
+         [res-type param-codes])))
     resource-defs)})
 
 (def ^:private list-search-param

--- a/modules/db/src/blaze/db/search_param_registry_spec.clj
+++ b/modules/db/src/blaze/db/search_param_registry_spec.clj
@@ -30,4 +30,4 @@
 (s/fdef sr/compartment-resources
   :args (s/cat :search-param-registry :blaze.db/search-param-registry
                :type :fhir.resource/type)
-  :ret (s/coll-of (s/tuple :fhir.resource/type string?)))
+  :ret (s/coll-of (s/tuple :fhir.resource/type (s/coll-of string?))))

--- a/modules/db/test/blaze/db/search_param_registry_test.clj
+++ b/modules/db/test/blaze/db/search_param_registry_test.clj
@@ -185,11 +185,9 @@
   (testing "Patient"
     (with-system [{:blaze.db/keys [search-param-registry]} config]
       (given (sr/compartment-resources search-param-registry "Patient")
-        count := 100
-        [0] := ["Account" "subject"]
-        [1] := ["AdverseEvent" "subject"]
-        [2] := ["AllergyIntolerance" "patient"]
-        [3] := ["AllergyIntolerance" "recorder"]
-        [4] := ["AllergyIntolerance" "asserter"]
-        [5] := ["Appointment" "actor"]
-        [99] := ["VisionPrescription" "patient"]))))
+        count := 66
+        [0] := ["Account" ["subject"]]
+        [1] := ["AdverseEvent" ["subject"]]
+        [2] := ["AllergyIntolerance" ["patient" "recorder" "asserter"]]
+        [3] := ["Appointment" ["actor"]]
+        [65] := ["VisionPrescription" ["patient"]]))))


### PR DESCRIPTION
The problem was that compartment definitions sometimes define more than one search parameter for resource type. For example the Patient compartments defines that MedicationAdministration is reachable via the search params patient, performer or subject. Especially the search param patient and subject points to the same Patient resource. By following each of the search params separately and just concatenating the results, we did output duplicate resources.

I did apply the function distinct for all resources of a given type in order top prevent the duplicates.

Closes: #1287