### PR TITLE
Show that Sorting Works with Missing Values

### DIFF
--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -797,24 +797,28 @@
     :measure-id := "0")
 
   (given (first-stratifier-strata (evaluate "q31-stratifier-storage-temperature"))
+    count := 2
     [0 :value :text type/value] := "temperature2to10"
     [0 :population 0 :count] := 1
     [1 :value :text type/value] := "temperatureGN"
     [1 :population 0 :count] := 1)
 
   (given (first-stratifier-strata (evaluate "q32-stratifier-underweight"))
+    count := 2
     [0 :value :text type/value] := "false"
     [0 :population 0 :count] := 2
     [1 :value :text type/value] := "true"
     [1 :population 0 :count] := 1)
 
   (given (first-stratifier-strata (evaluate "q40-specimen-stratifier"))
+    count := 2
     [0 :value :text type/value] := "blood-plasma"
     [0 :population 0 :count] := 4
     [1 :value :text type/value] := "peripheral-blood-cells-vital"
     [1 :population 0 :count] := 3)
 
   (given (first-stratifier-strata (evaluate "q41-specimen-multi-stratifier"))
+    count := 4
     [0 :component 0 :code :coding 0 :code type/value] := "sample-diagnosis"
     [0 :component 0 :value :text type/value] := "C34.9"
     [0 :component 1 :code :coding 0 :code type/value] := "sample-type"
@@ -828,8 +832,13 @@
     [2 :population 0 :count] := 2
     [3 :component 0 :value :text type/value] := "C50.9"
     [3 :component 1 :value :text type/value] := "peripheral-blood-cells-vital"
-    [3 :population 0 :count] := 2))
+    [3 :population 0 :count] := 2)
+
+  (given (first-stratifier-strata (evaluate "q52-sort-with-missing-values"))
+    count := 1
+    [0 :value :text type/value] := "Condition[id = 0, t = 1]"
+    [0 :population 0 :count] := 1))
 
 (comment
   (log/set-level! :debug)
-  (evaluate "q50-specimen-condition-reference"))
+  (evaluate "q52-sort-with-missing-values"))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q52-sort-with-missing-values.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q52-sort-with-missing-values.cql
@@ -1,0 +1,11 @@
+library "q52-sort-with-missing-values"
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+context Patient
+
+define InInitialPopulation:
+  true
+
+define PrimaryDiagnosis:
+  First(from [Condition] C sort by date from onset asc)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q52-sort-with-missing-values.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q52-sort-with-missing-values.json
@@ -1,0 +1,113 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "0"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/0"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/0"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "0",
+        "_onsetDateTime": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/0"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/1"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "1",
+        "onsetDateTime": "2019-06-17",
+        "subject": {
+          "reference": "Patient/0"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Measure",
+        "id": "0",
+        "url": "0",
+        "status": "active",
+        "subjectCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/resource-types",
+              "code": "Patient"
+            }
+          ]
+        },
+        "library": [
+          "0"
+        ],
+        "scoring": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+              "code": "cohort"
+            }
+          ]
+        },
+        "group": [
+          {
+            "population": [
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "initial-population"
+                    }
+                  ]
+                },
+                "criteria": {
+                  "language": "text/cql-identifier",
+                  "expression": "InInitialPopulation"
+                }
+              }
+            ],
+            "stratifier": [
+              {
+                "code": {
+                  "text": "primary-diagnosis"
+                },
+                "criteria": {
+                  "language": "text/cql-identifier",
+                  "expression": "PrimaryDiagnosis"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Measure/0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The test q52-sort-with-missing-values shows that sorting in CQL works with missing values.

Also removed dead code in namespace blaze.elm.compiler.queries.

Related to: #1315