### PR TITLE
Refactor d/patient-everything Returning the Patient

### DIFF
--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -425,7 +425,7 @@
   `patient-handle` including supporting resources like Practitioners,
   Medications, Locations, Organizations etc.
 
-  The `patient-handle` itself isn't returned."
+  The `patient-handle` itself is returned first."
   [db patient-handle]
   (p/-patient-everything db patient-handle))
 

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -177,24 +177,27 @@
           supporting-codes (partial supporting-codes search-param-registry
                                     non-compartment-types)]
       (coll/eduction
-       (comp
-        (mapcat
-         (fn [[type codes]]
-           (let [supporting-codes (supporting-codes type)]
-             (coll/eduction
-              (comp
-               (mapcat (partial p/-rev-include db patient-handle type))
-               (mapcat
-                (fn [resource-handle]
-                  (into
-                   [resource-handle]
-                   (comp
-                    (mapcat (partial p/-include db resource-handle))
-                    (filter (comp non-compartment-types name type/type)))
-                   supporting-codes))))
-              codes))))
-        (distinct))
-       (sr/compartment-resources search-param-registry "Patient"))))
+       cat
+       [[patient-handle]
+        (coll/eduction
+         (comp
+          (mapcat
+           (fn [[type codes]]
+             (let [supporting-codes (supporting-codes type)]
+               (coll/eduction
+                (comp
+                 (mapcat (partial p/-rev-include db patient-handle type))
+                 (mapcat
+                  (fn [resource-handle]
+                    (into
+                     [resource-handle]
+                     (comp
+                      (mapcat (partial p/-include db resource-handle))
+                      (filter (comp non-compartment-types name type/type)))
+                     supporting-codes))))
+                codes))))
+          (distinct))
+         (sr/compartment-resources search-param-registry "Patient"))])))
 
   ;; ---- Transaction ---------------------------------------------------------
 

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -5329,7 +5329,10 @@
       (let [db (d/db node)
             patient (d/resource-handle db "Patient" "0")]
 
-        (is (coll/empty? (d/patient-everything db patient))))))
+        (given (vec (d/patient-everything db patient))
+          count := 1
+          [0 fhir-spec/fhir-type] := :fhir/Patient
+          [0 :id] := "0"))))
 
   (testing "with three resources"
     (with-system-data [{:blaze.db/keys [node]} config]
@@ -5345,13 +5348,15 @@
             patient (d/resource-handle db "Patient" "0")]
 
         (given (vec (d/patient-everything db patient))
-          count := 3
-          [0 fhir-spec/fhir-type] := :fhir/Condition
+          count := 4
+          [0 fhir-spec/fhir-type] := :fhir/Patient
           [0 :id] := "0"
-          [1 fhir-spec/fhir-type] := :fhir/Observation
+          [1 fhir-spec/fhir-type] := :fhir/Condition
           [1 :id] := "0"
-          [2 fhir-spec/fhir-type] := :fhir/Specimen
-          [2 :id] := "0"))))
+          [2 fhir-spec/fhir-type] := :fhir/Observation
+          [2 :id] := "0"
+          [3 fhir-spec/fhir-type] := :fhir/Specimen
+          [3 :id] := "0"))))
 
   (testing "With MedicationAdministration because it is reachable twice via
                 the search param `patient` and `subject`.
@@ -5367,9 +5372,11 @@
             patient (d/resource-handle db "Patient" "0")]
 
         (given (vec (d/patient-everything db patient))
-          count := 1
-          [0 fhir-spec/fhir-type] := :fhir/MedicationAdministration
-          [0 :id] := "0"))))
+          count := 2
+          [0 fhir-spec/fhir-type] := :fhir/Patient
+          [0 :id] := "0"
+          [1 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+          [1 :id] := "0"))))
 
   (testing "one MedicationAdministration with referenced Medication"
     (with-system-data [{:blaze.db/keys [node]} config]
@@ -5384,11 +5391,13 @@
 
         (testing "contains also the Medication"
           (given (vec (d/patient-everything db patient))
-            count := 2
-            [0 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+            count := 3
+            [0 fhir-spec/fhir-type] := :fhir/Patient
             [0 :id] := "0"
-            [1 fhir-spec/fhir-type] := :fhir/Medication
-            [1 :id] := "0")))))
+            [1 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+            [1 :id] := "0"
+            [2 fhir-spec/fhir-type] := :fhir/Medication
+            [2 :id] := "0")))))
 
   (testing "two MedicationAdministrations with two referenced Medications"
     (with-system-data [{:blaze.db/keys [node]} config]
@@ -5407,15 +5416,17 @@
 
         (testing "contains both Medications"
           (given (vec (d/patient-everything db patient))
-            count := 4
-            [0 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+            count := 5
+            [0 fhir-spec/fhir-type] := :fhir/Patient
             [0 :id] := "0"
-            [1 fhir-spec/fhir-type] := :fhir/Medication
+            [1 fhir-spec/fhir-type] := :fhir/MedicationAdministration
             [1 :id] := "0"
-            [2 fhir-spec/fhir-type] := :fhir/MedicationAdministration
-            [2 :id] := "1"
-            [3 fhir-spec/fhir-type] := :fhir/Medication
-            [3 :id] := "1")))))
+            [2 fhir-spec/fhir-type] := :fhir/Medication
+            [2 :id] := "0"
+            [3 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+            [3 :id] := "1"
+            [4 fhir-spec/fhir-type] := :fhir/Medication
+            [4 :id] := "1")))))
 
   (testing "two MedicationAdministrations with one referenced Medication"
     (with-system-data [{:blaze.db/keys [node]} config]
@@ -5433,13 +5444,15 @@
 
         (testing "contains the Medication only once"
           (given (vec (d/patient-everything db patient))
-            count := 3
-            [0 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+            count := 4
+            [0 fhir-spec/fhir-type] := :fhir/Patient
             [0 :id] := "0"
-            [1 fhir-spec/fhir-type] := :fhir/Medication
+            [1 fhir-spec/fhir-type] := :fhir/MedicationAdministration
             [1 :id] := "0"
-            [2 fhir-spec/fhir-type] := :fhir/MedicationAdministration
-            [2 :id] := "1")))))
+            [2 fhir-spec/fhir-type] := :fhir/Medication
+            [2 :id] := "0"
+            [3 fhir-spec/fhir-type] := :fhir/MedicationAdministration
+            [3 :id] := "1")))))
 
   (testing "no duplicates are returned"
     (let [observation-gen

--- a/modules/operation-patient-everything/src/blaze/operation/patient/everything.clj
+++ b/modules/operation-patient-everything/src/blaze/operation/patient/everything.clj
@@ -28,7 +28,7 @@
     (let [handles (into [] (take max-size) (d/patient-everything db patient))]
       (if (= max-size (count handles))
         (ba/conflict (too-costly-msg patient-id) :fhir/issue "too-costly")
-        (into [patient] handles)))
+        handles))
     (ba/not-found (format "The Patient with id `%s` was not found." patient-id))))
 
 (defn- luid [{:keys [clock rng-fn]}]

--- a/modules/operation-patient-everything/test/blaze/operation/patient/everything_test.clj
+++ b/modules/operation-patient-everything/test/blaze/operation/patient/everything_test.clj
@@ -385,7 +385,7 @@
         (map (fn [i]
                [:put {:fhir/type :fhir/Observation :id (str i)
                       :subject #fhir/Reference{:reference "Patient/0"}}]))
-        (range 10000))]
+        (range 9999))]
 
       (let [{:keys [status body]}
             @(handler {:path-params {:id "0"}})]


### PR DESCRIPTION
We need the patient anyway in patient everything, but we added it later after taking the max 10.0000 resources. Now in #1297 we will expand the linked patients, so we will need to return the patients from d/patient-everything because there could be more than the initial patient.

I use the cat transducer and an extra eduction to concatenate the patient-handle with the other resource handles.