### PR TITLE
Update Jetty to v12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,6 @@ jobs:
         - thread-pool-executor-collector
 
         java-version:
-        - '11'
         - '17'
         - '21'
 
@@ -124,7 +123,6 @@ jobs:
     strategy:
       matrix:
         java-version:
-        - '11'
         - '17'
         - '21'
 

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -118,7 +118,7 @@ All reading FHIR interactions have to acquire the last database state known at t
 | -Dhttp.proxyHost | -       | v0.11 | The hostname of the proxy server for outbound HTTP requests. |
 | -Dhttp.proxyPort | 80      | v0.11 | The port of the proxy server.                                |
 
-[1]: <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/doc-files/net-properties.html#Proxies>
+[1]: <https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/doc-files/net-properties.html#Proxies>
 [2]: <https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size>
 [3]: <https://github.com/facebook/rocksdb/wiki/Thread-Pool>
 [4]: <https://openid.net/connect/>

--- a/docs/deployment/manual-deployment.md
+++ b/docs/deployment/manual-deployment.md
@@ -1,6 +1,6 @@
 # Manual Deployment
 
-The installation works under Windows, Linux and macOS. The only dependency is an installed OpenJDK 11 or 17 with 17 recommended. Blaze is tested with [Eclipse Temurin][1].
+The installation works under Windows, Linux and macOS. The only dependency is an installed OpenJDK 17 or 21 with 17 recommended. Blaze is tested with [Eclipse Temurin][1].
 
 Blaze runs on the JVM and comes as single JAR file. Download the most recent version [here](https://github.com/samply/blaze/releases/tag/v0.23.2). Look for `blaze-0.23.2-standalone.jar`.
 

--- a/modules/server/deps.edn
+++ b/modules/server/deps.edn
@@ -6,7 +6,7 @@
   {:local/root "../module-base"}
 
   info.sunng/ring-jetty9-adapter
-  {:mvn/version "0.22.3"
+  {:mvn/version "0.30.2"
    :exclusions
    [commons-fileupload/commons-fileupload
     crypto-equality/crypto-equality


### PR DESCRIPTION
Jetty v12 requires JDK 17. This commit will remove the support for JDK 11.