### PR TITLE
Fix Error while Evaluating Measure with Population Basis Boolean

### DIFF
--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
@@ -207,8 +207,8 @@
    * context :parameters        - an optional map of parameters
    * context :return-handles?   - whether subject-handles or a simple count
                                   should be returned
-   * context :population-basis  - the population basis of either :boolean or a
-                                  type like `Encounter`
+   * context :population-basis  - an optional population basis of a type like
+                                  `Encounter`
    * name                       - the name of the expression
    * subject-type               - the type of subjects like `Patient`
 

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -170,7 +170,8 @@
    (fn [{:keys [url value]}]
      (when (= "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis" url)
        (let [basis (type/value value)]
-         (cond-> basis (= "boolean" basis) keyword))))
+         (when-not (= "boolean" basis)
+           basis))))
    extension))
 
 (defn- evaluate-group

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -263,6 +263,10 @@
                      :library [#fhir/canonical"0"]
                      :group
                      [{:fhir/type :fhir.Measure/group
+                       :extension
+                       [#fhir/Extension
+                         {:url "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis"
+                          :value #fhir/code"boolean"}]
                        :population
                        [{:fhir/type :fhir.Measure.group/population
                          :code (population-concept "initial-population")
@@ -659,6 +663,8 @@
 
   (testing-query "q51-specimen-condition-reference-2" 1)
 
+  (testing-query "q53-population-basis-boolean" 2)
+
   (let [result (evaluate "q1" "subject-list")]
     (testing "MeasureReport is valid"
       (is (s/valid? :blaze/resource (:resource result))))
@@ -851,4 +857,4 @@
 
 (comment
   (log/set-level! :debug)
-  (evaluate "q52-sort-with-missing-values"))
+  (evaluate "q53-population-basis-boolean"))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q53-population-basis-boolean.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q53-population-basis-boolean.cql
@@ -1,0 +1,8 @@
+library "q53-population-basis-boolean"
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+context Patient
+
+define InInitialPopulation:
+  Patient.gender = 'male'

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q53-population-basis-boolean.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q53-population-basis-boolean.json
@@ -1,0 +1,149 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "0",
+        "gender": "male"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "1",
+        "gender": "female"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "2",
+        "gender": "female",
+        "_gender": {
+          "extension": [
+            {
+              "url": "http://fhir.de/StructureDefinition/gender-amtlich-de",
+              "valueCoding": {
+                "system": "http://fhir.de/CodeSystem/gender-amtlich-de",
+                "code": "W",
+                "display": "weiblich"
+              }
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/2"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "3",
+        "gender": "male",
+        "_gender": {
+          "extension": [
+            {
+              "url": "http://fhir.de/StructureDefinition/gender-amtlich-de",
+              "valueCoding": {
+                "system": "http://fhir.de/CodeSystem/gender-amtlich-de",
+                "code": "M",
+                "display": "männlich"
+              }
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/3"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "4",
+        "_gender": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "unknown"
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/4"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Measure",
+        "id": "0",
+        "url": "0",
+        "status": "active",
+        "subjectCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/resource-types",
+              "code": "Patient"
+            }
+          ]
+        },
+        "library": [
+          "0"
+        ],
+        "scoring": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+              "code": "cohort"
+            }
+          ]
+        },
+        "group": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+                "valueCode": "boolean"
+              }
+            ],
+            "population": [
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "initial-population"
+                    }
+                  ]
+                },
+                "criteria": {
+                  "language": "text/cql-identifier",
+                  "expression": "InInitialPopulation"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Measure/0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The bug was introduced by #1335 in v0.23.3.

The problem was that I decided to change the value of the special boolean population basis from `:boolean` to `nil` but did it only half way.

Closes: #1397