### PR TITLE
Remove Custom API for Default Column Family

### DIFF
--- a/modules/db-resource-store/src/blaze/db/resource_store/kv.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store/kv.clj
@@ -69,11 +69,11 @@
    (fn [[hash resource]]
      (let [content (fhir-spec/unform-cbor resource)]
        (prom/observe! resource-bytes (alength ^bytes content))
-       [(hash/to-byte-array hash) content]))))
+       [:default (hash/to-byte-array hash) content]))))
 
 (defn- get-content [kv-store hash]
   (with-open [_ (prom/timer duration-seconds "get-resource")]
-    (kv/get kv-store (hash/to-byte-array hash))))
+    (kv/get kv-store :default (hash/to-byte-array hash))))
 
 (defn- get-and-parse [kv-store hash]
   (some-> (get-content kv-store hash) (parse-and-conform-cbor hash)))

--- a/modules/db-resource-store/test/blaze/db/resource_store/kv_test.clj
+++ b/modules/db-resource-store/test/blaze/db/resource_store/kv_test.clj
@@ -107,7 +107,7 @@
 
 (defmethod ig/init-key ::failing-kv-store [_ {:keys [msg] :as config}]
   (reify kv/KvStore
-    (-get [_ hash]
+    (-get [_ _ hash]
       (when (or (nil? (:hash config))
                 (= (hash/from-byte-buffer! (bb/wrap hash)) (:hash config)))
         (throw (Exception. ^String msg))))))
@@ -130,7 +130,7 @@
 (def ^:private error-msg "msg-154312")
 
 (defn- put! [kv-store hash content]
-  (kv/put! kv-store (hash/to-byte-array hash) (fhir-spec/unform-cbor content)))
+  (kv/put! kv-store [[:default (hash/to-byte-array hash) (fhir-spec/unform-cbor content)]]))
 
 (deftest get-test
   (testing "success"
@@ -142,7 +142,7 @@
 
   (testing "parsing error"
     (with-system [{store ::rs/kv kv-store ::kv/mem} system]
-      (kv/put! kv-store (hash/to-byte-array (hash)) (invalid-content))
+      (kv/put! kv-store [[:default (hash/to-byte-array (hash)) (invalid-content)]])
 
       (given-failed-future (rs/get store (hash))
         ::anom/category := ::anom/incorrect
@@ -150,7 +150,7 @@
 
   (testing "conforming error"
     (with-system [{store ::rs/kv kv-store ::kv/mem} system]
-      (kv/put! kv-store (hash/to-byte-array (hash)) (j/write-value-as-bytes {} cbor-object-mapper))
+      (kv/put! kv-store [[:default (hash/to-byte-array (hash)) (j/write-value-as-bytes {} cbor-object-mapper)]])
 
       (given-failed-future (rs/get store (hash))
         ::anom/category := ::anom/fault
@@ -188,7 +188,7 @@
   (testing "parsing error"
     (let [hash (hash)]
       (with-system [{store ::rs/kv kv-store ::kv/mem} system]
-        (kv/put! kv-store (hash/to-byte-array hash) (invalid-content))
+        (kv/put! kv-store [[:default (hash/to-byte-array hash) (invalid-content)]])
 
         (given-failed-future (rs/multi-get store [hash])
           ::anom/category := ::anom/incorrect

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -451,7 +451,7 @@
 (def ^:private expected-kv-store-version 0)
 
 (defn- kv-store-version [kv-store]
-  (or (some-> (kv/get kv-store version/key) version/decode-value) 0))
+  (or (some-> (kv/get kv-store :default version/key) version/decode-value) 0))
 
 (def ^:private incompatible-kv-store-version-msg
   "Incompatible index store version %1$d found. This version of Blaze needs

--- a/modules/db/src/blaze/db/tx_log/local/codec.clj
+++ b/modules/db/src/blaze/db/tx_log/local/codec.clj
@@ -54,3 +54,6 @@
         (update :tx-cmds #(mapv decode-hash %))
         (update :instant decode-instant)
         (assoc :t t))))
+
+(defn encode-entry [t instant tx-cmds]
+  [:default (encode-key t) (encode-tx-data instant tx-cmds)])

--- a/modules/db/test/blaze/db/impl/iterators_test.clj
+++ b/modules/db/test/blaze/db/impl/iterators_test.clj
@@ -35,11 +35,11 @@
     (with-system [{kv-store ::kv/mem} config]
       (kv/put!
        kv-store
-       [[(ba 0x00) bytes/empty]
-        [(ba 0x01) bytes/empty]])
+       [[:default (ba 0x00) bytes/empty]
+        [:default (ba 0x01) bytes/empty]])
 
       (with-open [snapshot (kv/new-snapshot kv-store)
-                  iter (kv/new-iterator snapshot)]
+                  iter (kv/new-iterator snapshot :default)]
         (is (= [[0x00] [0x01]]
                (vec (i/keys! iter decode-1 (bs/from-hex "00"))))))))
 
@@ -47,11 +47,11 @@
     (with-system [{kv-store ::kv/mem} config]
       (kv/put!
        kv-store
-       [[(ba 0x00) bytes/empty]
-        [(ba 0x00 0x01) bytes/empty]])
+       [[:default (ba 0x00) bytes/empty]
+        [:default (ba 0x00 0x01) bytes/empty]])
 
       (with-open [snapshot (kv/new-snapshot kv-store)
-                  iter (kv/new-iterator snapshot)]
+                  iter (kv/new-iterator snapshot :default)]
         (is (= [[0x00] [0x00 0x01]]
                (vec (i/keys! iter decode-1 (bs/from-hex "00")))))))
 
@@ -59,10 +59,10 @@
       (with-system [{kv-store ::kv/mem} config]
         (kv/put!
          kv-store
-         [[(ba 0x00) bytes/empty]
-          [(ba 0x00 0x01 0x02) bytes/empty]])
+         [[:default (ba 0x00) bytes/empty]
+          [:default (ba 0x00 0x01 0x02) bytes/empty]])
 
         (with-open [snapshot (kv/new-snapshot kv-store)
-                    iter (kv/new-iterator snapshot)]
+                    iter (kv/new-iterator snapshot :default)]
           (is (= [[0x00] [0x00 0x01 0x02]]
                  (vec (i/keys! iter decode-1 (bs/from-hex "00"))))))))))

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -478,12 +478,9 @@
 
             (testing "and content changing transaction in between"
               (with-redefs [kv/put!
-                            (fn
-                              ([store entries]
-                               (Thread/sleep 20)
-                               (kv/-put store entries))
-                              ([store key value]
-                               (kv/-put store key value)))]
+                            (fn [store entries]
+                              (Thread/sleep 20)
+                              (kv/-put store entries))]
                 (with-handler [handler node]
                   [[[:put {:fhir/type :fhir/Patient :id "0"
                            :gender #fhir/code"female"}]]]
@@ -1352,12 +1349,9 @@
 
           (testing "and content changing transaction in between"
             (with-redefs [kv/put!
-                          (fn
-                            ([store entries]
-                             (Thread/sleep 20)
-                             (kv/-put store entries))
-                            ([store key value]
-                             (kv/-put store key value)))]
+                          (fn [store entries]
+                            (Thread/sleep 20)
+                            (kv/-put store entries))]
               (with-handler [handler node]
                 [[[:create {:fhir/type :fhir/Patient :id "0"
                             :gender #fhir/code"female"}]]]
@@ -1968,12 +1962,9 @@
 
           (testing "and content changing transaction in between"
             (with-redefs [kv/put!
-                          (fn
-                            ([store entries]
-                             (Thread/sleep 20)
-                             (kv/-put store entries))
-                            ([store key value]
-                             (kv/-put store key value)))]
+                          (fn [store entries]
+                            (Thread/sleep 20)
+                            (kv/-put store entries))]
               (with-handler [handler node]
                 [[[:create {:fhir/type :fhir/Patient :id "0"
                             :gender #fhir/code"female"}]]]
@@ -2080,12 +2071,9 @@
 
           (testing "and content changing transaction in between"
             (with-redefs [kv/put!
-                          (fn
-                            ([store entries]
-                             (Thread/sleep 20)
-                             (kv/-put store entries))
-                            ([store key value]
-                             (kv/-put store key value)))]
+                          (fn [store entries]
+                            (Thread/sleep 20)
+                            (kv/-put store entries))]
               (with-handler [handler node]
                 [[[:create {:fhir/type :fhir/Patient :id "0"
                             :birthDate #fhir/date"2020"}]]]

--- a/modules/interaction/test/blaze/interaction/update_test.clj
+++ b/modules/interaction/test/blaze/interaction/update_test.clj
@@ -266,12 +266,9 @@
 
         (testing "and content changing transaction in between"
           (with-redefs [kv/put!
-                        (fn
-                          ([store entries]
-                           (Thread/sleep 20)
-                           (kv/-put store entries))
-                          ([store key value]
-                           (kv/-put store key value)))]
+                        (fn [store entries]
+                          (Thread/sleep 20)
+                          (kv/-put store entries))]
             (with-handler [handler node]
               [[[:create {:fhir/type :fhir/Patient :id "0"
                           :gender #fhir/code"female"}]]]
@@ -525,12 +522,9 @@
 
     (testing "and content changing transaction in between"
       (with-redefs [kv/put!
-                    (fn
-                      ([store entries]
-                       (Thread/sleep 20)
-                       (kv/-put store entries))
-                      ([store key value]
-                       (kv/-put store key value)))]
+                    (fn [store entries]
+                      (Thread/sleep 20)
+                      (kv/-put store entries))]
         (doseq [if-match [nil "W/\"1\",W/\"2\""]]
           (with-handler [handler node]
             [[[:create {:fhir/type :fhir/Patient :id "0"

--- a/modules/kv/src/blaze/db/kv.clj
+++ b/modules/kv/src/blaze/db/kv.clj
@@ -133,12 +133,12 @@
 (defprotocol KvSnapshot
   "A snapshot of the contents of a KvStore."
 
-  (-new-iterator [snapshot] [snapshot column-family])
+  (-new-iterator [snapshot column-family])
 
-  (-snapshot-get [snapshot key] [snapshot column-family key]))
+  (-snapshot-get [snapshot column-family key]))
 
 (defn new-iterator
-  "Return an iterator over the contents of the database.
+  "Return an iterator over the contents of `column-family`.
 
   The result is initially invalid, so the caller must call one of the seek
   functions with the iterator before using it.
@@ -146,30 +146,24 @@
   Throws an anomaly if `column-family` was not found.
 
   Iterators have to be closed after usage."
-  (^AutoCloseable
-   [snapshot]
-   (-new-iterator snapshot))
-  (^AutoCloseable
-   [snapshot column-family]
-   (-new-iterator snapshot column-family)))
+  ^AutoCloseable
+  [snapshot column-family]
+  (-new-iterator snapshot column-family))
 
 (defn snapshot-get
-  "Returns a new byte array storing the value associated with the `key` if any."
-  ([snapshot key]
-   (-snapshot-get snapshot key))
-  ([snapshot column-family key]
-   (-snapshot-get snapshot column-family key)))
+  "Returns a new byte array storing the value associated with the `key` in
+  `column-family` if any."
+  [snapshot column-family key]
+  (-snapshot-get snapshot column-family key))
 
 (defprotocol KvStore
   "A key-value store."
 
   (-new-snapshot [store])
 
-  (-get [store key] [store column-family key])
+  (-get [store column-family key])
 
-  (-multi-get [store keys])
-
-  (-put [store entries] [store key value])
+  (-put [store entries])
 
   (-delete [store keys])
 
@@ -187,43 +181,30 @@
   (-new-snapshot store))
 
 (defn get
-  "Returns the value of `key` in `column-family` (optional) or nil if not found.
+  "Returns the value of `key` in `column-family` or nil if not found.
 
   Blocks the current thread."
-  ([store key]
-   (-get store key))
-  ([store column-family key]
-   (-get store column-family key)))
-
-(defn multi-get
-  "Returns a map of key to value of all found entries of `keys`.
-
-  Blocks the current thread."
-  ([store keys]
-   (-multi-get store keys)))
+  [store column-family key]
+  (-get store column-family key))
 
 (defn put!
-  "Stores either `entries` or the pair of `key` and `value`.
-
-  Entries are either tuples of key and value or triples of column-family, key
-  and value.
+  "Stores `entries` that are triples of column-family, key and value.
 
   Throws an anomaly if a column-family of an entry was not found.
 
   Puts are atomic. Blocks. Returns nil."
-  ([store entries]
-   (-put store entries))
-  ([store key value]
-   (-put store key value)))
+  [store entries]
+  (-put store entries))
 
 (defn delete!
-  "Deletes entries with `keys`."
-  [store keys]
-  (-delete store keys))
+  "Deletes `entries` that are tuples of column-family and key.
+
+  Deletes are atomic. Blocks. Returns nil."
+  [store entries]
+  (-delete store entries))
 
 (defn write!
-  "Entries are either triples of operator, key and value or quadruples of
-  operator, column-family, key and value.
+  "Entries are quadruples of operator, column-family, key and value.
 
   Operators are :put, :merge and :delete.
 

--- a/modules/kv/src/blaze/db/kv/mem.clj
+++ b/modules/kv/src/blaze/db/kv/mem.clj
@@ -111,17 +111,10 @@
 
 (deftype MemKvSnapshot [db]
   kv/KvSnapshot
-  (-new-iterator [_]
-    (let [db (:default db)]
-      (->MemKvIterator db (atom {:rest (seq db)}) false)))
-
   (-new-iterator [_ column-family]
     (if-let [db (get db column-family)]
       (->MemKvIterator db (atom {:rest (seq db)}) false)
       (throw-anom (ba/not-found (column-family-not-found-msg column-family)))))
-
-  (-snapshot-get [_ k]
-    (some-> (get-in db [:default k]) (copy)))
 
   (-snapshot-get [_ column-family k]
     (some-> (get-in db [column-family k]) (copy)))
@@ -129,35 +122,32 @@
   AutoCloseable
   (close [_]))
 
-(defn- assoc-copy-cf [m column-family k v]
+(defn- assoc-copy [m column-family k v]
   (when (nil? m)
     (throw-anom (ba/not-found (column-family-not-found-msg column-family))))
-  (assoc m (copy k) (copy v)))
-
-(defn- assoc-copy [m k v]
   (assoc m (copy k) (copy v)))
 
 (defn- put-entries [db entries]
   (reduce
    (fn [db [column-family k v]]
-     (if (keyword? column-family)
-       (update db column-family assoc-copy-cf column-family k v)
-       (update db :default assoc-copy column-family k)))
+     (update db column-family assoc-copy column-family k v))
+   db
+   entries))
+
+(defn- delete-entries [db entries]
+  (reduce
+   (fn [db [column-family k]]
+     (update db column-family dissoc k))
    db
    entries))
 
 (defn- write-entries [db entries]
   (reduce
    (fn [db [op column-family k v]]
-     (if (keyword? column-family)
-       (case op
-         :put (update db column-family assoc-copy-cf column-family k v)
-         :delete (update db column-family dissoc k)
-         (throw-anom (ba/unsupported (str (name op) " is not supported"))))
-       (case op
-         :put (update db :default assoc-copy column-family k)
-         :delete (update db :default dissoc column-family)
-         (throw-anom (ba/unsupported (str (name op) " is not supported"))))))
+     (case op
+       :put (update db column-family assoc-copy column-family k v)
+       :delete (update db column-family dissoc k)
+       (throw-anom (ba/unsupported (str (name op) " is not supported")))))
    db
    entries))
 
@@ -166,33 +156,15 @@
   (-new-snapshot [_]
     (->MemKvSnapshot @db))
 
-  (-get [_ k]
-    (kv/snapshot-get (->MemKvSnapshot @db) k))
-
   (-get [_ column-family k]
     (kv/snapshot-get (->MemKvSnapshot @db) column-family k))
 
-  (-multi-get [_ ks]
-    (with-open [snapshot ^AutoCloseable (->MemKvSnapshot @db)]
-      (reduce
-       (fn [r k]
-         (if-let [v (kv/snapshot-get snapshot k)]
-           (assoc r k v)
-           r))
-       {}
-       ks)))
-
   (-put [_ entries]
-    (log/trace "put" (count entries) "entries")
     (swap! db put-entries entries)
     nil)
 
-  (-put [_ k v]
-    (swap! db update :default assoc-copy k v)
-    nil)
-
-  (-delete [_ ks]
-    (swap! db update :default #(apply dissoc % ks))
+  (-delete [_ entries]
+    (swap! db delete-entries entries)
     nil)
 
   (-write [_ entries]

--- a/modules/kv/src/blaze/db/kv/spec.clj
+++ b/modules/kv/src/blaze/db/kv/spec.clj
@@ -16,29 +16,22 @@
   (s/and #(satisfies? kv/KvIterator %)
          #(instance? AutoCloseable %)))
 
-(s/def ::kv/put-entry-wo-cf
-  (s/tuple bytes? bytes?))
-
-(s/def ::kv/put-entry-w-cf
+(s/def ::kv/put-entry
   (s/tuple keyword? bytes? bytes?))
 
-(s/def ::kv/put-entry
-  (s/or :kv ::kv/put-entry-wo-cf
-        :cf-kv ::kv/put-entry-w-cf))
+(s/def ::kv/delete-entry
+  (s/tuple keyword? bytes?))
 
 (defmulti write-entry first)
 
 (defmethod write-entry :put [_]
-  (s/or :kv (s/cat :op #{:put} :key bytes? :val bytes?)
-        :cf-kv (s/cat :op #{:put} :cf-key keyword? :key bytes? :val bytes?)))
+  (s/cat :op #{:put} :column-family keyword? :key bytes? :val bytes?))
 
 (defmethod write-entry :merge [_]
-  (s/or :kv (s/cat :op #{:merge} :key bytes? :val bytes?)
-        :cf-kv (s/cat :op #{:merge} :cf-key keyword? :key bytes? :val bytes?)))
+  (s/cat :op #{:merge} :column-family keyword? :key bytes? :val bytes?))
 
 (defmethod write-entry :delete [_]
-  (s/or :k (s/cat :op #{:delete} :key bytes?)
-        :cf-k (s/cat :op #{:delete} :cf-key keyword? :key bytes?)))
+  (s/cat :op #{:delete} :column-family keyword? :key bytes?))
 
 (s/def ::kv/write-entry
   (s/multi-spec write-entry first))

--- a/modules/kv/src/blaze/db/kv_spec.clj
+++ b/modules/kv/src/blaze/db/kv_spec.clj
@@ -51,13 +51,11 @@
   :ret nat-int?)
 
 (s/fdef kv/new-iterator
-  :args (s/cat :snapshot :blaze.db/kv-snapshot
-               :column-family (s/? keyword?))
+  :args (s/cat :snapshot :blaze.db/kv-snapshot :column-family keyword?)
   :ret :blaze.db/kv-iterator)
 
 (s/fdef kv/snapshot-get
-  :args (s/cat :snapshot :blaze.db/kv-snapshot
-               :column-family (s/? keyword?)
+  :args (s/cat :snapshot :blaze.db/kv-snapshot :column-family keyword?
                :key bytes?)
   :ret (s/nilable bytes?))
 
@@ -70,27 +68,16 @@
   :ret :blaze.db/kv-snapshot)
 
 (s/fdef kv/get
-  :args (s/cat :kv-store :blaze.db/kv-store
-               :column-family (s/? keyword?)
-               :key bytes?)
+  :args (s/cat :kv-store :blaze.db/kv-store :column-family keyword? :key bytes?)
   :ret (s/nilable bytes?))
 
-(s/fdef kv/multi-get
-  :args (s/cat :kv-store :blaze.db/kv-store :keys (s/coll-of bytes?))
-  :ret (s/map-of bytes? bytes?))
-
 (s/fdef kv/put!
-  :args
-  (s/alt
-   :entries
-   (s/cat
-    :kv-store :blaze.db/kv-store
-    :entries (cs/coll-of :blaze.db.kv/put-entry))
-   :kv
-   (s/cat :kv-store :blaze.db/kv-store :key bytes? :value bytes?)))
+  :args (s/cat :kv-store :blaze.db/kv-store
+               :entries (cs/coll-of :blaze.db.kv/put-entry)))
 
 (s/fdef kv/delete!
-  :args (s/cat :kv-store :blaze.db/kv-store :keys (s/coll-of bytes?)))
+  :args (s/cat :kv-store :blaze.db/kv-store
+               :entries (cs/coll-of :blaze.db.kv/delete-entry)))
 
 (s/fdef kv/write!
   :args (s/cat :kv-store :blaze.db/kv-store

--- a/modules/kv/test/blaze/db/kv/mem_test.clj
+++ b/modules/kv/test/blaze/db/kv/mem_test.clj
@@ -28,9 +28,6 @@
 (def reverse-comparator-config
   {::kv/mem {:column-families {:a {:reverse-comparator? true}}}})
 
-(def a-config
-  {::kv/mem {:column-families {:a nil}}})
-
 (def a-b-config
   {::kv/mem {:column-families {:a nil :b nil}}})
 
@@ -73,7 +70,7 @@
 (deftest valid-test
   (with-system [{kv-store ::kv/mem} config]
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
       (testing "iterator is initially invalid"
         (is (not (kv/valid? iter))))
 
@@ -83,11 +80,11 @@
 
 (deftest seek-to-first-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x02) (ba 0x20)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x02) (ba 0x20)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (kv/seek-to-first! iter)
       (is (kv/valid? iter))
@@ -100,11 +97,11 @@
 
 (deftest seek-to-last-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x02) (ba 0x20)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x02) (ba 0x20)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (kv/seek-to-last! iter)
       (is (kv/valid? iter))
@@ -117,11 +114,11 @@
 
 (deftest seek-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "before first entry"
         (kv/seek! iter (ba 0x00))
@@ -197,11 +194,11 @@
 
 (deftest seek-buffer-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "before first entry"
         (kv/seek-buffer! iter (bb 0x00))
@@ -277,11 +274,11 @@
 
 (deftest seek-for-prev-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "past second entry"
         (kv/seek-for-prev! iter (ba 0x04))
@@ -317,11 +314,11 @@
 
 (deftest next-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "first entry"
         (kv/seek-to-first! iter)
@@ -344,11 +341,11 @@
 
 (deftest prev-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "first entry"
         (kv/seek-to-last! iter)
@@ -371,10 +368,10 @@
 
 (deftest key-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x01 0x02) (ba 0x00)]]
+    [[:default (ba 0x01 0x02) (ba 0x00)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "errors on invalid iterator"
         (is (iterator-invalid-anom? (ba/try-anomaly (kv/key iter))))
@@ -405,10 +402,10 @@
 
 (deftest value-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x00) (ba 0x01 0x02)]]
+    [[:default (ba 0x00) (ba 0x01 0x02)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "errors on invalid iterator"
         (is (iterator-invalid-anom? (ba/try-anomaly (kv/value iter))))
@@ -458,102 +455,59 @@
         (is (ba/not-found? (ba/try-anomaly (kv/new-iterator snapshot :c))))))))
 
 (deftest snapshot-get-test
-  (with-system-data [{kv-store ::kv/mem} a-config]
-    [[(ba 0x00) (ba 0x01)]
-     [:a (ba 0x00) (ba 0x02)]]
+  (with-system-data [{kv-store ::kv/mem} config]
+    [[:default (ba 0x00) (ba 0x01)]]
 
     (with-open [snapshot (kv/new-snapshot kv-store)]
 
       (testing "returns found value"
-        (is (bytes= (ba 0x01) (kv/snapshot-get snapshot (ba 0x00)))))
+        (is (bytes= (ba 0x01) (kv/snapshot-get snapshot :default (ba 0x00)))))
 
       (testing "returns nil on not found value"
-        (is (nil? (kv/snapshot-get snapshot (ba 0x01)))))
-
-      (testing "returns found value of column-family :a"
-        (is (bytes= (ba 0x02) (kv/snapshot-get snapshot :a (ba 0x00)))))
-
-      (testing "returns nil on not found value of column-family :a"
-        (is (nil? (kv/snapshot-get snapshot :a (ba 0x01))))))))
+        (is (nil? (kv/snapshot-get snapshot :default (ba 0x01))))))))
 
 (deftest get-test
-  (with-system-data [{kv-store ::kv/mem} a-config]
-    [[(ba 0x00) (ba 0x01)]
-     [:a (ba 0x00) (ba 0x02)]]
+  (with-system-data [{kv-store ::kv/mem} config]
+    [[:default (ba 0x00) (ba 0x01)]]
 
     (testing "returns found value"
-      (is (bytes= (ba 0x01) (kv/get kv-store (ba 0x00)))))
+      (is (bytes= (ba 0x01) (kv/get kv-store :default (ba 0x00)))))
 
     (testing "returns nil on not found value"
-      (is (nil? (kv/get kv-store (ba 0x01)))))
-
-    (testing "returns found value of column-family :a"
-      (is (bytes= (ba 0x02) (kv/get kv-store :a (ba 0x00)))))
-
-    (testing "returns nil on not found value of column-family :a"
-      (is (nil? (kv/get kv-store :a (ba 0x01)))))))
-
-(deftest multi-get-test
-  (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x00) (ba 0x10)]
-     [(ba 0x01) (ba 0x11)]]
-
-    (testing "returns all found entries"
-      (let [m (into
-               {}
-               (map (fn [[k v]] [(vec k) (vec v)]))
-               (kv/multi-get kv-store [(ba 0x00) (ba 0x01) (ba 0x02)]))]
-        (is (= [0x10] (get m [0x00])))
-        (is (= [0x11] (get m [0x01])))))))
+      (is (nil? (kv/get kv-store :default (ba 0x01)))))))
 
 (deftest put-test
   (with-system [{kv-store ::kv/mem} config]
 
-    (testing "key value"
-      (kv/put! kv-store (ba 0x00) (ba 0x01))
-      (is (bytes= (ba 0x01) (kv/get kv-store (ba 0x00)))))
+    (testing "get after put"
+      (kv/put! kv-store [[:default (ba 0x00) (ba 0x01)]])
+      (is (bytes= (ba 0x01) (kv/get kv-store :default (ba 0x00)))))
 
     (testing "errors on unknown column-family"
       (is (ba/not-found? (ba/try-anomaly (kv/put! kv-store [[:a (ba 0x00) (ba 0x01)]])))))))
 
 (deftest delete-test
   (with-system-data [{kv-store ::kv/mem} config]
-    [[(ba 0x00) (ba 0x10)]]
+    [[:default (ba 0x00) (ba 0x10)]]
 
-    (kv/delete! kv-store [(ba 0x00)])
+    (kv/delete! kv-store [[:default (ba 0x00)]])
 
-    (is (nil? (kv/get kv-store (ba 0x00))))))
+    (is (nil? (kv/get kv-store :default (ba 0x00))))))
 
 (deftest write-test
-  (testing "default column-family"
-    (with-system-data [{kv-store ::kv/mem} config]
-      [[(ba 0x00) (ba 0x10)]]
+  (with-system-data [{kv-store ::kv/mem} config]
+    [[:default (ba 0x00) (ba 0x10)]]
 
-      (testing "put"
-        (kv/write! kv-store [[:put (ba 0x01) (ba 0x11)]])
-        (is (bytes= (ba 0x11) (kv/get kv-store (ba 0x01)))))
+    (testing "put"
+      (kv/write! kv-store [[:put :default (ba 0x01) (ba 0x11)]])
+      (is (bytes= (ba 0x11) (kv/get kv-store :default (ba 0x01)))))
 
-      (testing "merge is not supported"
-        (is (ba/unsupported? (ba/try-anomaly (kv/write! kv-store [[:merge (ba 0x00) (ba 0x00)]])))))
+    (testing "merge is not supported"
+      (is (ba/unsupported? (ba/try-anomaly (kv/write! kv-store [[:merge :default (ba 0x00) (ba 0x00)]])))))
 
-      (testing "delete"
-        (kv/write! kv-store [[:delete (ba 0x00)]])
-        (is (nil? (kv/get kv-store (ba 0x00)))))))
-
-  (testing "custom column-family"
-    (with-system-data [{kv-store ::kv/mem} a-config]
-      [[:a (ba 0x00) (ba 0x10)]]
-
-      (testing "put"
-        (kv/write! kv-store [[:put :a (ba 0x01) (ba 0x11)]])
-        (is (bytes= (ba 0x11) (kv/get kv-store :a (ba 0x01)))))
-
-      (testing "merge is not supported"
-        (is (ba/unsupported? (ba/try-anomaly (kv/write! kv-store [[:merge :a (ba 0x00) (ba 0x00)]])))))
-
-      (testing "delete"
-        (kv/write! kv-store [[:delete :a (ba 0x00)]])
-        (is (nil? (kv/get kv-store :a (ba 0x00))))))))
+    (testing "delete"
+      (kv/write! kv-store [[:delete :default (ba 0x00)]])
+      (is (nil? (kv/get kv-store :default (ba 0x00)))))))
 
 (deftest init-component-test
   (is (kv/store? (ig/init-key ::kv/mem {}))))

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb/impl_spec.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb/impl_spec.clj
@@ -26,7 +26,9 @@
                :entries (cs/coll-of :blaze.db.kv/put-entry)))
 
 (s/fdef impl/delete-wb!
-  :args (s/cat :wb ::impl/write-batch :ks (s/coll-of bytes?)))
+  :args (s/cat :cfhs (s/map-of keyword? ::impl/column-family-handle)
+               :wb ::impl/write-batch
+               :entries (cs/coll-of :blaze.db.kv/delete-entry)))
 
 (s/fdef impl/write-wb!
   :args (s/cat :cfhs (s/map-of keyword? ::impl/column-family-handle)

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
@@ -159,7 +159,7 @@
 (deftest valid-test
   (with-system [{db ::kv/rocksdb} (config (new-temp-dir!))]
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
       (testing "iterator is initially invalid"
         (is (not (kv/valid? iter)))))))
 
@@ -174,11 +174,11 @@
 
 (deftest seek-to-first-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x02) (ba 0x20)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x02) (ba 0x20)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (kv/seek-to-first! iter)
       (is (kv/valid? iter))
@@ -187,11 +187,11 @@
 
 (deftest seek-to-last-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x02) (ba 0x20)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x02) (ba 0x20)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (kv/seek-to-last! iter)
       (is (kv/valid? iter))
@@ -209,11 +209,11 @@
 
 (deftest seek-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "before first entry"
         (kv/seek! iter (ba 0x00))
@@ -281,11 +281,11 @@
 
 (deftest seek-buffer-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "before first entry"
         (kv/seek-buffer! iter (bb 0x00))
@@ -353,11 +353,11 @@
 
 (deftest seek-for-prev-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "past second entry"
         (kv/seek-for-prev! iter (ba 0x04))
@@ -389,11 +389,11 @@
 
 (deftest next-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "first entry"
         (kv/seek-to-first! iter)
@@ -413,11 +413,11 @@
 
 (deftest prev-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01) (ba 0x10)]
-     [(ba 0x03) (ba 0x30)]]
+    [[:default (ba 0x01) (ba 0x10)]
+     [:default (ba 0x03) (ba 0x30)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "first entry"
         (kv/seek-to-last! iter)
@@ -437,10 +437,10 @@
 
 (deftest key-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x01 0x02) (ba 0x00)]]
+    [[:default (ba 0x01 0x02) (ba 0x00)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "puts the first byte into the buffer without overflowing"
         (kv/seek-to-first! iter)
@@ -467,10 +467,10 @@
 
 (deftest value-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x00) (ba 0x01 0x02)]]
+    [[:default (ba 0x00) (ba 0x01 0x02)]]
 
     (with-open [snapshot (kv/new-snapshot db)
-                iter (kv/new-iterator snapshot)]
+                iter (kv/new-iterator snapshot :default)]
 
       (testing "puts the first byte into the buffer without overflowing"
         (kv/seek-to-first! iter)
@@ -534,75 +534,44 @@
    ::rocksdb/stats {}})
 
 (deftest snapshot-get-test
-  (with-system-data [{db ::kv/rocksdb} (a-config (new-temp-dir!))]
-    [[(ba 0x00) (ba 0x01)]
-     [:a (ba 0x00) (ba 0x02)]]
+  (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
+    [[:default (ba 0x00) (ba 0x01)]]
 
     (with-open [snapshot (kv/new-snapshot db)]
 
       (testing "returns found value"
-        (is (bytes= (ba 0x01) (kv/snapshot-get snapshot (ba 0x00)))))
+        (is (bytes= (ba 0x01) (kv/snapshot-get snapshot :default (ba 0x00)))))
 
       (testing "returns nil on not found value"
-        (is (nil? (kv/snapshot-get snapshot (ba 0x01)))))
-
-      (testing "returns found value of column-family :a"
-        (is (bytes= (ba 0x02) (kv/snapshot-get snapshot :a (ba 0x00)))))
-
-      (testing "returns nil on not found value of column-family :a"
-        (is (nil? (kv/snapshot-get snapshot :a (ba 0x01))))))))
+        (is (nil? (kv/snapshot-get snapshot :default (ba 0x01))))))))
 
 (deftest get-test
-  (with-system-data [{db ::kv/rocksdb} (a-config (new-temp-dir!))]
-    [[(ba 0x00) (ba 0x01)]
-     [:a (ba 0x00) (ba 0x02)]]
+  (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
+    [[:default (ba 0x00) (ba 0x01)]]
 
     (testing "returns found value"
-      (is (bytes= (ba 0x01) (kv/get db (ba 0x00)))))
+      (is (bytes= (ba 0x01) (kv/get db :default (ba 0x00)))))
 
     (testing "returns nil on not found value"
-      (is (nil? (kv/get db (ba 0x01)))))
-
-    (testing "returns found value of column-family :a"
-      (is (bytes= (ba 0x02) (kv/get db :a (ba 0x00)))))
-
-    (testing "returns nil on not found value of column-family :a"
-      (is (nil? (kv/get db :a (ba 0x01)))))))
-
-(deftest multi-get-test
-  (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x00) (ba 0x10)]
-     [(ba 0x01) (ba 0x11)]]
-
-    (testing "returns all found entries"
-      (let [m (into
-               {}
-               (map (fn [[k v]] [(vec k) (vec v)]))
-               (kv/multi-get db [(ba 0x00) (ba 0x01) (ba 0x02)]))]
-        (is (= [0x10] (get m [0x00])))
-        (is (= [0x11] (get m [0x01])))))))
+      (is (nil? (kv/get db :default (ba 0x01)))))))
 
 (deftest put-test
   (with-system [{db ::kv/rocksdb} (config (new-temp-dir!))]
 
-    (testing "key value"
-      (kv/put! db (ba 0x00) (ba 0x01))
-      (is (bytes= (ba 0x01) (kv/get db (ba 0x00)))))
-
-    (testing "entries"
+    (testing "get after put"
       (kv/put! db [[:default (ba 0x00) (ba 0x01)]])
-      (is (bytes= (ba 0x01) (kv/get db (ba 0x00)))))
+      (is (bytes= (ba 0x01) (kv/get db :default (ba 0x00)))))
 
     (testing "errors on unknown column-family"
       (is (ba/not-found? (ba/try-anomaly (kv/put! db [[:a (ba 0x00) (ba 0x01)]])))))))
 
 (deftest delete-test
   (with-system-data [{db ::kv/rocksdb} (config (new-temp-dir!))]
-    [[(ba 0x00) (ba 0x10)]]
+    [[:default (ba 0x00) (ba 0x10)]]
 
-    (kv/delete! db [(ba 0x00)])
+    (kv/delete! db [[:default (ba 0x00)]])
 
-    (is (nil? (kv/get db (ba 0x00))))))
+    (is (nil? (kv/get db :default (ba 0x00))))))
 
 (defn- merge-config [dir]
   {::kv/rocksdb
@@ -613,49 +582,22 @@
    ::rocksdb/block-cache {}
    ::rocksdb/stats {}})
 
-(defn- merge-a-config [dir]
-  {::kv/rocksdb
-   {:dir dir
-    :block-cache (ig/ref ::rocksdb/block-cache)
-    :stats (ig/ref ::rocksdb/stats)
-    :column-families {:a {:merge-operator :stringappend}}}
-   ::rocksdb/block-cache {}
-   ::rocksdb/stats {}})
-
 (deftest write-test
-  (testing "default column-family"
-    (with-system-data [{db ::kv/rocksdb} (merge-config (new-temp-dir!))]
-      [[(ba 0x00) (ba 0x10)]]
+  (with-system-data [{db ::kv/rocksdb} (merge-config (new-temp-dir!))]
+    [[:default (ba 0x00) (ba 0x10)]]
 
-      (testing "put"
-        (kv/write! db [[:put (ba 0x01) (ba 0x11)]])
-        (is (bytes= (ba 0x11) (kv/get db (ba 0x01)))))
+    (testing "put"
+      (kv/write! db [[:put :default (ba 0x01) (ba 0x11)]])
+      (is (bytes= (ba 0x11) (kv/get db :default (ba 0x01)))))
 
-      (testing "merge"
-        (kv/write! db [[:merge (ba 0x00) (ba 0x20)]])
-        ;; 0x2C is a comma
-        (is (bytes= (ba 0x10 0x2C 0x20) (kv/get db (ba 0x00)))))
+    (testing "merge"
+      (kv/write! db [[:merge :default (ba 0x00) (ba 0x20)]])
+      ;; 0x2C is a comma
+      (is (bytes= (ba 0x10 0x2C 0x20) (kv/get db :default (ba 0x00)))))
 
-      (testing "delete"
-        (kv/write! db [[:delete (ba 0x00)]])
-        (is (nil? (kv/get db (ba 0x00)))))))
-
-  (testing "custom column-family"
-    (with-system-data [{db ::kv/rocksdb} (merge-a-config (new-temp-dir!))]
-      [[:a (ba 0x00) (ba 0x10)]]
-
-      (testing "put"
-        (kv/write! db [[:put :a (ba 0x01) (ba 0x11)]])
-        (is (bytes= (ba 0x11) (kv/get db :a (ba 0x01)))))
-
-      (testing "merge"
-        (kv/write! db [[:merge :a (ba 0x00) (ba 0x20)]])
-        ;; 0x2C is a comma
-        (is (bytes= (ba 0x10 0x2C 0x20) (kv/get db :a (ba 0x00)))))
-
-      (testing "delete"
-        (kv/write! db [[:delete :a (ba 0x00)]])
-        (is (nil? (kv/get db :a (ba 0x00))))))))
+    (testing "delete"
+      (kv/write! db [[:delete :default (ba 0x00)]])
+      (is (nil? (kv/get db :default (ba 0x00)))))))
 
 (deftest path-test
   (with-system [{db ::kv/rocksdb} (config (new-temp-dir!))]
@@ -748,15 +690,14 @@
             ::anom/category := ::anom/not-found
             ::anom/message := "Property with name `name-143127` was not found on column-family with name `a`."))))))
 
+(defn int-ba [i]
+  (bs/to-byte-array (bs/from-hex (str/upper-case (Long/toHexString i)))))
+
 (deftest tables-test
   (testing "default column-family"
     (with-system [{db ::kv/rocksdb} (config (new-temp-dir!))]
       (run!
-       (fn [i]
-         (kv/put!
-          db
-          (bs/to-byte-array (bs/from-hex (str/upper-case (Long/toHexString i))))
-          (apply ba (range 10000))))
+       #(kv/put! db [[:default (int-ba %) (apply ba (range 10000))]])
        (range 10000 20000))
 
       (is (pos-int? (rocksdb/long-property db "rocksdb.estimate-live-data-size")))
@@ -777,12 +718,7 @@
   (testing "with column-family"
     (with-system [{db ::kv/rocksdb} (a-config (new-temp-dir!))]
       (run!
-       (fn [i]
-         (kv/put!
-          db
-          [[:a
-            (bs/to-byte-array (bs/from-hex (str/upper-case (Long/toHexString i))))
-            (apply ba (range 10000))]]))
+       #(kv/put! db [[:a (int-ba %) (apply ba (range 10000))]])
        (range 10000 20000))
 
       (is (= 0 (rocksdb/long-property db :default "rocksdb.estimate-live-data-size")))
@@ -833,26 +769,17 @@
   (testing "whole database"
     (with-system [{db ::kv/rocksdb} (config (new-temp-dir!))]
       (run!
-       (fn [i]
-         (kv/put!
-          db
-          [[(bs/to-byte-array (bs/from-hex (str/upper-case (Long/toHexString i))))
-            (apply ba (range 10000))]]))
+       #(kv/put! db [[:default (int-ba %) (apply ba (range 10000))]])
        (range 10000 30000))
 
       (rocksdb/compact-range! db)
 
-      (is (some? (kv/get db (ba 0x27 0x10))))))
+      (is (some? (kv/get db :default (ba 0x27 0x10))))))
 
   (testing "with column-family"
     (with-system [{db ::kv/rocksdb} (a-config (new-temp-dir!))]
       (run!
-       (fn [i]
-         (kv/put!
-          db
-          [[:a
-            (bs/to-byte-array (bs/from-hex (str/upper-case (Long/toHexString i))))
-            (apply ba (range 10000))]]))
+       #(kv/put! db [[:a (int-ba %) (apply ba (range 10000))]])
        (range 10000 20000))
 
       (rocksdb/compact-range! db :a)


### PR DESCRIPTION
RocksDB has a custom API for the default column family from the time before column family support. We used that custom api also in the Key Value Store abstraction, because we didn't know that it's the same as accessing the default column family.

This change simplifies the Key Value Store API.