### PR TITLE
Improve Finding of Library Resource by Literal Ref

### DIFF
--- a/.clj-kondo/root/config.edn
+++ b/.clj-kondo/root/config.edn
@@ -69,6 +69,7 @@
     blaze.elm.compiler.external-data ed
     blaze.elm.expression expr
     blaze.executors ex
+    blaze.fhir.spec.references fsr
     blaze.fhir.structure-definition-repo sdr
     blaze.middleware.fhir.db db
     blaze.rest-api.header header

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -4,12 +4,12 @@
 
 The following table lists the recommended system sizes depending on the number of patients. 
 
-| # Patients | Cores |     RAM |    SSD | Heap Mem ¹ | Block Cache ² | Resource Cache ³ |
-|-----------:|------:|--------:|-------:|-----------:|--------------:|-----------------:|
-|    < 100 k |     4 |  32 GiB | 0.5 TB |      8 GiB |         8 GiB |            2.5 M | 
-|      100 k |     8 |  64 GiB |   1 TB |     16 GiB |        16 GiB |              5 M | 
-|        1 M |    16 | 128 GiB |   2 TB |     32 GiB |        32 GiB |             10 M | 
-|      > 1 M |    32 | 256 GiB |   4 TB |     64 GiB |        64 GiB |             20 M | 
+| # Patients | Cores |     RAM |    SSD | Heap Mem | Block Cache | Resource Cache |
+|-----------:|------:|--------:|-------:|---------:|------------:|---------------:|
+|    < 100 k |     4 |  32 GiB | 0.5 TB |    8 GiB |       8 GiB |          2.5 M | 
+|      100 k |     8 |  64 GiB |   1 TB |   16 GiB |      16 GiB |            5 M | 
+|        1 M |    16 | 128 GiB |   2 TB |   32 GiB |      32 GiB |           10 M | 
+|      > 1 M |    32 | 256 GiB |   4 TB |   64 GiB |      64 GiB |           20 M | 
 
 ### Configuration
 

--- a/modules/db-tx-log/src/blaze/db/tx_log/spec.clj
+++ b/modules/db-tx-log/src/blaze/db/tx_log/spec.clj
@@ -25,7 +25,7 @@
   :fhir.resource/type)
 
 (s/def :blaze.db.tx-cmd/refs
-  (s/coll-of :blaze.fhir/local-ref-tuple))
+  (s/coll-of :blaze.fhir/literal-ref-tuple))
 
 (s/def :blaze.db/t
   (s/and int? #(<= 0 % 0xFFFFFFFFFFFFFF)))

--- a/modules/db/src/blaze/db/impl/search_param.clj
+++ b/modules/db/src/blaze/db/impl/search_param.clj
@@ -19,7 +19,8 @@
    [blaze.db.impl.search-param.token]
    [blaze.db.impl.search-param.util :as u]
    [blaze.fhir-path :as fhir-path]
-   [blaze.fhir.spec :as fhir-spec]))
+   [blaze.fhir.spec :as fhir-spec]
+   [blaze.fhir.spec.references :as fsr]))
 
 (set! *warn-on-reflection* true)
 
@@ -102,7 +103,7 @@
   (reify
     fhir-path/Resolver
     (-resolve [_ uri]
-      (when-let [[type id] (some-> uri u/split-literal-ref)]
+      (when-let [[type id] (some-> uri fsr/split-literal-ref)]
         {:fhir/type (keyword "fhir" type)
          :id id}))))
 

--- a/modules/db/src/blaze/db/impl/search_param/token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/token.clj
@@ -14,6 +14,7 @@
    [blaze.db.impl.search-param.util :as u]
    [blaze.fhir-path :as fhir-path]
    [blaze.fhir.spec :as fhir-spec]
+   [blaze.fhir.spec.references :as fsr]
    [blaze.fhir.spec.type :as type]
    [taoensso.timbre :as log]))
 
@@ -95,7 +96,7 @@
 
 (defn- literal-reference-entries [reference]
   (when-let [value (type/value reference)]
-    (if-let [[type id] (u/split-literal-ref value)]
+    (if-let [[type id] (fsr/split-literal-ref value)]
       [[nil (codec/v-hash id)]
        [nil (codec/v-hash (str type "/" id))]
        [nil (codec/tid-id (codec/tid type)
@@ -173,7 +174,7 @@
         (fn [value]
           (when (identical? :fhir/Reference (fhir-spec/fhir-type value))
             (when-let [reference (type/value (:reference value))]
-              (some-> (u/split-literal-ref reference) (coll/nth 1))))))
+              (some-> (fsr/split-literal-ref reference) (coll/nth 1))))))
        values)))
 
   (-index-values [search-param resolver resource]

--- a/modules/db/src/blaze/db/impl/search_param/util.clj
+++ b/modules/db/src/blaze/db/impl/search_param/util.clj
@@ -107,15 +107,6 @@
            id (bs/from-byte-buffer! %)]
        (non-deleted-resource-handle resource-handle tid id)))))
 
-(defn split-literal-ref [^String s]
-  (let [idx (.indexOf s 47)]
-    (when (pos? idx)
-      (let [type (.substring s 0 idx)]
-        (when (.matches (re-matcher #"[A-Z]([A-Za-z0-9_]){0,254}" type))
-          (let [id (.substring s (unchecked-inc-int idx))]
-            (when (.matches (re-matcher #"[A-Za-z0-9\-\.]{1,64}" id))
-              [type id])))))))
-
 (defn invalid-decimal-value-msg [code value]
   (format "Invalid decimal value `%s` in search parameter `%s`." value code))
 

--- a/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
@@ -40,4 +40,4 @@
 
 (s/fdef rh/reference
   :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.fhir/local-ref)
+  :ret :blaze.fhir/literal-ref)

--- a/modules/fhir-structure/src/blaze/fhir/spec/references.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/references.clj
@@ -1,0 +1,14 @@
+(ns blaze.fhir.spec.references)
+
+(set! *warn-on-reflection* true)
+
+(defn split-literal-ref [^String s]
+  (if (and (pos? (.length s)) (= \/ (.charAt s 0)))
+    (recur (.substring s 1))
+    (let [idx (.indexOf s 47)]
+      (when (pos? idx)
+        (let [type (.substring s 0 idx)]
+          (when (.matches (re-matcher #"[A-Z]([A-Za-z0-9_]){0,254}" type))
+            (let [id (.substring s (unchecked-inc-int idx))]
+              (when (.matches (re-matcher #"[A-Za-z0-9\-\.]{1,64}" id))
+                [type id]))))))))

--- a/modules/fhir-structure/src/blaze/fhir/spec/references_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/references_spec.clj
@@ -1,0 +1,10 @@
+(ns blaze.fhir.spec.references-spec
+  (:require
+   [blaze.fhir.spec.references :as fsr]
+   [blaze.fhir.spec.spec]
+   [blaze.fhir.spec.type.system-spec]
+   [clojure.spec.alpha :as s]))
+
+(s/fdef fsr/split-literal-ref
+  :args (s/cat :s string?)
+  :ret (s/nilable :blaze.fhir/literal-ref-tuple))

--- a/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
@@ -1,6 +1,7 @@
 (ns blaze.fhir.spec.spec
   (:require
    [blaze.fhir.spec.impl]
+   [blaze.fhir.spec.references :as fsr]
    [clojure.alpha.spec :as s2]
    [clojure.spec.alpha :as s]
    [clojure.string :as str]))
@@ -17,13 +18,12 @@
 (s/def :blaze.resource/id
   (s/and string? #(re-matches #"[A-Za-z0-9\-\.]{1,64}" %)))
 
-(s/def :blaze.fhir/local-ref-tuple
+(s/def :blaze.fhir/literal-ref-tuple
   (s/tuple :fhir.resource/type :blaze.resource/id))
 
-(s/def :blaze.fhir/local-ref
+(s/def :blaze.fhir/literal-ref
   (s/and string?
-         (s/conformer #(str/split % #"/" 2))
-         :blaze.fhir/local-ref-tuple))
+         (s/conformer #(or (fsr/split-literal-ref %) ::s/invalid))))
 
 (s/def :blaze/resource
   #(s2/valid? :fhir/Resource %))

--- a/modules/fhir-structure/src/blaze/fhir/spec/type_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type_spec.clj
@@ -16,7 +16,7 @@
 
 (s/fdef type/references
   :args (s/cat :x any?)
-  :ret (s/coll-of :blaze.fhir/local-ref-tuple))
+  :ret (s/coll-of :blaze.fhir/literal-ref-tuple))
 
 (s/fdef type/boolean
   :args (s/cat :value (s/alt :value boolean? :extended map?))

--- a/modules/fhir-structure/test/blaze/fhir/spec/references_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/references_test.clj
@@ -1,0 +1,29 @@
+(ns blaze.fhir.spec.references-test
+  (:require
+   [blaze.fhir.spec.references :as fsr]
+   [blaze.fhir.spec.references-spec]
+   [blaze.test-util :as tu :refer [satisfies-prop]]
+   [clojure.spec.test.alpha :as st]
+   [clojure.test :as test :refer [are deftest testing]]
+   [clojure.test.check.generators :as gen]
+   [clojure.test.check.properties :as prop]))
+
+(st/instrument)
+
+(test/use-fixtures :each tu/fixture)
+
+(deftest split-literal-ref-test
+  (testing "valid refs"
+    (are [ref type id] (= [type id] (fsr/split-literal-ref ref))
+      "Patient/0" "Patient" "0"
+      "/Library/0" "Library" "0"
+      "//Measure/1" "Measure" "1"))
+
+  (testing "invalid refs"
+    (are [ref] (nil? (fsr/split-literal-ref ref))
+      "http://localhost:8080/fhir/Patient/0"))
+
+  (testing "works on arbitrary strings"
+    (satisfies-prop 10000
+      (prop/for-all [s gen/string]
+        (any? (fsr/split-literal-ref s))))))

--- a/modules/fhir-structure/test/blaze/fhir/spec/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/spec_test.clj
@@ -1,0 +1,31 @@
+(ns blaze.fhir.spec.spec-test
+  (:require
+   [blaze.fhir.spec.spec]
+   [blaze.test-util :as tu :refer [satisfies-prop]]
+   [clojure.spec.alpha :as s]
+   [clojure.spec.test.alpha :as st]
+   [clojure.test :as test :refer [are deftest testing]]
+   [clojure.test.check.generators :as gen]
+   [clojure.test.check.properties :as prop]))
+
+(st/instrument)
+
+(test/use-fixtures :each tu/fixture)
+
+(deftest split-literal-ref-test
+  (testing "valid refs"
+    (are [ref type id] (= [type id] (s/conform :blaze.fhir/literal-ref ref))
+      "Patient/0" "Patient" "0"
+      "/Library/0" "Library" "0"
+      "//Measure/1" "Measure" "1"))
+
+  (testing "invalid refs"
+    (are [ref] (s/invalid? (s/conform :blaze.fhir/literal-ref ref))
+      "Patient/_"
+      "patient/0"
+      "http://localhost:8080/fhir/Patient/0"))
+
+  (testing "works on arbitrary strings"
+    (satisfies-prop 10000
+      (prop/for-all [s gen/string]
+        (any? (s/conform :blaze.fhir/literal-ref s))))))

--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -85,11 +85,6 @@
     "A"
     "0"))
 
-(deftest local-ref-spec-test
-  (is (= ["Patient" "0"] (s/conform :blaze.fhir/local-ref "Patient/0")))
-
-  (is (s/invalid? (s/conform :blaze.fhir/local-ref "Patient/0/1"))))
-
 (deftest patient-id-test
   (are [s] (s2/valid? :fhir.Patient/id s)
     "."

--- a/modules/interaction/test/blaze/interaction/transaction/bundle/url_spec.clj
+++ b/modules/interaction/test/blaze/interaction/transaction/bundle/url_spec.clj
@@ -7,5 +7,5 @@
 (s/fdef url/match-url
   :args (s/cat :url string?)
   :ret (s/or :type-level (s/tuple :fhir.resource/type)
-             :instance-level :blaze.fhir/local-ref-tuple
+             :instance-level :blaze.fhir/literal-ref-tuple
              :other nil?))

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/spec.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/spec.clj
@@ -11,7 +11,7 @@
 
 (s/def ::measure/subject-ref
   (s/or :id :blaze.resource/id
-        :local-ref :blaze.fhir/local-ref-tuple))
+        :local-ref :blaze.fhir/literal-ref-tuple))
 
 (s/def ::measure/population-handle
   ed/resource?)

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
@@ -58,8 +58,8 @@
 
 (defn- coerce-subject-ref-param [{{:strs [subject]} :params}]
   (when subject
-    (let [local-ref (s/conform :blaze.fhir/local-ref subject)]
-      (if (s/invalid? local-ref)
+    (let [literal-ref (s/conform :blaze.fhir/literal-ref subject)]
+      (if (s/invalid? literal-ref)
         (if (s/valid? :blaze.resource/id subject)
           subject
           (ba/incorrect
@@ -67,7 +67,7 @@
            :fhir/issue "value"
            :fhir/operation-outcome "MSG_PARAM_INVALID"
            :fhir.issue/expression "subject"))
-        local-ref))))
+        literal-ref))))
 
 (def ^:private no-subject-list-on-get-msg
   "The parameter `reportType` with value `subject-list` is not supported for GET requests. Please use POST or one of `subject` or `population`.")


### PR DESCRIPTION
Before, we did just split the library reference by / and expected the second part to be the library id. Now we ensure that the library reference is a valid :blaze.fhir/literal-ref and that the resource type is Library.