### PR TITLE
Remove Direct Byte Buffer Usage

### DIFF
--- a/modules/byte-buffer/src/blaze/byte_buffer.clj
+++ b/modules/byte-buffer/src/blaze/byte_buffer.clj
@@ -29,11 +29,6 @@
   [capacity]
   (ByteBuffer/allocate capacity))
 
-(defn allocate-direct
-  {:inline (fn [capacity] `(ByteBuffer/allocateDirect ~capacity))}
-  [capacity]
-  (ByteBuffer/allocateDirect capacity))
-
 (defn wrap
   {:inline (fn [byte-array] `(ByteBuffer/wrap ~byte-array))}
   [byte-array]

--- a/modules/kv/src/blaze/db/kv.clj
+++ b/modules/kv/src/blaze/db/kv.clj
@@ -83,11 +83,11 @@
   "Puts the key of current entry of `iter` in `buf`.
 
   Uses the position of `buf` and sets the limit of `buf` according to the key
-  size. Supports direct buffers only.
+  size.
 
   Returns the size of the actual key. If the key is greater than the length of
   `buf`, then it indicates that the size of the `buf` is insufficient and a
-  partial result is put."
+  partial result was returned."
   [iter buf]
   (p/-key iter buf))
 
@@ -102,11 +102,11 @@
   "Puts the value of current entry of `iter` in `buf`.
 
   Uses the position of `buf` and sets the limit of `buf` according to the value
-  size. Supports direct buffers only.
+  size.
 
   Returns the size of the actual value. If the value is greater than the length
   of `buf`, then it indicates that the size of the `buf` is insufficient and a
-  partial result is put."
+  partial result was returned."
   [iter buf]
   (p/-value iter buf))
 

--- a/modules/kv/src/blaze/db/kv_spec.clj
+++ b/modules/kv/src/blaze/db/kv_spec.clj
@@ -6,9 +6,6 @@
    [blaze.db.kv.spec]
    [clojure.spec.alpha :as s]))
 
-(defn- direct-buffer? [x]
-  (and (bb/byte-buffer? x) (bb/direct? x)))
-
 (s/fdef kv/valid?
   :args (s/cat :iter ::kv/iterator)
   :ret boolean?)
@@ -23,7 +20,7 @@
   :args (s/cat :iter ::kv/iterator :target bytes?))
 
 (s/fdef kv/seek-buffer!
-  :args (s/cat :iter ::kv/iterator :target direct-buffer?))
+  :args (s/cat :iter ::kv/iterator :target bb/byte-buffer?))
 
 (s/fdef kv/seek-for-prev!
   :args (s/cat :iter ::kv/iterator :target bytes?))
@@ -39,7 +36,7 @@
   :ret bytes?)
 
 (s/fdef kv/key!
-  :args (s/cat :iter ::kv/iterator :buf direct-buffer?)
+  :args (s/cat :iter ::kv/iterator :buf bb/byte-buffer?)
   :ret nat-int?)
 
 (s/fdef kv/value
@@ -47,7 +44,7 @@
   :ret bytes?)
 
 (s/fdef kv/value!
-  :args (s/cat :iter ::kv/iterator :buf direct-buffer?)
+  :args (s/cat :iter ::kv/iterator :buf bb/byte-buffer?)
   :ret nat-int?)
 
 (s/fdef kv/new-iterator

--- a/modules/kv/test/blaze/db/kv/mem_test.clj
+++ b/modules/kv/test/blaze/db/kv/mem_test.clj
@@ -46,9 +46,7 @@
   (byte-array bytes))
 
 (defn- bb [& bytes]
-  (-> (bb/allocate-direct (count bytes))
-      (bb/put-byte-array! (byte-array bytes))
-      bb/flip!))
+  (bb/wrap (byte-array bytes)))
 
 (deftest init-test
   (testing "nil config"
@@ -397,23 +395,23 @@
 
         (testing "errors on invalid iterator"
           (is (iterator-invalid-anom? (ba/try-anomaly (kv/key iter))))
-          (is (iterator-invalid-anom? (ba/try-anomaly (kv/key! iter (bb/allocate-direct 0))))))
+          (is (iterator-invalid-anom? (ba/try-anomaly (kv/key! iter (bb/allocate 0))))))
 
         (testing "puts the first byte into the buffer without overflowing"
           (kv/seek-to-first! iter)
-          (let [buf (bb/allocate-direct 1)]
+          (let [buf (bb/allocate 1)]
             (is (= 2 (kv/key! iter buf)))
             (is (= 0x01 (bb/get-byte! buf)))))
 
         (testing "sets the limit of a bigger buffer to two"
           (kv/seek-to-first! iter)
-          (let [buf (bb/allocate-direct 3)]
+          (let [buf (bb/allocate 3)]
             (is (= 2 (kv/key! iter buf)))
             (is (= 2 (bb/limit buf)))))
 
         (testing "writes the key at position"
           (kv/seek-to-first! iter)
-          (let [buf (bb/allocate-direct 3)]
+          (let [buf (bb/allocate 3)]
             (bb/set-position! buf 1)
             (is (= 2 (kv/key! iter buf)))
             (is (= 1 (bb/position buf)))
@@ -425,7 +423,7 @@
         (testing "errors on closed iterator"
           (close! iter)
           (is (iterator-closed-anom? (ba/try-anomaly (kv/key iter))))
-          (is (iterator-closed-anom? (ba/try-anomaly (kv/key! iter (bb/allocate-direct 0))))))))))
+          (is (iterator-closed-anom? (ba/try-anomaly (kv/key! iter (bb/allocate 0))))))))))
 
 (deftest value-test
   (with-system-data [{kv-store ::kv/mem} config]
@@ -437,23 +435,23 @@
 
         (testing "errors on invalid iterator"
           (is (iterator-invalid-anom? (ba/try-anomaly (kv/value iter))))
-          (is (iterator-invalid-anom? (ba/try-anomaly (kv/value! iter (bb/allocate-direct 0))))))
+          (is (iterator-invalid-anom? (ba/try-anomaly (kv/value! iter (bb/allocate 0))))))
 
         (testing "puts the first byte into the buffer without overflowing"
           (kv/seek-to-first! iter)
-          (let [buf (bb/allocate-direct 1)]
+          (let [buf (bb/allocate 1)]
             (is (= 2 (kv/value! iter buf)))
             (is (= 0x01 (bb/get-byte! buf)))))
 
         (testing "sets the limit of a bigger buffer to two"
           (kv/seek-to-first! iter)
-          (let [buf (bb/allocate-direct 3)]
+          (let [buf (bb/allocate 3)]
             (is (= 2 (kv/value! iter buf)))
             (is (= 2 (bb/limit buf)))))
 
         (testing "writes the value at position"
           (kv/seek-to-first! iter)
-          (let [buf (bb/allocate-direct 3)]
+          (let [buf (bb/allocate 3)]
             (bb/set-position! buf 1)
             (is (= 2 (kv/value! iter buf)))
             (is (= 1 (bb/position buf)))
@@ -465,7 +463,7 @@
         (testing "errors on closed iterator"
           (close! iter)
           (is (iterator-closed-anom? (ba/try-anomaly (kv/value iter))))
-          (is (iterator-closed-anom? (ba/try-anomaly (kv/value! iter (bb/allocate-direct 0))))))))))
+          (is (iterator-closed-anom? (ba/try-anomaly (kv/value! iter (bb/allocate 0))))))))))
 
 (deftest different-column-families-test
   (with-system-data [{kv-store ::kv/mem} a-b-config]

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
@@ -35,9 +35,7 @@
   (byte-array bytes))
 
 (defn- bb [& bytes]
-  (-> (bb/allocate-direct (count bytes))
-      (bb/put-byte-array! (byte-array bytes))
-      bb/flip!))
+  (bb/wrap (byte-array bytes)))
 
 (deftest init-test
   (testing "nil config"
@@ -444,19 +442,19 @@
 
       (testing "puts the first byte into the buffer without overflowing"
         (kv/seek-to-first! iter)
-        (let [buf (bb/allocate-direct 1)]
+        (let [buf (bb/allocate 1)]
           (is (= 2 (kv/key! iter buf)))
           (is (= 0x01 (bb/get-byte! buf)))))
 
       (testing "sets the limit of a bigger buffer to two"
         (kv/seek-to-first! iter)
-        (let [buf (bb/allocate-direct 3)]
+        (let [buf (bb/allocate 3)]
           (is (= 2 (kv/key! iter buf)))
           (is (= 2 (bb/limit buf)))))
 
       (testing "writes the key at position"
         (kv/seek-to-first! iter)
-        (let [buf (bb/allocate-direct 3)]
+        (let [buf (bb/allocate 3)]
           (bb/set-position! buf 1)
           (is (= 2 (kv/key! iter buf)))
           (is (= 1 (bb/position buf)))
@@ -474,19 +472,19 @@
 
       (testing "puts the first byte into the buffer without overflowing"
         (kv/seek-to-first! iter)
-        (let [buf (bb/allocate-direct 1)]
+        (let [buf (bb/allocate 1)]
           (is (= 2 (kv/value! iter buf)))
           (is (= 0x01 (bb/get-byte! buf)))))
 
       (testing "sets the limit of a bigger buffer to two"
         (kv/seek-to-first! iter)
-        (let [buf (bb/allocate-direct 3)]
+        (let [buf (bb/allocate 3)]
           (is (= 2 (kv/value! iter buf)))
           (is (= 2 (bb/limit buf)))))
 
       (testing "writes the value at position"
         (kv/seek-to-first! iter)
-        (let [buf (bb/allocate-direct 3)]
+        (let [buf (bb/allocate 3)]
           (bb/set-position! buf 1)
           (is (= 2 (kv/value! iter buf)))
           (is (= 1 (bb/position buf)))


### PR DESCRIPTION
Since RocksDB v8.10.0 the byte buffers don't need to be direct anymore. This commit removes any notion of direct byte buffers from the key value store API.