### PR TITLE
Improve Secondary Search Clause Matching

### DIFF
--- a/modules/db/src/blaze/db/impl/index/resource_search_param_value.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_search_param_value.clj
@@ -63,6 +63,15 @@
                  (+ (- (bs/size target) (bs/size value)) (long value-prefix-length))
                  target))))
 
+(defn value-prefix-exists?
+  "Returns true iff a key encoded from `resource-handle`, `c-hash` and
+  `value-prefix` exists."
+  {:arglists '([snapshot resource-handle c-hash value-prefix])}
+  [snapshot {:keys [tid id hash]} c-hash value-prefix]
+  (let [id (codec/id-byte-string id)
+        target (encode-key tid id hash c-hash value-prefix)]
+    (i/contains-key-prefix? snapshot :resource-value-index target)))
+
 (defn next-value-prev
   "Returns the decoded value of the key that is at or before the key encoded
   from `resource-handle`, `c-hash`, `value` and with `value-prefix-length` bytes

--- a/modules/db/src/blaze/db/impl/iterators.clj
+++ b/modules/db/src/blaze/db/impl/iterators.clj
@@ -17,6 +17,18 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
+(defn contains-key-prefix?
+  "Returns true iff a key with `key-prefix` exists in `column-family`."
+  [snapshot column-family key-prefix]
+  (with-open [iter (kv/new-iterator snapshot column-family)]
+    (let [target (bs/to-byte-array key-prefix)]
+      (kv/seek! iter target)
+      (when (kv/valid? iter)
+        (let [target-buf (bb/wrap target)
+              key-buf (bb/allocate (bs/size key-prefix))]
+          (kv/key! iter key-buf)
+          (= key-buf target-buf))))))
+
 (defn- prefix-matches? [target prefix-length buf]
   (let [prefix-buf (bb/allocate prefix-length)]
     (bb/put-byte-string! prefix-buf (bs/subs target 0 prefix-length))

--- a/modules/db/src/blaze/db/impl/search_param/composite/token_token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/composite/token_token.clj
@@ -3,6 +3,7 @@
    [blaze.anomaly :refer [when-ok]]
    [blaze.byte-string :as bs]
    [blaze.coll.core :as coll]
+   [blaze.db.impl.index.resource-search-param-value :as r-sp-v]
    [blaze.db.impl.protocols :as p]
    [blaze.db.impl.search-param.composite.common :as cc]
    [blaze.db.impl.search-param.token :as spt]
@@ -34,7 +35,7 @@
      (spt/resource-keys context c-hash tid value)))
 
   (-matches? [_ context resource-handle _ values]
-    (some? (some (partial spt/matches? (:snapshot context) c-hash resource-handle) values)))
+    (some (partial r-sp-v/value-prefix-exists? (:snapshot context) resource-handle c-hash) values))
 
   (-index-values [_ resolver resource]
     (when-ok [values (fhir-path/eval resolver main-expression resource)]

--- a/modules/db/src/blaze/db/impl/search_param/string.clj
+++ b/modules/db/src/blaze/db/impl/search_param/string.clj
@@ -75,9 +75,6 @@
      (sp-vr/prefix-keys snapshot c-hash tid (bs/size start-value) start-value
                         start-id))))
 
-(defn- matches? [snapshot c-hash resource-handle value]
-  (some? (r-sp-v/next-value snapshot resource-handle c-hash (bs/size value) value)))
-
 (defrecord SearchParamString [name type base code c-hash expression normalize]
   p/SearchParam
   (-compile-value [_ _ value]
@@ -99,7 +96,7 @@
      (resource-keys context c-hash tid value)))
 
   (-matches? [_ context resource-handle _ values]
-    (some? (some (partial matches? (:snapshot context) c-hash resource-handle) values)))
+    (some (partial r-sp-v/value-prefix-exists? (:snapshot context) resource-handle c-hash) values))
 
   (-index-values [search-param resolver resource]
     (when-ok [values (fhir-path/eval resolver expression resource)]

--- a/modules/db/src/blaze/db/impl/search_param/token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/token.clj
@@ -144,9 +144,6 @@
   ([{:keys [snapshot]} c-hash tid value start-id]
    (sp-vr/prefix-keys snapshot c-hash tid (bs/size value) value start-id)))
 
-(defn matches? [snapshot c-hash resource-handle value]
-  (some? (r-sp-v/next-value snapshot resource-handle c-hash (bs/size value) value)))
-
 (defrecord SearchParamToken [name url type base code target c-hash expression]
   p/SearchParam
   (-compile-value [_ _ value]
@@ -174,7 +171,7 @@
     (c-sp-vr/prefix-keys (:snapshot context) compartment c-hash tid value))
 
   (-matches? [_ context resource-handle modifier values]
-    (some? (some (partial matches? (:snapshot context) (c-hash-w-modifier c-hash code modifier) resource-handle) values)))
+    (some (partial r-sp-v/value-prefix-exists? (:snapshot context) resource-handle (c-hash-w-modifier c-hash code modifier)) values))
 
   (-compartment-ids [_ resolver resource]
     (when-ok [values (fhir-path/eval resolver expression resource)]

--- a/modules/db/test/blaze/db/impl/index/resource_search_param_value_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_search_param_value_spec.clj
@@ -15,6 +15,13 @@
                                   :value byte-string?)))
   :ret (s/nilable byte-string?))
 
+(s/fdef r-sp-v/value-prefix-exists?
+  :args (s/cat :snapshot :blaze.db.kv/snapshot
+               :resource-handle :blaze.db/resource-handle
+               :c-hash :blaze.db/c-hash
+               :value-prefix byte-string?)
+  :ret boolean?)
+
 (s/fdef r-sp-v/next-value-prev
   :args (s/cat :snapshot :blaze.db.kv/snapshot
                :resource-handle :blaze.db/resource-handle

--- a/modules/db/test/blaze/db/impl/iterators_spec.clj
+++ b/modules/db/test/blaze/db/impl/iterators_spec.clj
@@ -10,6 +10,12 @@
    [blaze.db.kv-spec]
    [clojure.spec.alpha :as s]))
 
+(s/fdef i/contains-key-prefix?
+  :args (s/cat :snapshot :blaze.db.kv/snapshot
+               :column-family (s/? keyword?)
+               :key-prefix byte-string?)
+  :ret boolean?)
+
 (s/fdef i/seek-key
   :args (s/and (s/cat :snapshot :blaze.db.kv/snapshot
                       :column-family (s/? keyword?) :decode fn?

--- a/modules/db/test/blaze/db/impl/search_param/token_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param/token_spec.clj
@@ -18,9 +18,3 @@
                :tid :blaze.db/tid
                :value byte-string?
                :start-id (s/? :blaze.db/id-byte-string)))
-
-(s/fdef spt/matches?
-  :args (s/cat :snapshot :blaze.db.kv/snapshot
-               :c-hash :blaze.db/c-hash
-               :resource-handle :blaze.db/resource-handle
-               :value byte-string?))


### PR DESCRIPTION
With the new function blaze.db.impl.iterators/contains-key-prefix? the seek into ResourceSearchParamValue index doesn't have the read the key back for token and string search.