### PR TITLE
Improve other-clauses-filter Function

### DIFF
--- a/modules/db/src/blaze/db/impl/index.clj
+++ b/modules/db/src/blaze/db/impl/index.clj
@@ -8,15 +8,16 @@
    [blaze.db.impl.search-param :as search-param]
    [blaze.db.impl.search-param.util :as u]))
 
-(defn- other-clauses-filter [context clauses]
-  (filter
-   (fn [resource-handle]
-     (loop [[[search-param modifier _ values] & clauses] clauses]
-       (if search-param
-         (when (search-param/matches? search-param context resource-handle
-                                      modifier values)
-           (recur clauses))
-         true)))))
+(defn- other-clauses-filter
+  "Creates a filter xform for all `clauses` by possibly composing multiple
+  filter xforms for each clause."
+  [context clauses]
+  (transduce
+   (map
+    (fn [[search-param modifier _ values]]
+      (filter #(search-param/matches? search-param context % modifier values))))
+   comp
+   clauses))
 
 (defn- resource-handles
   ([search-param context tid modifier values]

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -2672,7 +2672,15 @@
             count := 4)
 
           (testing "count query"
-            (is (= 4 (count-type-query node "Observation" clauses))))))))
+            (is (= 4 (count-type-query node "Observation" clauses))))))
+
+      (testing "three clauses"
+        (given (pull-type-query node "Observation" [["_profile:below" "profile-uri-091902"]
+                                                    ["status" "final"]
+                                                    ["date" "2021"]])
+          count := 2
+          [0 :id] := "id-0"
+          [1 :id] := "id-1"))))
 
   (testing "Observation"
     (with-system-data [{:blaze.db/keys [node]} config]


### PR DESCRIPTION
Before one filter xform was created that looped over the clauses, now a function composition of one filter per clause is created. The new xform will still short cut after the first non-match and has the advantage that the clauses do not have to be looped over in every filter step.