### PR TITLE
Improve Iterator Handling in Other Filters

### DIFF
--- a/dev/blaze/dev/rocksdb.clj
+++ b/dev/blaze/dev/rocksdb.clj
@@ -18,7 +18,11 @@
 
 (comment
   (rocksdb/compact-range! (index-kv-store) :resource-as-of-index)
+  (rocksdb/compact-range! (index-kv-store) :type-as-of-index)
+  (rocksdb/compact-range! (index-kv-store) :system-as-of-index)
   (rocksdb/compact-range! (index-kv-store) :search-param-value-index)
+  (rocksdb/compact-range! (index-kv-store) :compartment-search-param-value-index)
+  (rocksdb/compact-range! (index-kv-store) :resource-value-index)
 
   (mapv
     (fn [^ThreadStatus status]

--- a/docs/performance/fhir-search.md
+++ b/docs/performance/fhir-search.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-Under ideal conditions, Blaze can execute a FHIR Search query for a single code in **0.5 seconds per 1 million found resources** and export the matching resources in **20 seconds per 1 million found resources**, independent of the total number of resources hold.
+Under ideal conditions, Blaze can execute a FHIR Search query for a single code in **0.5 seconds per 1 million found resources** and export the matching resources in **17 seconds per 1 million found resources**, independent of the total number of resources hold.
 
 ## Systems
 
@@ -49,15 +49,18 @@ curl -s "http://localhost:8080/fhir/Observation?code=http://loinc.org|$CODE&_sum
 
 | System | Dataset | Code    | # Hits | Time (s) | StdDev | T/1M ¹ |
 |--------|---------|---------|-------:|---------:|-------:|-------:|
-| LEA47  | 100k    | 8310-5  |  115 k |     0.08 |  0.005 |   0.66 |
-| LEA47  | 100k    | 55758-7 |  1.0 M |     0.56 |  0.017 |   0.55 |
-| LEA47  | 100k    | 72514-3 |  2.7 M |     1.63 |  0.017 |   0.59 |
-| CCX42  | 100k    | 8310-5  |  115 k |     0.07 |  0.005 |   0.62 |
-| CCX42  | 100k    | 55758-7 |  1.0 M |     0.53 |  0.062 |   0.52 |
-| CCX42  | 100k    | 72514-3 |  2.7 M |     1.31 |  0.017 |   0.47 |
-| LEA47  | 1M      | 8310-5  |  1.1 M |     0.67 |  0.011 |   0.57 |
-| LEA47  | 1M      | 55758-7 | 10.1 M |     6.08 |  0.066 |   0.59 |
-| LEA47  | 1M      | 72514-3 | 27.3 M |    16.37 |  0.234 |   0.59 |
+| LEA47  | 100k    | 8310-5  |  115 k |     0.06 |  0.001 |   0.55 |
+| LEA47  | 100k    | 55758-7 |  1.0 M |     0.50 |  0.012 |   0.49 |
+| LEA47  | 100k    | 72514-3 |  2.7 M |     1.35 |  0.056 |   0.49 |
+| LEA58  | 100k    | 8310-5  |  115 k |     0.06 |  0.001 |   0.55 |
+| LEA58  | 100k    | 55758-7 |  1.0 M |     0.52 |  0.011 |   0.51 |
+| LEA58  | 100k    | 72514-3 |  2.7 M |     1.39 |  0.027 |   0.50 |
+| LEA47  | 1M      | 8310-5  |  1.1 M |     0.59 |  0.006 |   0.50 |
+| LEA47  | 1M      | 55758-7 | 10.1 M |     5.45 |  0.182 |   0.53 |
+| LEA47  | 1M      | 72514-3 | 27.3 M |    14.03 |  0.135 |   0.51 |
+| LEA58  | 1M      | 8310-5  |  1.1 M |     0.60 |  0.011 |   0.51 |
+| LEA58  | 1M      | 55758-7 | 10.1 M |     5.17 |  0.077 |   0.50 |
+| LEA58  | 1M      | 72514-3 | 27.3 M |    13.77 |  0.244 |   0.50 |
 
 ¹ time in seconds per 1 million resources
 
@@ -73,21 +76,24 @@ Download is done using the following `blazectl` command:
 blazectl download --server http://localhost:8080/fhir Observation -q "code=http://loinc.org|$CODE&_count=1000" > /dev/null"
 ```
 
-| System | Dataset | Code    | # Hits | Time (s) |  StdDev |  T/1M ¹ |
-|--------|---------|---------|-------:|---------:|--------:|--------:|
-| LEA47  | 100k    | 8310-5  |  115 k |     2.06 |   0.014 |   17.88 |  
-| LEA47  | 100k    | 55758-7 |  1.0 M |    17.34 |   0.175 |   17.21 |
-| LEA47  | 100k    | 72514-3 |  2.7 M |    45.62 |   0.464 |   16.60 |
-| CCX42  | 100k    | 8310-5  |  115 k |     2.46 |   0.044 |   21.34 |           
-| CCX42  | 100k    | 55758-7 |  1.0 M |    19.74 |   0.237 |   19.60 |         
-| CCX42  | 100k    | 72514-3 |  2.7 M |    52.95 |   0.484 |   19.26 |         
-| LEA47  | 1M      | 8310-5  |  1.1 M |    21.51 |   0.192 |   18.55 |         
-| LEA47  | 1M      | 55758-7 | 10.1 M |   233.01 |   2.150 |   22.98 |         
-| LEA47  | 1M      | 72514-3 | 27.3 M |   966.59 | 150.132 | 35.34 ² |
+| System | Dataset | Code    | # Hits | Time (s) | StdDev |  T/1M ¹ |
+|--------|---------|---------|-------:|---------:|-------:|--------:|
+| LEA47  | 100k    | 8310-5  |  115 k |     2.00 |  0.021 |   17.33 |  
+| LEA47  | 100k    | 55758-7 |  1.0 M |    15.99 |  0.147 |   15.87 |
+| LEA47  | 100k    | 72514-3 |  2.7 M |    43.48 |  0.128 |   15.82 |
+| LEA58  | 100k    | 8310-5  |  115 k |     1.96 |  0.039 |   17.04 |  
+| LEA58  | 100k    | 55758-7 |  1.0 M |    16.61 |  0.161 |   16.48 |
+| LEA58  | 100k    | 72514-3 |  2.7 M |    43.84 |  0.124 |   15.95 |         
+| LEA47  | 1M      | 8310-5  |  1.1 M |    19.88 |  0.206 |   17.15 |         
+| LEA47  | 1M      | 55758-7 | 10.1 M |   208.97 |  5.157 | 20.60 ² |         
+| LEA47  | 1M      | 72514-3 | 27.3 M |   799.61 |  9.035 | 29.24 ² |
+| LEA58  | 1M      | 8310-5  |  1.1 M |    18.95 |  0.075 |   16.34 |         
+| LEA58  | 1M      | 55758-7 | 10.1 M |   160.31 |  0.976 |   15.80 |         
+| LEA58  | 1M      | 72514-3 | 27.3 M |   498.38 |  9.773 | 18.22 ² |         
 
-¹ time in seconds per 1 million resources, ² resource cache size (10 million) is smaller than the number of resources returned (27.3 million)
+¹ time in seconds per 1 million resources, ² resource cache size is smaller than the number of resources returned
 
-According to the measurements the time needed by Blaze to deliver resources only depends on the number of hits and equals roughly in **20 seconds per 1 million hits**.
+According to the measurements the time needed by Blaze to deliver resources only depends on the number of hits and equals roughly in **17 seconds per 1 million hits**.
 
 ### Download of Resources with Subsetting
 
@@ -103,19 +109,22 @@ blazectl download --server http://localhost:8080/fhir Observation -q "code=http:
 
 | System | Dataset | Code    | # Hits | Time (s) | StdDev |  T/1M ¹ |
 |--------|---------|---------|-------:|---------:|-------:|--------:|
-| LEA47  | 100k    | 8310-5  |  115 k |     1.42 |  0.043 |   12.32 |
-| LEA47  | 100k    | 55758-7 |  1.0 M |    10.96 |  0.097 |   10.87 |
-| LEA47  | 100k    | 72514-3 |  2.7 M |    27.62 |  0.277 |   10.05 |
-| CCX42  | 100k    | 8310-5  |  115 k |     1.78 |  0.052 |   15.41 |           
-| CCX42  | 100k    | 55758-7 |  1.0 M |    14.46 |  0.177 |   14.35 |           
-| CCX42  | 100k    | 72514-3 |  2.7 M |    37.82 |  0.107 |   13.76 |
-| LEA47  | 1M      | 8310-5  |  1.1 M |    15.21 |  0.161 |   13.11 |          
-| LEA47  | 1M      | 55758-7 | 10.1 M |   167.34 |  0.942 |   16.50 |          
-| LEA47  | 1M      | 72514-3 | 27.3 M |   662.15 |  8.179 | 24.21 ² |
+| LEA47  | 100k    | 8310-5  |  115 k |     1.34 |  0.009 |   11.60 |
+| LEA47  | 100k    | 55758-7 |  1.0 M |     9.95 |  0.065 |    9.87 |
+| LEA47  | 100k    | 72514-3 |  2.7 M |    26.76 |  0.284 |    9.73 |
+| LEA58  | 100k    | 8310-5  |  115 k |     1.28 |  0.017 |   11.08 |
+| LEA58  | 100k    | 55758-7 |  1.0 M |    10.55 |  0.209 |   10.47 |
+| LEA58  | 100k    | 72514-3 |  2.7 M |    27.15 |  0.749 |    9.87 |
+| LEA47  | 1M      | 8310-5  |  1.1 M |    13.13 |  0.085 |   11.32 |          
+| LEA47  | 1M      | 55758-7 | 10.1 M |   146.38 |  1.231 | 14.43 ² |          
+| LEA47  | 1M      | 72514-3 | 27.3 M |   602.81 |  8.866 | 22.04 ² |
+| LEA58  | 1M      | 8310-5  |  1.1 M |    12.28 |  0.351 |   10.59 |          
+| LEA58  | 1M      | 55758-7 | 10.1 M |   103.67 |  1.057 |   10.22 |          
+| LEA58  | 1M      | 72514-3 | 27.3 M |   309.76 |  1.580 | 11.32 ² |          
 
-¹ time in seconds per 1 million resources, ² resource cache size (10 million) is smaller than the number of resources returned (27.3 million)
+¹ time in seconds per 1 million resources, ² resource cache size is smaller than the number of resources returned
 
-According to the measurements, the time needed by Blaze to deliver subsetted Observations containing only the subject reference only depends on the number of hits and equals roughly in **15 seconds per 1 million hits**.
+According to the measurements, the time needed by Blaze to deliver subsetted Observations containing only the subject reference only depends on the number of hits and equals roughly in **11 seconds per 1 million hits**.
 
 ## Code and Value Search
 
@@ -131,18 +140,12 @@ curl -s "http://localhost:8080/fhir/Observation?code=http://loinc.org|$CODE&valu
 
 | System | Dataset | Code    | Value | # Hits | Time (s) | StdDev | T/1M ¹ |
 |--------|---------|---------|------:|-------:|---------:|-------:|-------:|
-| LEA47  | 100k    | 29463-7 |  26.8 |  158 k |    12.90 |  0.053 |  81.63 |
-| LEA47  | 100k    | 29463-7 |  79.5 |  790 k |    13.27 |  0.139 |  16.80 |
-| LEA47  | 100k    | 29463-7 |   183 |  1.6 M |    13.73 |  0.157 |   8.67 |
-| LEA58  | 100k    | 29463-7 |  26.8 |  158 k |    12.26 |  0.061 |  77.55 |
-| LEA58  | 100k    | 29463-7 |  79.5 |  790 k |    12.39 |  0.027 |  15.69 |
-| LEA58  | 100k    | 29463-7 |   183 |  1.6 M |    12.88 |  0.100 |   8.14 |
-| CCX42  | 100k    | 29463-7 |  26.8 |  158 k |    56.45 |  0.149 | 357.08 |
-| CCX42  | 100k    | 29463-7 |  79.5 |  790 k |    56.72 |  0.174 |  71.84 |
-| CCX42  | 100k    | 29463-7 |   183 |  1.6 M |    56.77 |  0.135 |  35.87 |
-| LEA47  | 1M      | 29463-7 |  26.8 |
-| LEA47  | 1M      | 29463-7 |  79.5 |
-| LEA47  | 1M      | 29463-7 |   183 |
+| LEA47  | 100k    | 29463-7 |  26.8 |  158 k |    10.47 |  0.038 |  66.21 |
+| LEA47  | 100k    | 29463-7 |  79.5 |  790 k |    10.77 |  0.040 |  13.64 |
+| LEA47  | 100k    | 29463-7 |   183 |  1.6 M |    10.73 |  0.028 |   6.77 |
+| LEA58  | 100k    | 29463-7 |  26.8 |  158 k |    10.33 |  0.055 |  65.33 |
+| LEA58  | 100k    | 29463-7 |  79.5 |  790 k |    10.58 |  0.045 |  13.39 |
+| LEA58  | 100k    | 29463-7 |   183 |  1.6 M |    10.95 |  0.037 |   6.91 |
 
 ¹ time in seconds per 1 million resources
 
@@ -160,18 +163,12 @@ blazectl download --server http://localhost:8080/fhir Observation -q "code=http:
 
 | System | Dataset | Code    | Value | # Hits | Time (s) | StdDev | T/1M ¹ |
 |--------|---------|---------|------:|-------:|---------:|-------:|-------:|
-| LEA47  | 100k    | 29463-7 |  26.8 |  158 k |    15.45 |  0.073 |  97.73 |
-| LEA47  | 100k    | 29463-7 |  79.5 |  790 k |    24.42 |  0.073 |  30.92 |
-| LEA47  | 100k    | 29463-7 |   183 |  1.6 M |    35.51 |  0.309 |  22.44 |
-| LEA58  | 100k    | 29463-7 |  26.8 |  158 k |    14.62 |  0.028 |  92.48 |
-| LEA58  | 100k    | 29463-7 |  79.5 |  790 k |    23.47 |  0.130 |  29.72 |
-| LEA58  | 100k    | 29463-7 |   183 |  1.6 M |    33.72 |  0.099 |  21.30 |
-| CCX42  | 100k    | 29463-7 |  26.8 |  158 k |    59.19 |  0.060 | 374.44 |
-| CCX42  | 100k    | 29463-7 |  79.5 |  790 k |    70.26 |  0.142 |  88.98 |
-| CCX42  | 100k    | 29463-7 |   183 |  1.6 M |    83.82 |  0.076 |  52.97 |
-| LEA47  | 1M      | 29463-7 |  26.8 |
-| LEA47  | 1M      | 29463-7 |  79.5 |
-| LEA47  | 1M      | 29463-7 |   183 |
+| LEA47  | 100k    | 29463-7 |  26.8 |  158 k |    12.84 |  0.016 |  81.22 |
+| LEA47  | 100k    | 29463-7 |  79.5 |  790 k |    21.83 |  0.128 |  27.64 |
+| LEA47  | 100k    | 29463-7 |   183 |  1.6 M |    32.86 |  0.291 |  20.76 |
+| LEA58  | 100k    | 29463-7 |  26.8 |  158 k |    12.78 |  0.025 |  80.82 |
+| LEA58  | 100k    | 29463-7 |  79.5 |  790 k |    21.95 |  0.193 |  27.80 |
+| LEA58  | 100k    | 29463-7 |   183 |  1.6 M |    31.63 |  0.333 |  19.99 |
 
 ¹ time in seconds per 1 million resources
 
@@ -189,59 +186,14 @@ blazectl download --server http://localhost:8080/fhir Observation -q "code=http:
 
 | System | Dataset | Code    | Value | # Hits | Time (s) | StdDev | T/1M ¹ |
 |--------|---------|---------|------:|-------:|---------:|-------:|-------:|
-| LEA47  | 100k    | 29463-7 |  26.8 |  158 k |    14.62 |  0.054 |  92.48 |
-| LEA47  | 100k    | 29463-7 |  79.5 |  790 k |    19.95 |  0.057 |  25.26 |
-| LEA47  | 100k    | 29463-7 |   183 |  1.6 M |    26.89 |  0.192 |  16.99 |
-| LEA58  | 100k    | 29463-7 |  26.8 |  158 k |    13.69 |  0.037 |  86.62 |
-| LEA58  | 100k    | 29463-7 |  79.5 |  790 k |    18.84 |  0.139 |  23.86 |
-| LEA58  | 100k    | 29463-7 |   183 |  1.6 M |    25.47 |  0.302 |  16.09 |
-| CCX42  | 100k    | 29463-7 |  26.8 |  158 k |    58.07 |  0.028 | 367.36 |
-| CCX42  | 100k    | 29463-7 |  79.5 |  790 k |    65.31 |  0.197 |  82.71 |
-| CCX42  | 100k    | 29463-7 |   183 |  1.6 M |    74.40 |  0.183 |  47.01 |
-| LEA47  | 1M      | 29463-7 |  26.8 |
-| LEA47  | 1M      | 29463-7 |  79.5 |
-| LEA47  | 1M      | 29463-7 |   183 |
+| LEA47  | 100k    | 29463-7 |  26.8 |  158 k |    11.98 |  0.029 |  75.78 |
+| LEA47  | 100k    | 29463-7 |  79.5 |  790 k |    17.38 |  0.095 |  22.01 |
+| LEA47  | 100k    | 29463-7 |   183 |  1.6 M |    23.44 |  0.177 |  14.81 |
+| LEA58  | 100k    | 29463-7 |  26.8 |  158 k |    11.90 |  0.021 |  75.25 |
+| LEA58  | 100k    | 29463-7 |  79.5 |  790 k |    17.22 |  0.047 |  21.80 |
+| LEA58  | 100k    | 29463-7 |   183 |  1.6 M |    23.18 |  0.217 |  14.64 |
 
 ¹ time in seconds per 1 million resources
-
-### Download of Resources using the Combined Search Param
-
-All measurements are done after Blaze is in a steady state with all resources to download in it's resource cache in order to cancel out resource load times from disk or file system cache.
-
-Download is done using the following `blazectl` command:
-
-```sh
-blazectl download --server http://localhost:8080/fhir Observation -q "code-value-quantity=http://loinc.org|$CODE\$lt$VALUE|http://unitsofmeasure.org|$UNIT&_count=1000" > /dev/null"
-```
-
-| CPU        | Heap Mem | Block Cache | # Res. ¹ | # Obs. ² | Code    | Value | # Hits | Time (s) | T / 1M ³ |
-|------------|---------:|------------:|---------:|---------:|---------|------:|-------:|---------:|---------:|
-| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 17861-6 |  8.67 |   17 k |      0.4 |       24 |
-| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 17861-6 |  9.35 |   86 k |      2.0 |       23 |
-| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 17861-6 |  10.2 |  171 k |      4.2 |       25 |
-
-¹ Total Number of Resources, ² Number of Observations, ³ Time in seconds per 1 million resources, EPYC 7543P - The system has 16 cores and 128 GB RAM, H. CCX42 - The system has 16 cores and 64 GB RAM.
-
-### Download of Resources with Subsetting
-
-In case only a subset of information of a resource is needed, the special [_elements][1] search parameter can be used to retrieve only certain properties of a resource. Here `_elements=subject` was used.
-
-All measurements are done after Blaze is in a steady state with all resources to download in it's resource cache in order to cancel out resource load times from disk or file system cache.
-
-Download is done using the following `blazectl` command:
-
-```sh
-blazectl download --server http://localhost:8080/fhir Observation -q "code=http://loinc.org|$CODE&value-quantity=lt$VALUE|http://unitsofmeasure.org|$UNIT&_elements=subject&_count=1000" > /dev/null"
-```
-
-| CPU        | Heap Mem | Block Cache | # Res. ¹ | # Obs. ² | Code    | Value | # Hits | Time (s) | T / 1M ³ |
-|------------|---------:|------------:|---------:|---------:|---------|------:|-------:|---------:|---------:|
-| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 17861-6 |  8.67 |   17 k |      0.2 |          |
-| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 17861-6 |  9.35 |   86 k |      1.3 |          |
-| EPYC 7543P |     8 GB |        2 GB |     29 M |     28 M | 17861-6 |  10.2 |  171 k |      2.4 |          |
-
-¹ Total Number of Resources, ² Number of Observations, ³ Time in seconds per 1 million resources, EPYC 7543P - The system has 16 cores and 128 GB RAM, H. CCX42 - The system has 16 cores and 64 GB RAM.
-
 
 ## Simple Date Search
 
@@ -257,10 +209,10 @@ curl -s "http://localhost:8080/fhir/Observation?date=$YEAR&_summary=count"
 
 | System | Dataset | Year | # Hits | Time (s) | StdDev | T/1M ¹ |
 |--------|---------|------|-------:|---------:|-------:|-------:|
-| LEA47  | 100k    | 2013 |  3.1 M |     2.56 |  0.024 |   0.81 |
-| LEA47  | 100k    | 2019 |  6.0 M |     4.82 |  0.138 |   0.80 |
-| CCX42  | 100k    | 2013 |  3.1 M |     2.00 |  0.028 |   0.63 |
-| CCX42  | 100k    | 2019 |  6.0 M |     3.91 |  0.142 |   0.65 |
+| LEA47  | 100k    | 2013 |  3.1 M |     2.24 |  0.036 |   0.71 |
+| LEA47  | 100k    | 2019 |  6.0 M |     4.17 |  0.136 |   0.69 |
+| LEA58  | 100k    | 2013 |  3.1 M |     2.35 |  0.058 |   0.75 |
+| LEA58  | 100k    | 2019 |  6.0 M |     4.19 |  0.031 |   0.70 |
 | LEA47  | 1M      | 2013 | 31.1 M |    23.31 |  0.206 |   0.75 |
 | LEA47  | 1M      | 2019 | 60.0 M |    45.98 |  0.582 |   0.76 |
 
@@ -278,10 +230,10 @@ blazectl download --server http://localhost:8080/fhir Observation -q "date=$YEAR
 
 | System | Dataset | Year | # Hits | Time (s) | StdDev |  T/1M ¹ |
 |--------|---------|------|-------:|---------:|-------:|--------:|
-| LEA47  | 100k    | 2013 |  3.1 M |    56.35 |  1.001 |   18.02 |
-| LEA47  | 100k    | 2019 |  6.0 M |   103.39 |  0.877 |   17.29 |
-| CCX42  | 100k    | 2013 |  3.1 M |   128.16 |  0.406 |   41.00 |
-| CCX42  | 100k    | 2019 |  6.0 M |   276.13 |  2.020 | 46.18 ² |
+| LEA47  | 100k    | 2013 |  3.1 M |    53.41 |  0.377 |   17.08 |
+| LEA47  | 100k    | 2019 |  6.0 M |   107.15 |  0.116 |   17.92 |
+| LEA58  | 100k    | 2013 |  3.1 M |    53.07 |  0.090 |   16.98 |
+| LEA58  | 100k    | 2019 |  6.0 M |   100.73 |  0.473 |   16.84 |
 | LEA47  | 1M      | 2013 | 31.1 M |   991.28 | 12.329 | 31.90 ² |
 | LEA47  | 1M      | 2019 | 60.0 M |  2083.44 | 31.983 | 34.69 ² |
 
@@ -301,10 +253,10 @@ blazectl download --server http://localhost:8080/fhir Observation -q "date=$YEAR
 
 | System | Dataset | Year | # Hits | Time (s) | StdDev |  T/1M ¹ |
 |--------|---------|------|-------:|---------:|-------:|--------:|
-| LEA47  | 100k    | 2013 |  3.1 M |    35.15 |  0.688 |   11.24 |
-| LEA47  | 100k    | 2019 |  6.0 M |    66.72 |  0.521 |   11.16 |
-| CCX42  | 100k    | 2013 |  3.1 M |    85.59 |  0.293 |   27.38 |
-| CCX42  | 100k    | 2019 |  6.0 M |   179.29 |  1.786 | 29.99 ² |
+| LEA47  | 100k    | 2013 |  3.1 M |    31.99 |  0.061 |   10.23 |
+| LEA47  | 100k    | 2019 |  6.0 M |    66.33 |  0.045 |   11.09 |
+| LEA58  | 100k    | 2013 |  3.1 M |    32.43 |  0.340 |   10.37 |
+| LEA58  | 100k    | 2019 |  6.0 M |    62.14 |  0.488 |   10.39 |
 | LEA47  | 1M      | 2013 | 31.1 M |   673.36 | 10.199 | 21.67 ² |
 | LEA47  | 1M      | 2019 | 60.0 M |  1516.90 |  0.482 | 25.25 ² |
 

--- a/modules/byte-buffer/src/blaze/byte_buffer.clj
+++ b/modules/byte-buffer/src/blaze/byte_buffer.clj
@@ -163,6 +163,7 @@
   (.mark ^ByteBuffer byte-buffer))
 
 (defn reset!
+  "Resets the position of `byte-buffer` to the previously marked position."
   {:inline
    (fn [byte-buffer]
      `(.reset ~(vary-meta byte-buffer assoc :tag `ByteBuffer)))}

--- a/modules/db-protocols/src/blaze/db/impl/protocols.clj
+++ b/modules/db-protocols/src/blaze/db/impl/protocols.clj
@@ -96,7 +96,7 @@
     "Returns a CompletableFuture that will complete with the count of the
     matching resource handles.")
   (-compartment-keys [search-param context compartment tid compiled-value])
-  (-matches? [search-param context resource-handle modifier compiled-values])
+  (-matcher [_ context modifier values])
   (-compartment-ids [_ resolver resource])
   (-index-values [_ resolver resource])
   (-index-value-compiler [_]))

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -68,6 +68,9 @@
   (-basis-t [_]
     basis-t)
 
+  (-as-of-t [_]
+    (when (not= basis-t t) t))
+
   ;; ---- Instance-Level Functions --------------------------------------------
 
   (-resource-handle [_ tid id]

--- a/modules/db/src/blaze/db/impl/index.clj
+++ b/modules/db/src/blaze/db/impl/index.clj
@@ -15,7 +15,7 @@
   (transduce
    (map
     (fn [[search-param modifier _ values]]
-      (filter #(search-param/matches? search-param context % modifier values))))
+      (search-param/matcher search-param context modifier values)))
    comp
    clauses))
 
@@ -73,7 +73,7 @@
   [])
 
 (defn compartment-query
-  "Iterates over the CSV index."
+  "Iterates over the CompartmentSearchParamValueResource index."
   [context compartment tid clauses]
   (let [[[search-param _ _ values] & other-clauses] clauses]
     (if (seq other-clauses)

--- a/modules/db/src/blaze/db/impl/search_param.clj
+++ b/modules/db/src/blaze/db/impl/search_param.clj
@@ -93,9 +93,11 @@
    (u/resource-handle-mapper context tid)
    (compartment-keys search-param context compartment tid compiled-values)))
 
-(defn matches?
-  [search-param context resource-handle modifier compiled-values]
-  (p/-matches? search-param context resource-handle modifier compiled-values))
+(defn matcher
+  "Returns a stateful transducer that filters resource handles depending on
+  having one of `compiled-values` for `search-param` with `modifier`."
+  [search-param context modifier compiled-values]
+  (p/-matcher search-param context modifier compiled-values))
 
 (def ^:private stub-resolver
   "A resolver which only returns a resource stub with type and id from the local

--- a/modules/db/src/blaze/db/impl/search_param/composite/token_quantity.clj
+++ b/modules/db/src/blaze/db/impl/search_param/composite/token_quantity.clj
@@ -60,8 +60,8 @@
      context tid
      (spq/resource-keys context c-hash tid prefix-length value)))
 
-  (-matches? [_ context resource-handle _ values]
-    (some? (some (partial spq/matches? (:snapshot context) c-hash resource-handle prefix-length) values)))
+  (-matcher [_ context _ values]
+    (spq/matcher context c-hash prefix-length values))
 
   (-index-values [_ resolver resource]
     (when-ok [values (fhir-path/eval resolver main-expression resource)]

--- a/modules/db/src/blaze/db/impl/search_param/composite/token_token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/composite/token_token.clj
@@ -34,8 +34,8 @@
      context tid
      (spt/resource-keys context c-hash tid value)))
 
-  (-matches? [_ context resource-handle _ values]
-    (some (partial r-sp-v/value-prefix-exists? (:snapshot context) resource-handle c-hash) values))
+  (-matcher [_ context _ values]
+    (r-sp-v/value-prefix-filter (:snapshot context) c-hash values))
 
   (-index-values [_ resolver resource]
     (when-ok [values (fhir-path/eval resolver main-expression resource)]

--- a/modules/db/src/blaze/db/impl/search_param/has.clj
+++ b/modules/db/src/blaze/db/impl/search_param/has.clj
@@ -101,8 +101,8 @@
               (resource-handles* context tid data))))))
 
 (defn- matches?
-  [context {:keys [tid] :as resource-handle} value]
-  (contains? (resource-handles context tid value) resource-handle))
+  [context {:keys [tid] :as resource-handle} values]
+  (some #(contains? (resource-handles context tid %) resource-handle) values))
 
 (defrecord SearchParamHas [index name type code]
   p/SearchParam
@@ -127,8 +127,8 @@
     (ac/completed-future
      (count (p/-resource-handles search-param context tid modifier value))))
 
-  (-matches? [_ context resource-handle _ values]
-    (some? (some #(matches? context resource-handle %) values)))
+  (-matcher [_ context _ values]
+    (filter #(matches? context % values)))
 
   (-index-values [_ _ _]
     []))

--- a/modules/db/src/blaze/db/impl/search_param/number.clj
+++ b/modules/db/src/blaze/db/impl/search_param/number.clj
@@ -78,8 +78,8 @@
      context tid
      (spq/resource-keys context c-hash tid 0 value)))
 
-  (-matches? [_ context resource-handle _ values]
-    (some? (some (partial spq/matches? (:snapshot context) c-hash resource-handle 0) values)))
+  (-matcher [_ context _ values]
+    (spq/matcher context c-hash 0 values))
 
   (-index-values [search-param resolver resource]
     (when-ok [values (fhir-path/eval resolver expression resource)]

--- a/modules/db/src/blaze/db/impl/search_param/string.clj
+++ b/modules/db/src/blaze/db/impl/search_param/string.clj
@@ -96,8 +96,8 @@
      context tid
      (resource-keys context c-hash tid value)))
 
-  (-matches? [_ context resource-handle _ values]
-    (some (partial r-sp-v/value-prefix-exists? (:snapshot context) resource-handle c-hash) values))
+  (-matcher [_ context _ values]
+    (r-sp-v/value-prefix-filter (:snapshot context) c-hash values))
 
   (-index-values [search-param resolver resource]
     (when-ok [values (fhir-path/eval resolver expression resource)]

--- a/modules/db/src/blaze/db/impl/search_param/token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/token.clj
@@ -137,8 +137,8 @@
     c-hash))
 
 (defn resource-keys
-  "Returns a reducible collection of `[id hash-prefix]` tuples starting at
-  `start-id` (optional)."
+  "Returns a reducible collection of `[id hash-prefix]` tuples that have `value`
+  starting at `start-id` (optional)."
   ([{:keys [snapshot]} c-hash tid value]
    (sp-vr/prefix-keys snapshot c-hash tid (bs/size value) value))
   ([{:keys [snapshot]} c-hash tid value start-id]
@@ -170,8 +170,9 @@
   (-compartment-keys [_ context compartment tid value]
     (c-sp-vr/prefix-keys (:snapshot context) compartment c-hash tid value))
 
-  (-matches? [_ context resource-handle modifier values]
-    (some (partial r-sp-v/value-prefix-exists? (:snapshot context) resource-handle (c-hash-w-modifier c-hash code modifier)) values))
+  (-matcher [_ context modifier values]
+    (r-sp-v/value-prefix-filter (:snapshot context)
+                                (c-hash-w-modifier c-hash code modifier) values))
 
   (-compartment-ids [_ resolver resource]
     (when-ok [values (fhir-path/eval resolver expression resource)]

--- a/modules/db/src/blaze/db/node/tx_indexer/verify.clj
+++ b/modules/db/src/blaze/db/node/tx_indexer/verify.clj
@@ -104,12 +104,12 @@
 (defn- verify-tx-cmd-create-msg [type id]
   (format "verify-tx-cmd :create %s/%s" type id))
 
-(defn- id-collision-msg [type id]
-  (format "Resource `%s/%s` already exists and can't be created again." type id))
+(defn- id-collision-msg [type id t]
+  (format "Resource `%s/%s` already exists in the database with t = %d and can't be created again." type id t))
 
 (defn- check-id-collision! [db type id]
   (when (d/resource-handle db type id)
-    (throw-anom (ba/conflict (id-collision-msg type id)))))
+    (throw-anom (ba/conflict (id-collision-msg type id (d/t db))))))
 
 (defn- index-entries [tid id t hash num-changes op]
   (rts/index-entries tid (codec/id-byte-string id) t hash num-changes op))

--- a/modules/db/test/blaze/db/impl/index/resource_search_param_value_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_search_param_value_spec.clj
@@ -15,20 +15,20 @@
                                   :value byte-string?)))
   :ret (s/nilable byte-string?))
 
-(s/fdef r-sp-v/value-prefix-exists?
+(s/fdef r-sp-v/value-filter
   :args (s/cat :snapshot :blaze.db.kv/snapshot
-               :resource-handle :blaze.db/resource-handle
-               :c-hash :blaze.db/c-hash
-               :value-prefix byte-string?)
-  :ret boolean?)
+               :seek (s/? fn?)
+               :encode fn?
+               :matches? fn?
+               :value-prefix-length (s/? nat-int?)
+               :values (s/coll-of some? :min-count 1))
+  :ret fn?)
 
-(s/fdef r-sp-v/next-value-prev
+(s/fdef r-sp-v/value-prefix-filter
   :args (s/cat :snapshot :blaze.db.kv/snapshot
-               :resource-handle :blaze.db/resource-handle
                :c-hash :blaze.db/c-hash
-               :value-prefix-length nat-int?
-               :value byte-string?)
-  :ret (s/nilable byte-string?))
+               :value-prefixes (s/coll-of byte-string? :min-count 1))
+  :ret fn?)
 
 (s/fdef r-sp-v/index-entry
   :args (s/cat :tid :blaze.db/tid

--- a/modules/db/test/blaze/db/impl/iterators_spec.clj
+++ b/modules/db/test/blaze/db/impl/iterators_spec.clj
@@ -8,12 +8,6 @@
    [blaze.db.kv-spec]
    [clojure.spec.alpha :as s]))
 
-(s/fdef i/contains-key-prefix?
-  :args (s/cat :snapshot :blaze.db.kv/snapshot
-               :column-family (s/? keyword?)
-               :key-prefix byte-string?)
-  :ret boolean?)
-
 (s/fdef i/seek-key
   :args (s/and (s/cat :snapshot :blaze.db.kv/snapshot
                       :column-family (s/? keyword?) :decode fn?
@@ -27,14 +21,6 @@
                :decode fn?)
   :ret any?)
 
-(s/fdef i/seek-key-prev
-  :args (s/and (s/cat :snapshot :blaze.db.kv/snapshot
-                      :column-family (s/? keyword?) :decode fn?
-                      :prefix-length nat-int? :target byte-string?)
-               (fn [{:keys [prefix-length target]}]
-                 (<= prefix-length (bs/size target))))
-  :ret any?)
-
 (s/fdef i/seek-value
   :args (s/and (s/cat :snapshot :blaze.db.kv/snapshot
                       :column-family keyword? :decode fn?
@@ -42,6 +28,20 @@
                (fn [{:keys [prefix-length target]}]
                  (<= prefix-length (bs/size target))))
   :ret any?)
+
+(s/fdef i/seek-key-filter
+  :args (s/cat :snapshot :blaze.db.kv/snapshot :column-family keyword?
+               :seek fn? :matches? fn? :encode fn?
+               :values (s/coll-of some? :min-count 1))
+  :ret fn?)
+
+(s/fdef i/target-length-matcher
+  :args (s/cat :matches? fn?)
+  :ret fn?)
+
+(s/fdef i/prefix-length-matcher
+  :args (s/cat :prefix-length fn? :matches? fn?)
+  :ret fn?)
 
 (s/fdef i/keys
   :args (s/cat :snapshot :blaze.db.kv/snapshot

--- a/modules/db/test/blaze/db/impl/iterators_test.clj
+++ b/modules/db/test/blaze/db/impl/iterators_test.clj
@@ -21,6 +21,21 @@
 (defn- ba [& bytes]
   (byte-array bytes))
 
+(deftest seek-key-filter-test
+  (testing "minimal filter matching every input"
+    (with-system [{kv-store ::kv/mem} config]
+      (kv/put!
+       kv-store
+       [[:default (ba 0x00) bytes/empty]])
+
+      (with-open [snapshot (kv/new-snapshot kv-store)]
+        (is (= 3 (transduce
+                  (i/seek-key-filter snapshot :default (fn [_] kv/seek-buffer!)
+                                     (fn [_ _ _ _] true) (fn [tb _ _] tb)
+                                     [#blaze/byte-string"00"])
+                  +
+                  [1 2])))))))
+
 (deftest keys-test
   (testing "normal read"
     (with-system [{kv-store ::kv/mem} config]

--- a/modules/db/test/blaze/db/impl/search_param/quantity_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_spec.clj
@@ -21,9 +21,8 @@
                :value ::spq/value
                :start-id (s/? :blaze.db/id-byte-string)))
 
-(s/fdef spq/matches?
-  :args (s/cat :snapshot :blaze.db.kv/snapshot
+(s/fdef spq/matcher
+  :args (s/cat :context ::batch-db/context
                :c-hash :blaze.db/c-hash
-               :resource-handle :blaze.db/resource-handle
                :prefix-length nat-int?
-               :value ::spq/value))
+               :values (s/coll-of ::spq/value :min-count 1)))

--- a/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
@@ -59,17 +59,6 @@
       :code := "value-quantity"
       :c-hash := (codec/c-hash "value-quantity"))))
 
-(deftest matches-test
-  (testing "non matching op"
-    ;; although a non-matching op isn't allowed in the spec, it could happen at
-    ;; runtime, and we have to test that case
-    (st/unstrument `spq/matches?)
-
-    (try
-      (spq/matches? nil (codec/c-hash "value-quantity") nil 0 {:op :foo})
-      (catch Exception e
-        (is (= "No matching clause: :foo" (ex-message e)))))))
-
 (defn compile-quantity-value [search-param-registry value]
   (-> (value-quantity-param search-param-registry)
       (search-param/compile-values nil [value])

--- a/modules/db/test/blaze/db/impl/search_param_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param_spec.clj
@@ -68,13 +68,12 @@
                :compiled-values (s/coll-of some? :min-count 1))
   :ret (cs/coll-of :blaze.db/resource-handle))
 
-(s/fdef search-param/matches?
+(s/fdef search-param/matcher
   :args (s/cat :search-param :blaze.db/search-param
                :context ::batch-db/context
-               :resource-handle :blaze.db/resource-handle
                :modifier (s/nilable :blaze.db.search-param/modifier)
                :compiled-values (s/coll-of some? :min-count 1))
-  :ret boolean?)
+  :ret fn?)
 
 (s/fdef search-param/compartment-ids
   :args (s/cat :search-param :blaze.db/search-param

--- a/modules/interaction/src/blaze/interaction/read.clj
+++ b/modules/interaction/src/blaze/interaction/read.clj
@@ -64,7 +64,7 @@
     (do-sync [resource (pull db type id)]
       (response resource))))
 
-(defn- wrap-invalid-id-vid [handler]
+(defn- wrap-invalid-id [handler]
   (fn [{{:keys [id]} :path-params :as request}]
     (cond
       (not (re-matches #"[A-Za-z0-9\-\.]{1,64}" id))
@@ -79,4 +79,4 @@
 
 (defmethod ig/init-key :blaze.interaction/read [_ _]
   (log/info "Init FHIR read interaction handler")
-  (wrap-invalid-id-vid handler))
+  (wrap-invalid-id handler))

--- a/modules/kv/src/blaze/db/kv.clj
+++ b/modules/kv/src/blaze/db/kv.clj
@@ -58,6 +58,16 @@
   [iter target]
   (p/-seek-for-prev iter target))
 
+(defn seek-for-prev-buffer!
+  "Positions `iter` at the first entry of its source whose key is at or before
+  `target`.
+
+  The `target` is a byte buffer describing a key or a key prefix to seek for.
+
+  The iterator will be valid if its source contains a key at or before `target`."
+  [iter target]
+  (p/-seek-for-prev-buffer iter target))
+
 (defn next!
   "Moves `iter` to the next entry of its source.
 

--- a/modules/kv/src/blaze/db/kv/iter_pool.clj
+++ b/modules/kv/src/blaze/db/kv/iter_pool.clj
@@ -68,6 +68,10 @@
     (when closed? (throw-anom iterator-closed-anom))
     (p/-seek-for-prev iter target))
 
+  (-seek-for-prev-buffer [_ target]
+    (when closed? (throw-anom iterator-closed-anom))
+    (p/-seek-for-prev-buffer iter target))
+
   (-next [_]
     (when closed? (throw-anom iterator-closed-anom))
     (p/-next iter))

--- a/modules/kv/src/blaze/db/kv/mem.clj
+++ b/modules/kv/src/blaze/db/kv/mem.clj
@@ -75,6 +75,11 @@
     (let [[x & xs] (rsubseq db <= k)]
       (reset! cursor {:first x :rest xs})))
 
+  (-seek-for-prev-buffer [iter kb]
+    (let [k (byte-array (bb/remaining kb))]
+      (bb/copy-into-byte-array! kb k)
+      (p/-seek-for-prev iter k)))
+
   (-next [iter]
     (check-valid iter)
     (swap! cursor (fn [{[x & xs] :rest}] {:first x :rest xs})))

--- a/modules/kv/src/blaze/db/kv/protocols.clj
+++ b/modules/kv/src/blaze/db/kv/protocols.clj
@@ -15,6 +15,8 @@
 
   (-seek-for-prev [iter target])
 
+  (-seek-for-prev-buffer [iter target])
+
   (-next [iter])
 
   (-prev [iter])

--- a/modules/rocksdb/src/blaze/db/kv/rocksdb.clj
+++ b/modules/rocksdb/src/blaze/db/kv/rocksdb.clj
@@ -44,6 +44,9 @@
   (-seek-for-prev [_ target]
     (.seekForPrev i ^bytes target))
 
+  (-seek-for-prev-buffer [_ target]
+    (.seekForPrev i ^ByteBuffer target))
+
   (-next [_]
     (.next i))
 


### PR DESCRIPTION
Use stateful transducers which keep iterators open instead of predicates that open/close iterators on every call.