### PR TITLE
Remove Database T from Self Links

### DIFF
--- a/.github/scripts/follow-patient-next-link-after-write.sh
+++ b/.github/scripts/follow-patient-next-link-after-write.sh
@@ -12,14 +12,11 @@ BASE="http://localhost:8080/fhir"
 
 FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$BASE/Patient")"
 TOTAL="$(echo "$FIRST_PAGE" | jq -r .total)"
-SELF_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "self") | .url')"
 NEXT_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "next") | .url')"
 
 # create new patient
 curl -sfH 'Content-Type: application/fhir+json' -H 'Accept: application/fhir+json' -d "{\"resourceType\": \"Patient\"}" -o /dev/null "$BASE/Patient"
 
-FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$SELF_LINK")"
 SECOND_PAGE="$(curl -sH "Accept: application/fhir+json" "$NEXT_LINK")"
 
-test "first page total" "$(echo "$FIRST_PAGE" | jq -r .total)" "$TOTAL"
 test "second page total" "$(echo "$SECOND_PAGE" | jq -r .total)" "$TOTAL"

--- a/.github/scripts/follow-system-next-link-after-write.sh
+++ b/.github/scripts/follow-system-next-link-after-write.sh
@@ -12,14 +12,11 @@ BASE="http://localhost:8080/fhir"
 
 FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$BASE")"
 TOTAL="$(echo "$FIRST_PAGE" | jq -r .total)"
-SELF_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "self") | .url')"
 NEXT_LINK="$(echo "$FIRST_PAGE" | jq -r '.link[] | select(.relation == "next") | .url')"
 
 # create new patient
 curl -sfH 'Content-Type: application/fhir+json' -H 'Accept: application/fhir+json' -d "{\"resourceType\": \"Patient\"}" -o /dev/null "$BASE/Patient"
 
-FIRST_PAGE="$(curl -sH "Accept: application/fhir+json" "$SELF_LINK")"
 SECOND_PAGE="$(curl -sH "Accept: application/fhir+json" "$NEXT_LINK")"
 
-test "first page total" "$(echo "$FIRST_PAGE" | jq -r .total)" "$TOTAL"
 test "second page total" "$(echo "$SECOND_PAGE" | jq -r .total)" "$TOTAL"

--- a/.github/scripts/forwarded-header.sh
+++ b/.github/scripts/forwarded-header.sh
@@ -2,7 +2,7 @@
 
 PROTO=$1
 EXPECTED_SELF_LINK="$PROTO://blaze.de/fhir/Patient"
-ACTUAL_SELF_LINK=$(curl -s -H "Forwarded:host=blaze.de;proto=$PROTO" http://localhost:8080/fhir/Patient | jq -r .link[0].url | cut -d? -f1)
+ACTUAL_SELF_LINK=$(curl -s -H "Forwarded:host=blaze.de;proto=$PROTO" http://localhost:8080/fhir/Patient | jq -r '.link[] | select(.relation == "self") | .url' | cut -d? -f1)
 
 if [ "$EXPECTED_SELF_LINK" = "$ACTUAL_SELF_LINK" ]; then
   echo "OK 👍"

--- a/.github/scripts/x-forwarded-headers.sh
+++ b/.github/scripts/x-forwarded-headers.sh
@@ -2,7 +2,7 @@
 
 PROTO=$1
 EXPECTED_SELF_LINK="$PROTO://blaze.de/fhir/Patient"
-ACTUAL_SELF_LINK=$(curl -s -H 'X-Forwarded-Host:blaze.de' -H "X-Forwarded-Proto:$PROTO" http://localhost:8080/fhir/Patient | jq -r .link[0].url | cut -d? -f1)
+ACTUAL_SELF_LINK=$(curl -s -H 'X-Forwarded-Host:blaze.de' -H "X-Forwarded-Proto:$PROTO" http://localhost:8080/fhir/Patient | jq -r '.link[] | select(.relation == "self") | .url' | cut -d? -f1)
 
 if [ "$EXPECTED_SELF_LINK" = "$ACTUAL_SELF_LINK" ]; then
   echo "OK 👍"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ coverage:
     project:
       default:
         target: auto
+        threshold: "0.1"
 comment:
   layout: "reach, diff, flags, files"
   behavior: default

--- a/modules/interaction/src/blaze/interaction/search/nav.clj
+++ b/modules/interaction/src/blaze/interaction/search/nav.clj
@@ -84,11 +84,11 @@
 (defn- query-params [params clauses]
   (merge-params (clauses->query-params clauses) params))
 
-(defn url [base-url match params clauses t offset]
+(defn url
+  "Returns the URL created from `clauses` used in self links."
+  [base-url match params clauses]
   (let [query-params (query-params params clauses)]
-    (str base-url (reitit/match->path match (-> query-params
-                                                (assoc "__t" t)
-                                                (merge offset))))))
+    (str base-url (reitit/match->path match query-params))))
 
 (defn- token-query-params!
   [page-store {:keys [token] :as params} clauses]

--- a/modules/interaction/src/blaze/interaction/search_compartment.clj
+++ b/modules/interaction/src/blaze/interaction/search_compartment.clj
@@ -46,12 +46,10 @@
   (into [] (entries-xf context) resources))
 
 (defn- self-link
-  [{:keys [match] :blaze/keys [base-url db]
-    {:keys [page-offset] :as params} :params} clauses]
+  [{:keys [match params] :blaze/keys [base-url]} clauses]
   {:fhir/type :fhir.Bundle/link
    :relation "self"
-   :url (nav/url base-url match params clauses (d/t db)
-                 {"__page-offset" page-offset})})
+   :url (nav/url base-url match params clauses)})
 
 (defn- next-link-offset [{:keys [page-offset]} entries]
   {"__page-offset" (+ page-offset (dec (count entries)))})

--- a/modules/interaction/src/blaze/interaction/search_system.clj
+++ b/modules/interaction/src/blaze/interaction/search_system.clj
@@ -38,14 +38,10 @@
        (fn [resources]
          (mapv (partial search-util/entry context) resources)))))
 
-(defn- self-link-offset [[{first-resource :resource}]]
-  (when-let [{:fhir/keys [type] :keys [id]} first-resource]
-    {"__page-type" (name type) "__page-id" id}))
-
-(defn- self-link [{:keys [match params] :blaze/keys [base-url db]} entries]
+(defn- self-link [{:keys [params] :blaze/keys [base-url] ::reitit/keys [match]}]
   {:fhir/type :fhir.Bundle/link
    :relation "self"
-   :url (nav/url base-url match params [] (d/t db) (self-link-offset entries))})
+   :url (nav/url base-url match params [])})
 
 (defn- next-link-offset [entries]
   (let [{:fhir/keys [type] :keys [id]} (:resource (peek entries))]
@@ -60,15 +56,18 @@
      :url url}))
 
 (defn- normal-bundle
-  [{:blaze/keys [db] {:keys [page-size]} :params :as context} entries]
-  {:fhir/type :fhir/Bundle
-   :id (iu/luid context)
-   :type #fhir/code"searchset"
-   :total (type/->UnsignedInt (d/system-total db))
-   :entry (if (< page-size (count entries))
-            (pop entries)
-            entries)
-   :link [(self-link context entries)]})
+  [{:blaze/keys [db] {:keys [page-size]} :params
+    {{route-name :name} :data} ::reitit/match :as context} entries]
+  (cond->
+   {:fhir/type :fhir/Bundle
+    :id (iu/luid context)
+    :type #fhir/code"searchset"
+    :total (type/->UnsignedInt (d/system-total db))
+    :entry (if (< page-size (count entries))
+             (pop entries)
+             entries)}
+    (not= :page route-name)
+    (assoc :link [(self-link context)])))
 
 (defn- search-normal [{{:keys [page-size]} :params :as context}]
   (-> (entries context)
@@ -77,7 +76,7 @@
          (if (< page-size (count entries))
            (do-sync [next-link (next-link context entries)]
              (-> (normal-bundle context entries)
-                 (update :link conj next-link)))
+                 (update :link (fnil conj []) next-link)))
            (-> (normal-bundle context entries)
                ac/completed-future))))))
 
@@ -87,7 +86,7 @@
     :id (iu/luid context)
     :type #fhir/code"searchset"
     :total (type/->UnsignedInt (d/system-total db))
-    :link [(self-link context [])]}))
+    :link [(self-link context)]}))
 
 (defn- search [{:keys [params] :as context}]
   (if (:summary? params)
@@ -105,7 +104,7 @@
              :blaze/base-url base-url
              :blaze/db db
              ::reitit/router router
-             :match match
+             ::reitit/match match
              :page-match (reitit/match-by-name router :page)
              :params params))))
 

--- a/modules/interaction/test/blaze/interaction/search/nav_spec.clj
+++ b/modules/interaction/test/blaze/interaction/search/nav_spec.clj
@@ -10,9 +10,7 @@
   :args (s/cat :base-url string?
                :match some?
                :params (s/nilable map?)
-               :clauses (s/nilable :blaze.db.query/clauses)
-               :t :blaze.db/t
-               :offset (s/nilable map?))
+               :clauses (s/nilable :blaze.db.query/clauses))
   :ret string?)
 
 (s/fdef nav/token-url!

--- a/modules/interaction/test/blaze/interaction/search/nav_test.clj
+++ b/modules/interaction/test/blaze/interaction/search/nav_test.clj
@@ -22,66 +22,62 @@
 (deftest url-test
   (testing "url encoding of clauses"
     (testing "Observation code with URL"
-      (is (= "base/Observation?code=http%3A%2F%2Floinc.org%7C8480-6&__t=1"
-             (nav/url "base" match nil [["code" "http://loinc.org|8480-6"]] 1 nil))))
+      (is (= "base/Observation?code=http%3A%2F%2Floinc.org%7C8480-6"
+             (nav/url "base" match nil [["code" "http://loinc.org|8480-6"]]))))
 
     (testing "Observation code with multiple values"
-      (is (= "base/Observation?code=8480-6%2C8310-5&__t=1"
-             (nav/url "base" match nil [["code" "8480-6,8310-5"]] 1 nil)))))
+      (is (= "base/Observation?code=8480-6%2C8310-5"
+             (nav/url "base" match nil [["code" "8480-6,8310-5"]])))))
 
   (testing "two clauses with the same code"
-    (is (= "base-url-110421/Observation?combo-code-value-quantity=8480-6%24ge140&combo-code-value-quantity=8462-4%24ge90&__t=1"
+    (is (= "base-url-110421/Observation?combo-code-value-quantity=8480-6%24ge140&combo-code-value-quantity=8462-4%24ge90"
            (nav/url "base-url-110421" match nil
                     [["combo-code-value-quantity" "8480-6$ge140"]
-                     ["combo-code-value-quantity" "8462-4$ge90"]]
-                    1 nil))))
+                     ["combo-code-value-quantity" "8462-4$ge90"]]))))
 
   (testing "sort clause"
     (testing "ascending"
-      (is (= "base-url-110407/Observation?_sort=foo&__t=1"
-             (nav/url "base-url-110407" match nil [[:sort "foo" :asc]] 1 nil))))
+      (is (= "base-url-110407/Observation?_sort=foo"
+             (nav/url "base-url-110407" match nil [[:sort "foo" :asc]]))))
 
     (testing "descending"
-      (is (= "base-url-110407/Observation?_sort=-foo&__t=1"
-             (nav/url "base-url-110407" match nil [[:sort "foo" :desc]] 1 nil)))))
+      (is (= "base-url-110407/Observation?_sort=-foo"
+             (nav/url "base-url-110407" match nil [[:sort "foo" :desc]])))))
 
   (testing "_summary"
-    (is (= "base-url-110407/Observation?_summary=true&__t=1"
-           (nav/url "base-url-110407" match {:summary "true"} [] 1 nil))))
+    (is (= "base-url-110407/Observation?_summary=true"
+           (nav/url "base-url-110407" match {:summary "true"} []))))
 
   (testing "_elements"
     (testing "zero element"
-      (is (= "base-url-110407/Observation?__t=1"
-             (nav/url "base-url-110407" match {:elements []} [] 1 nil))))
+      (is (= "base-url-110407/Observation"
+             (nav/url "base-url-110407" match {:elements []} []))))
 
     (testing "one element"
-      (is (= "base-url-110407/Observation?_elements=a&__t=1"
-             (nav/url "base-url-110407" match {:elements [:a]} [] 1 nil))))
+      (is (= "base-url-110407/Observation?_elements=a"
+             (nav/url "base-url-110407" match {:elements [:a]} []))))
 
     (testing "two elements"
-      (is (= "base-url-110407/Observation?_elements=a%2Cb&__t=1"
-             (nav/url "base-url-110407" match {:elements [:a :b]} [] 1 nil)))))
+      (is (= "base-url-110407/Observation?_elements=a%2Cb"
+             (nav/url "base-url-110407" match {:elements [:a :b]} [])))))
 
   (testing "with include-defs"
     (testing "empty"
-      (is (= "base-url-110439/Observation?__t=1"
+      (is (= "base-url-110439/Observation"
              (nav/url "base-url-110439" match
-                      {:include-defs {:direct {} :iterate {}}} nil 1
-                      nil))))
+                      {:include-defs {:direct {} :iterate {}}} nil))))
 
     (testing "one direct forward include param"
-      (is (= "base-url-110542/Observation?_include=Observation%3Asubject&__t=1"
+      (is (= "base-url-110542/Observation?_include=Observation%3Asubject"
              (nav/url
               "base-url-110542"
               match
               {:include-defs
                {:direct {:forward {"Observation" [{:code "subject"}]}}}}
-              nil
-              1
               nil)))
 
       (testing "with target type"
-        (is (= "base-url-110553/Observation?_include=Observation%3Asubject%3AGroup&__t=1"
+        (is (= "base-url-110553/Observation?_include=Observation%3Asubject%3AGroup"
                (nav/url
                 "base-url-110553"
                 match
@@ -89,12 +85,10 @@
                  {:direct
                   {:forward
                    {"Observation" [{:code "subject" :target-type "Group"}]}}}}
-                nil
-                1
                 nil)))))
 
     (testing "two direct forward include params"
-      (is (= "base-url-110604/Observation?_include=MedicationStatement%3Amedication&_include=Medication%3Amanufacturer&__t=1"
+      (is (= "base-url-110604/Observation?_include=MedicationStatement%3Amedication&_include=Medication%3Amanufacturer"
              (nav/url
               "base-url-110604"
               match
@@ -103,23 +97,19 @@
                 {:forward
                  {"MedicationStatement" [{:code "medication"}]
                   "Medication" [{:code "manufacturer"}]}}}}
-              nil
-              1
               nil))))
 
     (testing "one iterate forward include param"
-      (is (= "base-url-110614/Observation?_include%3Aiterate=Observation%3Asubject&__t=1"
+      (is (= "base-url-110614/Observation?_include%3Aiterate=Observation%3Asubject"
              (nav/url
               "base-url-110614"
               match
               {:include-defs
                {:iterate {:forward {"Observation" [{:code "subject"}]}}}}
-              nil
-              1
               nil))))
 
     (testing "one direct and one iterate forward include param"
-      (is (= "base-url-110624/Observation?_include=MedicationStatement%3Amedication&_include%3Aiterate=Medication%3Amanufacturer&__t=1"
+      (is (= "base-url-110624/Observation?_include=MedicationStatement%3Amedication&_include%3Aiterate=Medication%3Amanufacturer"
              (nav/url
               "base-url-110624"
               match
@@ -130,12 +120,10 @@
                 :iterate
                 {:forward
                  {"Medication" [{:code "manufacturer"}]}}}}
-              nil
-              1
               nil))))
 
     (testing "one direct reverse include param"
-      (is (= "base-url-110635/Observation?_revinclude=Observation%3Asubject&__t=1"
+      (is (= "base-url-110635/Observation?_revinclude=Observation%3Asubject"
              (nav/url
               "base-url-110635"
               match
@@ -143,12 +131,10 @@
                {:direct
                 {:reverse
                  {:any [{:source-type "Observation" :code "subject"}]}}}}
-              nil
-              1
               nil)))
 
       (testing "with target type"
-        (is (= "base-url-110645/Observation?_revinclude=Observation%3Asubject%3AGroup&__t=1"
+        (is (= "base-url-110645/Observation?_revinclude=Observation%3Asubject%3AGroup"
                (nav/url
                 "base-url-110645"
                 match
@@ -156,12 +142,10 @@
                  {:direct
                   {:reverse
                    {"Group" [{:source-type "Observation" :code "subject"}]}}}}
-                nil
-                1
                 nil)))))
 
     (testing "one iterate reverse include param"
-      (is (= "base-url-110654/Observation?_revinclude%3Aiterate=Observation%3Asubject&__t=1"
+      (is (= "base-url-110654/Observation?_revinclude%3Aiterate=Observation%3Asubject"
              (nav/url
               "base-url-110654"
               match
@@ -169,8 +153,6 @@
                {:iterate
                 {:reverse
                  {:any [{:source-type "Observation" :code "subject"}]}}}}
-              nil
-              1
               nil))))))
 
 (def clauses-1

--- a/modules/interaction/test/blaze/interaction/search_compartment_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_compartment_test.clj
@@ -196,7 +196,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?_count=50")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -229,7 +229,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?_summary=count&_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?_summary=count&_count=50")
                          (link-url body "self"))))))))
 
         (testing "with another search parameter"
@@ -264,7 +264,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_count=50")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -298,7 +298,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_summary=count&_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_summary=count&_count=50")
                          (link-url body "self"))))))))))
 
     (testing "with default handling"
@@ -333,7 +333,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?_count=50")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -365,7 +365,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?_summary=count&_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?_summary=count&_count=50")
                          (link-url body "self"))))))))
 
         (testing "with another search parameter"
@@ -399,7 +399,7 @@
                   (is (= 1 (count (:entry body)))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_count=50")
                          (link-url body "self")))))))
 
           (testing "summary result"
@@ -432,7 +432,7 @@
                   (is (empty? (:entry body))))
 
                 (testing "has a self link"
-                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_summary=count&_count=50&__t=1&__page-offset=0")
+                  (is (= (str base-url context-path "/Patient/0/Observation?status=preliminary&_summary=count&_count=50")
                          (link-url body "self")))))))))))
 
   (testing "Returns an empty Bundle on Non-Existing Compartment"
@@ -512,7 +512,7 @@
               (is (= #fhir/unsignedInt 2 (:total body))))
 
             (testing "has a self link"
-              (is (= (str base-url context-path "/Patient/0/Observation?_count=50&__t=1&__page-offset=0")
+              (is (= (str base-url context-path "/Patient/0/Observation?_count=50")
                      (link-url body "self"))))
 
             (testing "the bundle contains two entries"

--- a/modules/rest-api/src/blaze/rest_api/routes.clj
+++ b/modules/rest-api/src/blaze/rest_api/routes.clj
@@ -47,10 +47,6 @@
   {:name :db
    :wrap db/wrap-db})
 
-(def ^:private wrap-search-db
-  {:name :search-db
-   :wrap db/wrap-search-db})
-
 (def ^:private wrap-snapshot-db
   {:name :snapshot-db
    :wrap db/wrap-snapshot-db})
@@ -115,7 +111,7 @@
       (cond-> {:name (keyword name "type")}
         (contains? interactions :search-type)
         (assoc :get {:interaction "search-type"
-                     :middleware [[wrap-search-db node db-sync-timeout]
+                     :middleware [[wrap-db node db-sync-timeout]
                                   wrap-link-headers]
                      :handler (-> interactions :search-type
                                   :blaze.rest-api.interaction/handler)})
@@ -286,7 +282,7 @@
          (cond-> {}
            (some? search-system-handler)
            (assoc :get {:interaction "search-system"
-                        :middleware [[wrap-search-db node db-sync-timeout]
+                        :middleware [[wrap-db node db-sync-timeout]
                                      wrap-link-headers]
                         :handler search-system-handler})
            (some? transaction-handler)

--- a/modules/rest-api/test/blaze/rest_api_test.clj
+++ b/modules/rest-api/test/blaze/rest_api_test.clj
@@ -185,12 +185,12 @@
                   (reitit/match-by-path (router []) path)
                   [:result request-method :data :middleware])
                  (mapv (comp :name #(if (sequential? %) (first %) %)))))
-      "" :get [:observe-request-duration :params :output :error :forwarded :sync :search-db :link-headers]
+      "" :get [:observe-request-duration :params :output :error :forwarded :sync :db :link-headers]
       "" :post [:observe-request-duration :params :output :error :forwarded :sync :resource :wrap-batch-handler]
       "/_history" :get [:observe-request-duration :params :output :error :forwarded :sync :db :link-headers]
       "/__page" :get [:observe-request-duration :params :output :error :forwarded :sync :snapshot-db :link-headers]
       "/__page" :post [:observe-request-duration :params :output :error :forwarded :sync :snapshot-db :link-headers]
-      "/Patient" :get [:observe-request-duration :params :output :error :forwarded :sync :search-db :link-headers]
+      "/Patient" :get [:observe-request-duration :params :output :error :forwarded :sync :db :link-headers]
       "/Patient" :post [:observe-request-duration :params :output :error :forwarded :sync :resource]
       "/Patient/_history" :get [:observe-request-duration :params :output :error :forwarded :sync :db :link-headers]
       "/Patient/_search" :post [:observe-request-duration :params :output :error :forwarded :sync :ensure-form-body :db :link-headers]
@@ -218,7 +218,7 @@
                     (reitit/match-by-path (router [:auth-backend]) path)
                     [:result request-method :data :middleware])
                    (mapv (comp :name #(if (sequential? %) (first %) %)))))
-        "" :get [:observe-request-duration :params :output :error :forwarded :sync :auth-guard :search-db :link-headers]
+        "" :get [:observe-request-duration :params :output :error :forwarded :sync :auth-guard :db :link-headers]
         "" :post [:observe-request-duration :params :output :error :forwarded :sync :auth-guard :resource :wrap-batch-handler]
         "/$compact-db" :get [:observe-request-duration :params :output :error :forwarded :sync :auth-guard :db]
         "/$compact-db" :post [:observe-request-duration :params :output :error :forwarded :sync :auth-guard :db :resource]

--- a/modules/rest-util/src/blaze/middleware/fhir/db.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/db.clj
@@ -41,21 +41,6 @@
       (ac/or-timeout! timeout TimeUnit/MILLISECONDS)
       (ac/exceptionally #(cond-> % (ba/busy? %) (assoc ::anom/message (timeout-t-msg t timeout))))))
 
-(defn wrap-search-db
-  "Database wrapping for requests that like to either operate on the latest
-  known database state or a known database state.
-
-  Currently the `t` of the database state taken from the query or form param
-  `__t`."
-  [handler node timeout]
-  (fn [{:keys [params] :as request}]
-    (if (:blaze/db request)
-      (handler request)
-      (-> (if-let [t (fhir-util/t params)]
-            (sync-t node t timeout)
-            (sync node timeout))
-          (ac/then-compose #(handler (assoc request :blaze/db %)))))))
-
 (defn wrap-snapshot-db
   "Database wrapping for requests that like to operate on a known database state.
 

--- a/modules/rest-util/src/blaze/middleware/fhir/db_spec.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/db_spec.clj
@@ -7,9 +7,6 @@
 (s/fdef db/wrap-db
   :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))
 
-(s/fdef db/wrap-search-db
-  :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))
-
 (s/fdef db/wrap-snapshot-db
   :args (s/cat :handler ifn? :node :blaze.db/node :timeout pos-int?))
 

--- a/test/blaze/system_test.clj
+++ b/test/blaze/system_test.clj
@@ -261,7 +261,7 @@
     (with-system [{:blaze/keys [rest-api]} config]
       (given (call rest-api {:request-method :get :uri "/Patient"})
         :status := 200
-        [:headers "Link"] := "<http://localhost:8080/Patient?_count=50&__t=0>;rel=\"self\""
+        [:headers "Link"] := "<http://localhost:8080/Patient?_count=50>;rel=\"self\""
         [:body fhir-spec/parse-json :resourceType] := "Bundle")))
 
   (testing "using POST"


### PR DESCRIPTION
Self links should point to the location were a new FHIR search can be started and not to the immutable page of the current search result.

This also means that only the first page will contain a self link. Furthermore the Search Type and Search System endpoint will no longer need to obtain a database with a certain t. So databases with a certain t will only needed to be obtained by __page endpoints and vread. This makes the surface area of getting access to older database states smaller.