### PR TITLE
Optimize Dependencies

### DIFF
--- a/modules/cassandra/Makefile
+++ b/modules/cassandra/Makefile
@@ -10,7 +10,13 @@ test:
 test-coverage:
 	clojure -M:test:coverage
 
+deps-tree:
+	clojure -X:deps tree
+
+deps-list:
+	clojure -X:deps list
+
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint test test-coverage clean
+.PHONY: fmt lint test test-coverage deps-tree deps-list clean

--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -3,7 +3,8 @@
   {:local/root "../async"}
 
   com.datastax.oss/java-driver-core
-  {:mvn/version "4.17.0"}
+  {:mvn/version "4.17.0"
+   :exclusions [com.github.spotbugs/spotbugs-annotations]}
 
   ;; current version of transitive dependency of com.datastax.oss/java-driver-core
   com.fasterxml.jackson.core/jackson-databind

--- a/modules/cql/deps.edn
+++ b/modules/cql/deps.edn
@@ -12,10 +12,14 @@
 
   info.cqframework/cql-to-elm
   {:mvn/version "2.11.0"
-   :exclusions [xpp3/xpp3_xpath]}
+   :exclusions
+   [org.antlr/antlr4
+    xpp3/xpp3
+    xpp3/xpp3_xpath]}
 
   info.cqframework/elm-jackson
-  {:mvn/version "2.11.0"}
+  {:mvn/version "2.11.0"
+   :exclusions [org.glassfish/javax.json]}
 
   info.cqframework/model-jackson
   {:mvn/version "2.11.0"}
@@ -38,10 +42,7 @@
 
    :extra-deps
    {blaze/db-stub
-    {:local/root "../db-stub"}
-
-    org.clojure/data.xml
-    {:mvn/version "0.2.0-alpha9"}}}
+    {:local/root "../db-stub"}}}
 
   :test-perf
   {:extra-paths ["test-perf"]

--- a/modules/fhir-path/Makefile
+++ b/modules/fhir-path/Makefile
@@ -13,7 +13,13 @@ test: prep
 test-coverage: prep
 	clojure -M:test:coverage
 
+deps-tree:
+	clojure -X:deps tree
+
+deps-list:
+	clojure -X:deps list
+
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep test test-coverage clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list clean

--- a/modules/fhir-path/deps.edn
+++ b/modules/fhir-path/deps.edn
@@ -3,7 +3,8 @@
   {:local/root "../fhir-structure"}
 
   info.cqframework/cql
-  {:mvn/version "2.11.0"}}
+  {:mvn/version "2.11.0"
+   :exclusions [org.antlr/antlr4]}}
 
  :aliases
  {:test

--- a/modules/operation-graphql/deps.edn
+++ b/modules/operation-graphql/deps.edn
@@ -12,7 +12,7 @@
   {:mvn/version "1.2.2"}
 
   org.antlr/antlr4
-  {:mvn/version "4.13.0"
+  {:mvn/version "4.10.1"
    :exclusions
    [com.ibm.icu/icu4j
     org.abego.treelayout/org.abego.treelayout.core

--- a/modules/rest-api/deps.edn
+++ b/modules/rest-api/deps.edn
@@ -17,10 +17,7 @@
 
   metosin/muuntaja
   {:mvn/version "0.6.8"
-   :exclusions [com.cognitect/transit-clj]}
-
-  org.clojure/data.xml
-  {:mvn/version "0.2.0-alpha9"}}
+   :exclusions [com.cognitect/transit-clj]}}
 
  :aliases
  {:test


### PR DESCRIPTION
* removed spotbugs-annotations, findbugs/jsr305, javax.json and xpp3/xpp3 because it's not needed
* downgraded antlr4 to v4.10.1 because CQL is build with it