### PR TITLE
Fix XML Output for Resources with Control Chars

### DIFF
--- a/modules/fhir-structure/.clj-kondo/config.edn
+++ b/modules/fhir-structure/.clj-kondo/config.edn
@@ -18,4 +18,6 @@
   {:level :off}
 
   :unused-private-var
-  {:exclude [blaze.fhir.spec.type/at-utc]}}}
+  {:exclude [blaze.fhir.spec.type/at-utc]}}
+
+ :exclude-files "src/blaze/fhir/spec/type.clj"}

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -818,6 +818,7 @@
 
 (declare markdown?)
 (declare markdown)
+(declare xml->Markdown)
 
 (def-primitive-type Markdown [value] :hash-num 16)
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/system.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/system.clj
@@ -487,7 +487,7 @@
     (-lower-bound (.atStartOfDay date)))
   LocalDateTime
   (-lower-bound [date-time]
-    (-lower-bound (.atOffset date-time (ZoneOffset/UTC))))
+    (-lower-bound (.atOffset date-time ZoneOffset/UTC)))
   OffsetDateTime
   (-lower-bound [date-time]
     (.toEpochSecond date-time)))
@@ -527,7 +527,7 @@
     (-upper-bound (.atTime date 23 59 59)))
   LocalDateTime
   (-upper-bound [date-time]
-    (-upper-bound (.atOffset date-time (ZoneOffset/UTC))))
+    (-upper-bound (.atOffset date-time ZoneOffset/UTC)))
   OffsetDateTime
   (-upper-bound [date-time]
     (.toEpochSecond date-time)))

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
@@ -90,12 +90,12 @@
            [{:key :fhir/string
              :spec-form `type/string?}
             {:key :fhir.json/string
-             :spec-form `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/string)}
+             :spec-form `(specs/json-regex-primitive "[\\r\\n\\t\\u0020-\\uFFFF]+" type/string)}
             {:key :fhir.xml/string
              :spec-form
              `(s2/and
                xml/element?
-               (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
+               (fn [~'e] (xml/value-matches? "[\\r\\n\\t\\u0020-\\uFFFF]+" ~'e))
                (s2/conformer xml/remove-character-content xml/set-extension-tag)
                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                (s2/conformer type/xml->String type/to-xml))}
@@ -127,12 +127,12 @@
            [{:key :fhir/uri
              :spec-form `type/uri?}
             {:key :fhir.json/uri
-             :spec-form `(specs/json-regex-primitive "\\S*" type/uri)}
+             :spec-form `(specs/json-regex-primitive "[\\u0021-\\uFFFF]*" type/uri)}
             {:key :fhir.xml/uri
              :spec-form
              `(s2/and
                xml/element?
-               (fn [~'e] (xml/value-matches? "\\S*" ~'e))
+               (fn [~'e] (xml/value-matches? "[\\u0021-\\uFFFF]*" ~'e))
                (s2/conformer xml/remove-character-content xml/set-extension-tag)
                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                (s2/conformer type/xml->Uri type/to-xml))}
@@ -145,12 +145,12 @@
            [{:key :fhir/canonical
              :spec-form `type/canonical?}
             {:key :fhir.json/canonical
-             :spec-form `(specs/json-regex-primitive "\\S*" type/canonical)}
+             :spec-form `(specs/json-regex-primitive "[\\u0021-\\uFFFF]*" type/canonical)}
             {:key :fhir.xml/canonical
              :spec-form
              `(s2/and
                xml/element?
-               (fn [~'e] (xml/value-matches? "\\S*" ~'e))
+               (fn [~'e] (xml/value-matches? "[\\u0021-\\uFFFF]*" ~'e))
                (s2/conformer xml/remove-character-content xml/set-extension-tag)
                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                (s2/conformer type/xml->Canonical type/to-xml))}
@@ -181,12 +181,12 @@
            [{:key :fhir/code
              :spec-form `type/code?}
             {:key :fhir.json/code
-             :spec-form `(specs/json-regex-primitive "[^\\s]+(\\s[^\\s]+)*" type/code)}
+             :spec-form `(specs/json-regex-primitive "[\\u0021-\\uFFFF]+([ \\t\\n\\r][\\u0021-\\uFFFF]+)*" type/code)}
             {:key :fhir.xml/code
              :spec-form
              `(s2/and
                xml/element?
-               (fn [~'e] (xml/value-matches? "[^\\s]+(\\s[^\\s]+)*" ~'e))
+               (fn [~'e] (xml/value-matches? "[\\u0021-\\uFFFF]+([ \\t\\n\\r][\\u0021-\\uFFFF]+)*" ~'e))
                (s2/conformer xml/remove-character-content xml/set-extension-tag)
                (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
                (s2/conformer type/xml->Code type/to-xml))}
@@ -420,11 +420,11 @@
   (testing "XML representation of Extension"
     (given (group-by :key (impl/struct-def->spec-def (complex-type "Extension")))
       [:fhir.Extension/url 0 :spec-form regexes->str]
-      := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
+      := `(s2/and string? (specs/regex "[\\u0021-\\uFFFF]*" impl/intern-string))
       [:fhir.json.Extension/url 0 :spec-form regexes->str]
-      := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
+      := `(s2/and string? (specs/regex "[\\u0021-\\uFFFF]*" impl/intern-string))
       [:fhir.xml.Extension/url 0 :spec-form regexes->str]
-      := `(s2/and string? (specs/regex "\\S*" impl/intern-string))
+      := `(s2/and string? (specs/regex "[\\u0021-\\uFFFF]*" impl/intern-string))
       [:fhir.xml.Extension/url 0 :representation] := :xmlAttr))
 
   (testing "XML representation of Coding"
@@ -461,14 +461,14 @@
   (testing "JSON representation of Quantity.unit"
     (given (group-by :key (impl/struct-def->spec-def (complex-type "Quantity")))
       [:fhir.json.Quantity/unit 0 :spec-form regexes->str]
-      := `(specs/json-regex-primitive "[ \\r\\n\\t\\S]+" type/intern-string)))
+      := `(specs/json-regex-primitive "[\\r\\n\\t\\u0020-\\uFFFF]+" type/intern-string)))
 
   (testing "XML representation of Quantity.unit"
     (given (group-by :key (impl/struct-def->spec-def (complex-type "Quantity")))
       [:fhir.xml.Quantity/unit 0 :spec-form regexes->str]
       := `(s2/and
            xml/element?
-           (fn [~'e] (xml/value-matches? "[ \\r\\n\\t\\S]+" ~'e))
+           (fn [~'e] (xml/value-matches? "[\\r\\n\\t\\u0020-\\uFFFF]+" ~'e))
            (s2/conformer xml/remove-character-content xml/set-extension-tag)
            (s2/schema {:content (s2/coll-of :fhir.xml/Extension)})
            (s2/conformer type/xml->InternedString type/to-xml))))

--- a/modules/fhir-structure/test/blaze/fhir/spec/type/system_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type/system_test.clj
@@ -305,7 +305,7 @@
       #system/date-time"2020-01"
       #system/date-time"2020-01-01"
       (system/date-time 2020 1 1 0 0 0 0)
-      (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)))
+      (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC))
 
     (are [x] (not (system/date-time? x))
       nil
@@ -379,14 +379,14 @@
           nil (system/date-time 2020 1 1 0 0 1 0) nil?
           nil nil nil?
 
-          (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) true?
-          (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) (system/date-time 2020 1 1 0 0 1 0 (ZoneOffset/UTC)) false?
-          (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) nil nil?
-          (system/date-time 2020 1 1 0 0 1 0 (ZoneOffset/UTC)) (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) false?
-          (system/date-time 2020 1 1 0 0 1 0 (ZoneOffset/UTC)) (system/date-time 2020 1 1 0 0 1 0 (ZoneOffset/UTC)) true?
-          (system/date-time 2020 1 1 0 0 1 0 (ZoneOffset/UTC)) nil nil?
-          nil (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) nil?
-          nil (system/date-time 2020 1 1 0 0 1 0 (ZoneOffset/UTC)) nil?
+          (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) true?
+          (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) (system/date-time 2020 1 1 0 0 1 0 ZoneOffset/UTC) false?
+          (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) nil nil?
+          (system/date-time 2020 1 1 0 0 1 0 ZoneOffset/UTC) (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) false?
+          (system/date-time 2020 1 1 0 0 1 0 ZoneOffset/UTC) (system/date-time 2020 1 1 0 0 1 0 ZoneOffset/UTC) true?
+          (system/date-time 2020 1 1 0 0 1 0 ZoneOffset/UTC) nil nil?
+          nil (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) nil?
+          nil (system/date-time 2020 1 1 0 0 1 0 ZoneOffset/UTC) nil?
           nil nil nil?))
 
       (testing "with date"
@@ -405,8 +405,8 @@
           #system/date-time"2020-01" #system/date-time"2020" nil?
           #system/date-time"2020-01" #system/date-time"2020-01-01" nil?
           #system/date-time"2020-01-01" #system/date-time"2020-01" nil?
-          (system/date-time 2020 1 1 0 0 0 0) (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) nil?
-          (system/date-time 2020 1 1 0 0 0 0 (ZoneOffset/UTC)) (system/date-time 2020 1 1 0 0 0 0) nil?))
+          (system/date-time 2020 1 1 0 0 0 0) (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) nil?
+          (system/date-time 2020 1 1 0 0 0 0 ZoneOffset/UTC) (system/date-time 2020 1 1 0 0 0 0) nil?))
 
       (testing "with date"
         (are [a b pred] (pred (system/equals a b))

--- a/modules/fhir-test-util/src/blaze/fhir/spec/generators.clj
+++ b/modules/fhir-test-util/src/blaze/fhir/spec/generators.clj
@@ -29,19 +29,19 @@
   gen/large-integer)
 
 (def string-value
-  (gen/such-that (partial re-matches #"[ \r\n\t\S]+") gen/string 100))
+  (gen/such-that (partial re-matches #"[\r\n\t\u0020-\uFFFF]+") gen/string 1000))
 
 (def decimal-value
   (gen/fmap #(BigDecimal/valueOf ^double %) (gen/double* {:infinite? false :NaN? false})))
 
 (def uri-value
-  (gen/such-that (partial re-matches #"\S*") gen/string 100))
+  (gen/such-that (partial re-matches #"[\u0021-\uFFFF]*") gen/string 1000))
 
 (def url-value
-  (gen/such-that (partial re-matches #"\S*") gen/string 100))
+  (gen/such-that (partial re-matches #"[\u0021-\uFFFF]*") gen/string 1000))
 
 (def canonical-value
-  (gen/such-that (partial re-matches #"\S*") gen/string 100))
+  (gen/such-that (partial re-matches #"[\u0021-\uFFFF]*") gen/string 1000))
 
 (def base64Binary-value
   (->> (gen/vector gen/char-alphanumeric 4)
@@ -102,7 +102,7 @@
             (gen/tuple hour minute time-second)))
 
 (def code-value
-  (gen/such-that (partial re-matches #"[^\s]+(\s[^\s]+)*") gen/string 100))
+  (gen/such-that (partial re-matches #"[\u0021-\uFFFF]+([ \t\n\r][\u0021-\uFFFF]+)*") gen/string 1000))
 
 (def char-digit
   (gen/fmap char (gen/choose 48 57)))
@@ -117,7 +117,7 @@
                  (gen/fmap str/join (gen/vector gen/char-alphanumeric 1 64))))
 
 (def markdown-value
-  (gen/such-that (partial re-matches #"[ \r\n\t\S]+") gen/string 100))
+  (gen/such-that (partial re-matches #"[\r\n\t\u0020-\uFFFF]+") gen/string 1000))
 
 (def unsignedInt-value
   gen/nat)

--- a/modules/rest-api/test/blaze/rest_api/middleware/resource_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/middleware/resource_test.clj
@@ -78,7 +78,7 @@
       [:body fhir-spec/fhir-type] := :fhir/OperationOutcome
       [:body :issue 0 :severity] := #fhir/code"error"
       [:body :issue 0 :code] := #fhir/code"invariant"
-      [:body :issue 0 :diagnostics] := "Error on value `{}`. Expected type is `code`, regex `[^\\s]+(\\s[^\\s]+)*`."
+      [:body :issue 0 :diagnostics] := "Error on value `{}`. Expected type is `code`, regex `[\\u0021-\\uFFFF]+([ \\t\\n\\r][\\u0021-\\uFFFF]+)*`."
       [:body :issue 0 :expression] := ["gender"]))
 
   (testing "body with bundle with null resource"
@@ -100,7 +100,7 @@
       [:body fhir-spec/fhir-type] := :fhir/OperationOutcome
       [:body :issue 0 :severity] := #fhir/code"error"
       [:body :issue 0 :code] := #fhir/code"invariant"
-      [:body :issue 0 :diagnostics] := "Error on value `{}`. Expected type is `code`, regex `[^\\s]+(\\s[^\\s]+)*`."
+      [:body :issue 0 :diagnostics] := "Error on value `{}`. Expected type is `code`, regex `[\\u0021-\\uFFFF]+([ \\t\\n\\r][\\u0021-\\uFFFF]+)*`."
       [:body :issue 0 :expression] := ["entry[0].resource.gender"])))
 
 (deftest xml-test


### PR DESCRIPTION
If resources contain control characters like \u001e (record separator) in strings or other string like primitive type values, the XML generator can't output them. Because the resulting exception is not handled, the output hangs and will never finish.

Closes: #1552