### PR TITLE
Generalize $evaluate-measure Timeout Handling

### DIFF
--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql/spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql/spec.clj
@@ -7,20 +7,15 @@
    [blaze.fhir.operation.evaluate-measure :as-alias evaluate-measure]
    [blaze.fhir.operation.evaluate-measure.cql :as-alias cql]
    [blaze.fhir.operation.evaluate-measure.spec]
-   [clojure.spec.alpha :as s]
-   [java-time.api :as time]))
+   [clojure.spec.alpha :as s]))
 
-(s/def ::cql/timeout-eclipsed?
+(s/def ::cql/interrupted?
   ifn?)
-
-(s/def ::cql/timeout
-  time/duration?)
 
 (s/def ::cql/context
   (s/merge
    ::expr/context
-   (s/keys :req-un [::cql/timeout-eclipsed? ::cql/timeout
-                    ::c/expression-defs])))
+   (s/keys :req-un [::cql/interrupted? ::c/expression-defs])))
 
 (s/def ::cql/reduce-op
   fn?)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_spec.clj
@@ -18,7 +18,7 @@
                :subject (s/nilable ed/resource?)
                :name string?
                :expression ::c/expression)
-  :ret ac/completable-future?)
+  :ret (s/or :result any? :anomaly ::anom/anomaly))
 
 (s/fdef cql/evaluate-expression
   :args (s/cat :context ::cql/evaluate-expression-context :name string?

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure/stratifier_test.clj
@@ -14,7 +14,6 @@
    [clojure.spec.test.alpha :as st]
    [clojure.test :as test :refer [deftest is testing]]
    [cognitect.anomalies :as anom]
-   [java-time.api :as time]
    [juxt.iota :refer [given]])
   (:import
    [java.time Clock OffsetDateTime]))
@@ -162,8 +161,7 @@
     (cond->
      {:db (d/db node)
       :now (now fixed-clock)
-      :timeout-eclipsed? (constantly false)
-      :timeout (time/seconds 42)
+      :interrupted? (constantly false)
       :expression-defs expression-defs
       :executor executor}
       function-defs

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -28,7 +28,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -25,7 +25,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 


### PR DESCRIPTION
Instead of an explicit timeout-eclipsed? function and timeout value, an interrupted? function is used that returns the anomaly to be propagated.

We will use the generalized functionality later to be able to cancel evaluations.