### PR TITLE
Add Estimated Number of Keys Function

### DIFF
--- a/modules/admin-api/src/blaze/admin_api.clj
+++ b/modules/admin-api/src/blaze/admin_api.clj
@@ -4,6 +4,7 @@
    [blaze.admin-api.validation]
    [blaze.anomaly :as ba :refer [if-ok]]
    [blaze.async.comp :as ac :refer [do-sync]]
+   [blaze.db.kv :as kv]
    [blaze.db.kv.rocksdb :as rocksdb]
    [blaze.elm.expression :as-alias expr]
    [blaze.fhir.response.create :as create-response]
@@ -86,7 +87,7 @@
 (defn- column-family-data [db column-family]
   (let [long-property (partial rocksdb/long-property db column-family)]
     {:name (name column-family)
-     :estimate-num-keys (long-property "rocksdb.estimate-num-keys")
+     :estimate-num-keys (kv/estimate-num-keys db column-family)
      :estimate-live-data-size (long-property "rocksdb.estimate-live-data-size")
      :live-sst-files-size (long-property "rocksdb.live-sst-files-size")
      :size-all-mem-tables (long-property "rocksdb.size-all-mem-tables")}))

--- a/modules/kv/src/blaze/db/kv.clj
+++ b/modules/kv/src/blaze/db/kv.clj
@@ -183,3 +183,10 @@
   Writes are atomic. Blocks."
   [store entries]
   (p/-write store entries))
+
+(defn estimate-num-keys
+  "Returns the estimated number of keys in `column-family` of `store`.
+
+  Returns an anomaly if the column-family was not found."
+  [store column-family]
+  (p/-estimate-num-keys store column-family))

--- a/modules/kv/src/blaze/db/kv/protocols.clj
+++ b/modules/kv/src/blaze/db/kv/protocols.clj
@@ -43,4 +43,6 @@
 
   (-delete [store entries])
 
-  (-write [store entries]))
+  (-write [store entries])
+
+  (-estimate-num-keys [store column-family]))

--- a/modules/kv/src/blaze/db/kv_spec.clj
+++ b/modules/kv/src/blaze/db/kv_spec.clj
@@ -4,7 +4,8 @@
    [blaze.coll.spec :as cs]
    [blaze.db.kv :as kv]
    [blaze.db.kv.spec]
-   [clojure.spec.alpha :as s]))
+   [clojure.spec.alpha :as s]
+   [cognitect.anomalies :as anom]))
 
 (s/fdef kv/valid?
   :args (s/cat :iter ::kv/iterator)
@@ -79,3 +80,7 @@
 (s/fdef kv/write!
   :args (s/cat :kv-store :blaze.db/kv-store
                :entries (cs/coll-of ::kv/write-entry)))
+
+(s/fdef kv/estimate-num-keys
+  :args (s/cat :kv-store :blaze.db/kv-store :column-family simple-keyword?)
+  :ret (s/or :estimate-num-keys nat-int? :anomaly ::anom/anomaly))

--- a/modules/rocksdb/src/blaze/db/kv/rocksdb.clj
+++ b/modules/rocksdb/src/blaze/db/kv/rocksdb.clj
@@ -206,6 +206,9 @@
       (impl/write-wb! cfhs wb entries)
       (.write db write-opts wb)))
 
+  (-estimate-num-keys [store column-family]
+    (p/-long-property store column-family "rocksdb.estimate-num-keys"))
+
   p/Rocks
   (-path [_]
     path)


### PR DESCRIPTION
We need this functionality for all key-value instead of only for RocksDB because we will use it in the CQL expression cache.

Needed in: #1051