### PR TITLE
Improve Workflow Permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
     - main
   merge_group:
 
+permissions: read-all
+
 jobs:
   fmt:
     runs-on: ubuntu-22.04
@@ -1849,7 +1851,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       packages: write
-      contents: write
     strategy:
       matrix:
         image:
@@ -1962,7 +1963,6 @@ jobs:
     - push-image
     runs-on: ubuntu-22.04
     permissions:
-      packages: write
       contents: write
 
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,8 @@ on:
     - main
   merge_group:
 
+permissions: read-all
+
 jobs:
   test-coverage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,6 @@ on:
     - main
   merge_group:
 
-# Declare default permissions as read only.
 permissions: read-all
 
 jobs:
@@ -21,9 +20,6 @@ jobs:
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
 
     steps:
     - name: "Checkout code"


### PR DESCRIPTION
Set default permissions to read-all and remove write permission for content in push-image and for pages in release.