### PR TITLE
Remove Merge Group Trigger from Scorecard Workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
     - main
-  merge_group:
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Score card isn't compatible with merge-group event trigger.