### PR TITLE
Remove Push Main Event Trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   schedule:
   - cron: '0 10 * * *' # every day at 10am
   push:
-    branches:
-    - main
     tags:
     - 'v*.*.*'
   pull_request:


### PR DESCRIPTION
Because PR's are rebased and pushed onto main now, we will have an extra build workflow running for already checked commits. By removing the push trigger, we save that runs.