### PR TITLE
Improve Error Handling in CI Scripts

### DIFF
--- a/.github/scripts/evaluate-measure-blazectl-stratifier.sh
+++ b/.github/scripts/evaluate-measure-blazectl-stratifier.sh
@@ -1,10 +1,16 @@
-#!/bin/bash -e
+#!/bin/bash
 
 BASE="http://localhost:8080/fhir"
 NAME="$1"
 EXPECTED_COUNT="$2"
 
-REPORT=$(blazectl --server "$BASE" evaluate-measure ".github/scripts/cql/$NAME.yml" 2> /dev/null)
+REPORT=$(blazectl --server "$BASE" evaluate-measure ".github/scripts/cql/$NAME.yml")
+
+if [ $? -ne 0 ]; then
+  echo "Measure evaluation failed: $REPORT"
+  exit 1
+fi
+
 COUNT=$(echo "$REPORT" | jq '.group[0].population[0].count')
 
 if [ "$COUNT" = "$EXPECTED_COUNT" ]; then

--- a/.github/scripts/evaluate-measure-blazectl.sh
+++ b/.github/scripts/evaluate-measure-blazectl.sh
@@ -1,10 +1,17 @@
-#!/bin/bash -e
+#!/bin/bash
 
 BASE="http://localhost:8080/fhir"
 NAME="$1"
 EXPECTED_COUNT="$2"
 
-COUNT=$(blazectl --server "$BASE" evaluate-measure ".github/scripts/cql/$NAME.yml" 2> /dev/null | jq '.group[0].population[0].count')
+REPORT=$(blazectl --server "$BASE" evaluate-measure ".github/scripts/cql/$NAME.yml")
+
+if [ $? -ne 0 ]; then
+  echo "Measure evaluation failed: $REPORT"
+  exit 1
+fi
+
+COUNT=$(echo "$REPORT" | jq '.group[0].population[0].count')
 
 if [ "$COUNT" = "$EXPECTED_COUNT" ]; then
   echo "OK 👍: count ($COUNT) equals the expected count"


### PR DESCRIPTION
In case blazectl exits with an error, it will be printed now.