### PR TITLE
Tidy Up Dependencies

### DIFF
--- a/modules/rest-api/Makefile
+++ b/modules/rest-api/Makefile
@@ -13,6 +13,12 @@ test: prep
 test-coverage: prep
 	clojure -M:test:coverage
 
+deps-tree:
+	clojure -X:deps tree
+
+deps-list:
+	clojure -X:deps list
+
 cloc-prod:
 	cloc src
 
@@ -22,4 +28,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/rest-util/Makefile
+++ b/modules/rest-util/Makefile
@@ -13,6 +13,12 @@ test: prep
 test-coverage: prep
 	clojure -M:test:coverage
 
+deps-tree:
+	clojure -X:deps tree
+
+deps-list:
+	clojure -X:deps list
+
 cloc-prod:
 	cloc src
 
@@ -22,4 +28,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/rest-util/deps.edn
+++ b/modules/rest-util/deps.edn
@@ -16,7 +16,7 @@
 
   metosin/reitit-ring
   {:mvn/version "0.7.1"
-   :exclusions [org.apache.commons/commons-fileupload2-core]}
+   :exclusions [ring/ring-core]}
 
   metosin/muuntaja
   {:mvn/version "0.6.10"


### PR DESCRIPTION
Removed the dependencies crypto-equality/crypto-equality and crypto-random/crypto-random as originally planned. They only sneaked in through a transitive dependency on ring/ring-core from metosin/reitit-ring.