### PR TITLE
Optimize Thread Usage while Loading Resources

### DIFF
--- a/modules/db-resource-store/src/blaze/db/resource_store.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store.clj
@@ -13,7 +13,7 @@
 
 (defn get
   "Returns a CompletableFuture that will complete with the resource content of
-  `hash` or nil if it was not found."
+  `hash` or will complete with nil if it was not found."
   [store hash]
   (-get store hash))
 

--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -54,10 +54,13 @@
 
   Returns a CompletableFuture that will complete with the database after the
   transaction in case of success or will complete exceptionally with an anomaly
-  in case of a transaction error or other errors."
+  in case of a transaction error or other errors.
+
+  Functions applied after the returned future are executed on the common
+  ForkJoinPool."
   [node tx-ops]
   (-> (np/-submit-tx node tx-ops)
-      (ac/then-compose-async #(np/-tx-result node %))))
+      (ac/then-compose #(np/-tx-result node %))))
 
 (defn changed-resources-publisher
   "Returns a publisher that publishes all changed resources of `type`."
@@ -459,7 +462,10 @@
 
 (defn pull
   "Returns a CompletableFuture that will complete with the resource of
-  `resource-handle` or an anomaly in case of errors."
+  `resource-handle` or an anomaly in case of errors.
+
+  Functions applied after the returned future are executed on the common
+  ForkJoinPool."
   [node-or-db resource-handle]
   (p/-pull node-or-db resource-handle))
 

--- a/modules/db/src/blaze/db/impl/db.clj
+++ b/modules/db/src/blaze/db/impl/db.clj
@@ -15,7 +15,7 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-(deftype Db [node kv-store basis-t t]
+(defrecord Db [node kv-store basis-t t]
   p/Db
   (-node [_]
     node)

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -2,7 +2,7 @@
   "This namespace contains the local database node component."
   (:require
    [blaze.anomaly :as ba :refer [if-ok when-ok]]
-   [blaze.async.comp :as ac :refer [do-async do-sync]]
+   [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.async.flow :as flow]
    [blaze.db.api :as d]
    [blaze.db.impl.batch-db :as batch-db]
@@ -335,19 +335,19 @@
 
   p/Pull
   (-pull [_ resource-handle]
-    (do-async [resource (get-resource resource-store resource-handle)]
+    (do-sync [resource (get-resource resource-store resource-handle)]
       (or (some->> resource (enhance-resource tx-cache resource-handle))
           (resource-content-not-found-anom resource-handle))))
 
   (-pull-content [_ resource-handle]
-    (do-async [resource (get-resource resource-store resource-handle)]
+    (do-sync [resource (get-resource resource-store resource-handle)]
       (or (some-> resource (with-meta (meta resource-handle)))
           (resource-content-not-found-anom resource-handle))))
 
   (-pull-many [_ resource-handles]
     (let [resource-handles (vec resource-handles)           ; don't evaluate resource-handles twice
           hashes (hashes-of-non-deleted resource-handles)]
-      (do-async [resources (rs/multi-get resource-store hashes)]
+      (do-sync [resources (rs/multi-get resource-store hashes)]
         (into
          []
          (comp (map (partial to-resource tx-cache resources))

--- a/modules/db/src/blaze/db/node/resource_indexer.clj
+++ b/modules/db/src/blaze/db/node/resource_indexer.clj
@@ -2,7 +2,7 @@
   "This namespace contains the resource indexer component."
   (:require
    [blaze.anomaly :as ba]
-   [blaze.async.comp :as ac :refer [do-async do-sync]]
+   [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.coll.core :as coll]
    [blaze.db.impl.codec :as codec]
    [blaze.db.impl.index.compartment.resource :as cr]
@@ -131,8 +131,7 @@
     (if resources
       (index-resources* context resources)
       (-> (rs/multi-get resource-store (hashes tx-cmds))
-          (ac/then-compose-async
-           (partial index-resources* context))))))
+          (ac/then-compose (partial index-resources* context))))))
 
 (defn- re-index-resource [search-param [hash resource]]
   (log/trace "Re-index resource with hash" (str hash))
@@ -150,7 +149,7 @@
 (defn- re-index-resources*
   [{:keys [resource-store kv-store executor]} search-param resource-handles]
   (log/trace "Re-index" (count resource-handles) "resource(s)")
-  (do-async [resources (rs/multi-get resource-store (mapv rh/hash resource-handles))]
+  (do-sync [resources (rs/multi-get resource-store (mapv rh/hash resource-handles))]
     (async-re-index-resources kv-store executor search-param resources)))
 
 (defn re-index-resources

--- a/modules/interaction/src/blaze/interaction/delete.clj
+++ b/modules/interaction/src/blaze/interaction/delete.clj
@@ -3,7 +3,7 @@
 
   https://www.hl7.org/fhir/http.html#delete"
   (:require
-   [blaze.async.comp :as ac]
+   [blaze.async.comp :refer [do-sync]]
    [blaze.db.api :as d]
    [blaze.db.spec]
    [blaze.handler.fhir.util :as fhir-util]
@@ -28,5 +28,5 @@
   (log/info "Init FHIR delete interaction handler")
   (fn [{{{:fhir.resource/keys [type]} :data} ::reitit/match
         {:keys [id]} :path-params}]
-    (-> (d/transact node [[:delete type id]])
-        (ac/then-apply build-response))))
+    (do-sync [db (d/transact node [[:delete type id]])]
+      (build-response db))))

--- a/modules/interaction/src/blaze/interaction/read.clj
+++ b/modules/interaction/src/blaze/interaction/read.clj
@@ -4,7 +4,7 @@
   https://www.hl7.org/fhir/http.html#read"
   (:require
    [blaze.anomaly :as ba]
-   [blaze.async.comp :as ac :refer [do-async]]
+   [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.db.spec]
    [blaze.handler.fhir.util :as fhir-util]
    [integrant.core :as ig]
@@ -21,7 +21,7 @@
 (def ^:private handler
   (fn [{{{:fhir.resource/keys [type]} :data} ::reitit/match
         {:keys [id]} :path-params :blaze/keys [db]}]
-    (do-async [resource (fhir-util/pull db type id)]
+    (do-sync [resource (fhir-util/pull db type id)]
       (response resource))))
 
 (defn- wrap-invalid-id [handler]

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -4,7 +4,7 @@
   https://www.hl7.org/fhir/http.html#transaction"
   (:require
    [blaze.anomaly :as ba :refer [if-ok when-ok]]
-   [blaze.async.comp :as ac :refer [do-async do-sync]]
+   [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.coll.core :as coll]
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
@@ -136,14 +136,14 @@
     ;; transaction because a new id is created for POST requests
     (if-let [handle (d/resource-handle db type id)]
       (if (identical? :blaze.preference.return/representation return-preference)
-        (do-async [resource (pull db handle)]
+        (do-sync [resource (pull db handle)]
           (assoc (created-entry context type handle) :resource resource))
         (ac/completed-future (created-entry context type handle)))
       (let [if-none-exist (-> entry :request :ifNoneExist)
             clauses (conditional-clauses if-none-exist)
             handle (coll/first (d/type-query db type clauses))]
         (if (identical? :blaze.preference.return/representation return-preference)
-          (do-async [resource (pull db handle)]
+          (do-sync [resource (pull db handle)]
             (assoc (noop-entry db handle) :resource resource))
           (ac/completed-future (noop-entry db handle)))))))
 
@@ -170,7 +170,7 @@
   (let [type (name type)
         [new-handle old-handle] (into [] (take 2) (d/instance-history db type id))]
     (if (identical? :blaze.preference.return/representation return-preference)
-      (do-async [resource (pull db new-handle)]
+      (do-sync [resource (pull db new-handle)]
         (assoc (update-entry context type tx-op old-handle new-handle) :resource resource))
       (ac/completed-future (update-entry context type tx-op old-handle new-handle)))))
 

--- a/modules/job-async-interaction/src/blaze/job/async_interaction.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction.clj
@@ -110,11 +110,11 @@
 (defn- on-start
   [{:keys [admin-node] ::keys [running-jobs] :as context} job]
   (-> (u/pull-request-bundle admin-node job)
-      (ac/then-compose-async
+      (ac/then-compose
        (fn [{entries :entry}]
          (if-let [t (t job)]
            (-> (job-util/update-job admin-node job start-job)
-               (ac/then-compose-async
+               (ac/then-compose
                 (fn [{:keys [id] :as job}]
                   (swap! running-jobs assoc id false)
                   (let [start (System/currentTimeMillis)]
@@ -127,7 +127,7 @@
                          (fn [e]
                            (if (ba/interrupted? e)
                              (-> (job-util/pull-job admin-node id)
-                                 (ac/then-compose-async
+                                 (ac/then-compose
                                   #(job-util/update-job admin-node % finish-cancellation)))
                              (ac/completed-future e))))
                         (ac/when-complete

--- a/modules/job-re-index/src/blaze/job/re_index.clj
+++ b/modules/job-re-index/src/blaze/job/re_index.clj
@@ -118,7 +118,7 @@
       (job-util/update-job admin-node job job-util/fail-job anomaly)
       (cond-> (update-job context job result)
         next
-        (ac/then-compose-async
+        (ac/then-compose
          (fn [job]
            (-> (re-index (name (:fhir/type next)) (:id next))
                (ac/handle (continuation context re-index job))
@@ -134,7 +134,7 @@
       (if-ok [total (d/re-index-total main-db search-param-url)]
         (let [re-index (re-index-fn main-db search-param-url)]
           (-> (job-util/update-job admin-node job start-job total)
-              (ac/then-compose-async
+              (ac/then-compose
                (fn [job]
                  (-> (re-index)
                      (ac/handle (continuation context re-index job))

--- a/modules/job-scheduler/tests.edn
+++ b/modules/job-scheduler/tests.edn
@@ -5,6 +5,7 @@
                   :color? false}
              :coverage {:plugins [:kaocha.plugin/cloverage]
                         :cloverage/opts
-                        {:codecov? true}
+                        {:ns-exclude-regex [".+\\.spec"],
+                         :codecov? true}
                         :reporter kaocha.report/documentation
                         :color? false}}]

--- a/modules/job-util/src/blaze/job/util.clj
+++ b/modules/job-util/src/blaze/job/util.clj
@@ -144,6 +144,8 @@
   (assoc e ::js/action :update-job))
 
 (defn pull-job
+  "Functions applied after the returned future are executed on the common
+  ForkJoinPool."
   ([node id]
    (pull-job node (d/db node) id))
   ([node db id]
@@ -183,7 +185,10 @@
 
   Returns a CompletableFuture that will complete with the job after the
   transaction in case of success or will complete exceptionally with an anomaly
-  in case of a transaction error or other errors."
+  in case of a transaction error or other errors.
+
+  Functions applied after the returned future are executed on the common
+  ForkJoinPool."
   {:arglists '([node job f] [node job f x])}
   ([node job f]
    (update-job+ node job nil f))

--- a/modules/module-test-util/src/blaze/module/test_util.clj
+++ b/modules/module-test-util/src/blaze/module/test_util.clj
@@ -1,6 +1,10 @@
 (ns blaze.module.test-util
   (:require
+   [blaze.async.comp :refer [do-sync]]
+   [clojure.string :as str]
    [integrant.core :as ig]))
+
+(set! *warn-on-reflection* true)
 
 (defmacro with-system
   "Runs `body` inside a system that is initialized from `config`, bound to
@@ -12,3 +16,15 @@
          ~@body)
        (finally
          (ig/halt! system#)))))
+
+(defn assoc-thread-name
+  "Associates the name of the thread on which a function will be executed after
+  `future` completes normally under :thread-name in the metadata of the returned
+  value."
+  [future]
+  (do-sync [value future]
+    (vary-meta value assoc :thread-name (.getName (Thread/currentThread)))))
+
+(defn common-pool-thread? [thread-name]
+  (or (str/starts-with? thread-name "ForkJoinPool.commonPool")
+      (= (.getName (Thread/currentThread)) thread-name)))

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -1,7 +1,7 @@
 (ns blaze.fhir.operation.evaluate-measure.measure
   (:require
    [blaze.anomaly :as ba :refer [if-ok when-ok]]
-   [blaze.async.comp :as ac :refer [do-async do-sync]]
+   [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.coll.core :as coll]
    [blaze.cql-translator :as cql-translator]
    [blaze.db.api :as d]
@@ -142,7 +142,7 @@
   Returns an anomaly on errors."
   [db measure opts]
   (if-let [library-ref (-> measure :library first type/value)]
-    (do-async [library (find-library db library-ref)]
+    (do-sync [library (find-library db library-ref)]
       (compile-library (d/node db) library opts))
     (ac/completed-future
      (ba/unsupported

--- a/modules/rest-api/src/blaze/rest_api/async_status_cancel_handler.clj
+++ b/modules/rest-api/src/blaze/rest_api/async_status_cancel_handler.clj
@@ -19,7 +19,7 @@
 (defn- handler [job-scheduler]
   (fn [{{:keys [id]} :path-params}]
     (-> (js/cancel-job job-scheduler id)
-        (ac/then-apply-async
+        (ac/then-apply
          (fn [_]
            (ring/status 202)))
         (ac/exceptionally

--- a/modules/rest-util/src/blaze/fhir/response/create.clj
+++ b/modules/rest-util/src/blaze/fhir/response/create.clj
@@ -1,6 +1,6 @@
 (ns blaze.fhir.response.create
   (:require
-   [blaze.async.comp :as ac :refer [do-async]]
+   [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.db.api :as d]
    [blaze.fhir.spec :as fhir-spec]
    [blaze.handler.fhir.util :as fhir-util]
@@ -32,7 +32,7 @@
         created (and (not (keep? tx-op))
                      (or (nil? old-handle) (identical? :delete (:op old-handle))))]
     (log/trace (format "build-response of %s/%s with vid = %s" type id vid))
-    (do-async [body (body context new-handle)]
+    (do-sync [body (body context new-handle)]
       (cond->
        (-> (ring/response body)
            (ring/status (if created 201 200))

--- a/modules/rest-util/src/blaze/handler/fhir/util.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util.clj
@@ -162,7 +162,10 @@
 
   Returns a not-found anomaly if the resource was not found or is deleted. In
   case it is deleted, sets :http/status to 410 and :http/headers Last-Modified
-  and ETag to appropriate values."
+  and ETag to appropriate values.
+
+  Functions applied after the returned future are executed on the common
+  ForkJoinPool."
   [db type id]
   (if-ok [resource-handle (resource-handle db type id)]
     (-> (d/pull db resource-handle)

--- a/modules/rest-util/test/blaze/handler/fhir/util_test.clj
+++ b/modules/rest-util/test/blaze/handler/fhir/util_test.clj
@@ -9,7 +9,7 @@
    [blaze.fhir.test-util :refer [given-failed-future]]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.handler.fhir.util-spec]
-   [blaze.module.test-util :refer [with-system]]
+   [blaze.module.test-util :as mtu :refer [with-system]]
    [blaze.test-util :as tu :refer [satisfies-prop]]
    [clojure.set :as set]
    [clojure.spec.alpha :as s]
@@ -236,9 +236,10 @@
     (with-system-data [{:blaze.db/keys [node]} mem-node-config]
       [[[:put {:fhir/type :fhir/Patient :id "0"}]]]
 
-      (given @(fhir-util/pull (d/db node) "Patient" "0")
+      (given @(mtu/assoc-thread-name (fhir-util/pull (d/db node) "Patient" "0"))
         :fhir/type := :fhir/Patient
-        :id := "0")))
+        :id := "0"
+        [meta :thread-name] :? mtu/common-pool-thread?)))
 
   (testing "pull error"
     (with-redefs


### PR DESCRIPTION
Before this change, the KV Resource Store used it's thread pool for both loading and parsing/conforming the resources. However loading is I/O but parsing/conforming is CPU bound. So it is better to use the KV Resource Store Executor only for the loading, the I/O part.

With this change the KV Resource Store uses do-async to change to a common ForkJoinPool thread. This change has also the advantage that functions that are applied after the returned future do not have to change the thread pool because the futures are already on the common ForkJoinPool.

Removed all pool switching async functions. Tested the thread pool used.