### PR TITLE
Update to Java 21 and Remove Testing for Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,13 +119,10 @@ jobs:
         - thread-pool-executor-collector
 
         java-version:
-        - '11'
         - '17'
         - '21'
 
         exclude:
-        - module: jepsen
-          java-version: '11'
         - module: jepsen
           java-version: '17'
 
@@ -166,7 +163,6 @@ jobs:
     strategy:
       matrix:
         java-version:
-        - '11'
         - '17'
         - '21'
 
@@ -212,7 +208,7 @@ jobs:
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@bc7570e912b028bbcc22f457adec7fdf98e2f4ed # 12.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.11_9-jre-jammy@sha256:e1f29ad3b15560942b5e1a0052bf732680ec8b2e921e07a8cb735b0fa9d99213
+FROM eclipse-temurin:21.0.4_7-jre-jammy@sha256:78d4dd1a43af317620ae19428e126e20fd8a02149f07365371a6baddae18898b
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install libjemalloc2 -y && \

--- a/docs/performance/synthea/Dockerfile
+++ b/docs/performance/synthea/Dockerfile
@@ -1,5 +1,4 @@
-FROM eclipse-temurin:17.0.11_9-jre@sha256:b9f5c0acd03eb8275690fe310506f62743a5aaf90e37d165bc0484037a5a9376
-
+FROM eclipse-temurin:21.0.4_7-jre-jammy@sha256:78d4dd1a43af317620ae19428e126e20fd8a02149f07365371a6baddae18898b
 
 ADD https://github.com/synthetichealth/synthea/releases/download/v3.1.1/synthea-with-dependencies.jar /gen/synthea.jar
 COPY synthea.properties /gen/

--- a/modules/ingress/gen-trust-store.sh
+++ b/modules/ingress/gen-trust-store.sh
@@ -5,6 +5,6 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 NAME="$1"
 
 docker run --rm -v "$SCRIPT_DIR":/tls-cert \
-  eclipse-temurin:17-jre-jammy@sha256:c1dd17f6b753f0af572069fb80dcacdc687f5d1ae3e05c98d5f699761b84a10a \
+  eclipse-temurin:21.0.4_7-jre-jammy@sha256:78d4dd1a43af317620ae19428e126e20fd8a02149f07365371a6baddae18898b \
   keytool -importcert -storetype PKCS12 -keystore "/tls-cert/$NAME-trust-store.p12" \
   -storepass "insecure" -alias ca -file "/tls-cert/$NAME-cert.pem" -noprompt


### PR DESCRIPTION
That means, we now support Java 17 and use Java 21 as default in our Docker images.