### PR TITLE
Refactor Function blaze.elm.util/parse-type

### DIFF
--- a/docs/implementation/database.md
+++ b/docs/implementation/database.md
@@ -120,14 +120,14 @@ The `SystemStats` index keeps track of the total number of resources, and the nu
 
 The indices not depending on `t` directly point to the resource versions by their content hash. 
 
-| Name                                | Key Parts                                                        | Value |
+| Name                                | Key Parts                                                      | Value |
 |-------------------------------------|----------------------------------------------------------------|-------|
 | SearchParamValueResource            | search-param, type, value, id, hash-prefix                     | -     |
 | ResourceSearchParamValue            | type, id, hash-prefix, search-param, value                     | -     |
 | CompartmentSearchParamValueResource | comp-code, comp-id, search-param, type, value, id, hash-prefix | -     |
 | CompartmentResourceType             | comp-code, comp-id, type, id                                   | -     |
 | SearchParam                         | code, type                                                     | id    |
-| ActiveSearchParams                  | id                                                               | -     |
+| ActiveSearchParams                  | id                                                             | -     |
 
 #### SearchParamValueResource
 

--- a/modules/cql/src/blaze/elm/util.clj
+++ b/modules/cql/src/blaze/elm/util.clj
@@ -17,9 +17,12 @@
     [ns name]))
 
 (defn parse-type
+  "Transforms `type-specifier` into either the type name or a vector of the
+  type name for list types."
+  {:arglists '([type-specifier])}
   [{:keys [type name] element-type :elementType}]
   (condp = type
     "NamedTypeSpecifier"
     (second (parse-qualified-name name))
     "ListTypeSpecifier"
-    (str "List<" (parse-type element-type) ">")))
+    [(parse-type element-type)]))

--- a/modules/cql/test/blaze/elm/util_spec.clj
+++ b/modules/cql/test/blaze/elm/util_spec.clj
@@ -7,3 +7,7 @@
 (s/fdef elm-util/parse-qualified-name
   :args (s/cat :s (s/nilable string?))
   :ret (s/nilable (s/tuple string? string?)))
+
+(s/fdef elm-util/parse-type
+  :args (s/cat :type-specifier :elm/type-specifier)
+  :ret (s/nilable (s/or :type string? :list-type (s/tuple string?))))

--- a/modules/cql/test/blaze/elm/util_test.clj
+++ b/modules/cql/test/blaze/elm/util_test.clj
@@ -30,5 +30,8 @@
   (testing "ELM type"
     (is (= "String" (elm-util/parse-type {:type "NamedTypeSpecifier" :name "{urn:hl7-org:elm-types:r1}String"}))))
 
+  (testing "FHIR type"
+    (is (= "Encounter" (elm-util/parse-type {:type "NamedTypeSpecifier" :name "{http://hl7.org/fhir}Encounter"}))))
+
   (testing "list type"
-    (is (= "List<Encounter>" (elm-util/parse-type {:type "ListTypeSpecifier" :elementType {:type "NamedTypeSpecifier" :name "{http://hl7.org/fhir}Encounter"}})))))
+    (is (= ["Encounter"] (elm-util/parse-type {:type "ListTypeSpecifier" :elementType {:type "NamedTypeSpecifier" :name "{http://hl7.org/fhir}Encounter"}})))))

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
@@ -127,6 +127,11 @@
     (elm-util/parse-type {:type "NamedTypeSpecifier" :name result-type-name})
     (elm-util/parse-type result-type-specifier)))
 
+(defn- render-result-type [result-type]
+  (if (vector? result-type)
+    (format "List<%s>" (first result-type))
+    result-type))
+
 (defn- check-result-type
   "Returns an anomaly if `population-basis` is not compatible with the result
   type of `expression-def`."
@@ -137,14 +142,14 @@
       (when-not (= "Boolean" result-type)
         (ba/incorrect
          (format "The result type `%s` of the expression `%s` differs from the population basis :boolean."
-                 result-type name)
+                 (render-result-type result-type) name)
          :expression-name name
          :population-basis :boolean
          :expression-result-type result-type))
-      (when-not (= (str "List<" population-basis ">") result-type)
+      (when-not (= [population-basis] result-type)
         (ba/incorrect
          (format "The result type `%s` of the expression `%s` differs from the population basis `%s`."
-                 result-type name population-basis)
+                 (render-result-type result-type) name population-basis)
          :expression-name name
          :population-basis population-basis
          :expression-result-type result-type)))))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/cql_test.clj
@@ -201,7 +201,7 @@
             ::anom/message := "The result type `List<Encounter>` of the expression `InInitialPopulation` differs from the population basis :boolean."
             :expression-name := "InInitialPopulation"
             :population-basis := :boolean
-            :expression-result-type := "List<Encounter>"))))
+            :expression-result-type := ["Encounter"]))))
 
     (testing "Encounter"
       (with-system [system config]


### PR DESCRIPTION
The function now returns a vector of the type name instead of the rendered string List<...> for list types.