### PR TITLE
Demonstrate the Version Independent CQL Retrieve

### DIFF
--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -932,6 +932,8 @@
       [:resource :extension bloom-filter-ratio :value :denominator :value] := 6M
       [first-population :count] := 1))
 
+  (testing-query "q59-icd10-code-version-independent" 2)
+
   (let [result (evaluate "q1" "subject-list")]
     (testing "MeasureReport is valid"
       (is (s/valid? :blaze/resource (:resource result))))
@@ -1194,4 +1196,4 @@
 
 (comment
   (log/set-level! :debug)
-  (evaluate "q58-overly-large-nonparsable-query"))
+  (evaluate "q59-icd10-code-version-independent"))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q59-icd10-code-version-independent.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q59-icd10-code-version-independent.cql
@@ -1,0 +1,10 @@
+library "q59-icd10-code-version-independent"
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0'
+
+codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+
+context Patient
+
+define InInitialPopulation:
+  exists [Condition: Code 'E10.6' from icd10]

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q59-icd10-code-version-independent.json
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q59-icd10-code-version-independent.json
@@ -1,0 +1,130 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "0"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/0"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "1"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "2"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/2"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/0"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "0",
+        "code": {
+          "coding": [
+            {
+              "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+              "version": "2024",
+              "code": "E10.6"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/0"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/1"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "1",
+        "code": {
+          "coding": [
+            {
+              "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+              "code": "E10.6"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/1"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Measure",
+        "id": "0",
+        "url": "0",
+        "status": "active",
+        "subjectCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/resource-types",
+              "code": "Patient"
+            }
+          ]
+        },
+        "library": [
+          "0"
+        ],
+        "scoring": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+              "code": "cohort"
+            }
+          ]
+        },
+        "group": [
+          {
+            "population": [
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "initial-population"
+                    }
+                  ]
+                },
+                "criteria": {
+                  "language": "text/cql-identifier",
+                  "expression": "InInitialPopulation"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Measure/0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I was unsure but because the retrieve expression uses FHIR Search internally, it's actually version independent.