### PR TITLE
Update clj-kondo to v2024.08.01

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,6 +9,9 @@
   {:level :warning}
 
   :keyword-binding
-  {:level :error}}
+  {:level :error}
+
+  :redundant-str-call
+  {:level :warning}}
 
  :skip-comments true}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@bc7570e912b028bbcc22f457adec7fdf98e2f4ed # 12.5
       with:
-        clj-kondo: '2024.03.13'
+        clj-kondo: '2024.08.01'
 
     - name: Check out Git repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/modules/rest-api/.clj-kondo/config.edn
+++ b/modules/rest-api/.clj-kondo/config.edn
@@ -8,5 +8,6 @@
  :lint-as
  {blaze.rest-api.async-status-handler-test/with-handler clojure.core/fn
   blaze.rest-api.async-status-cancel-handler-test/with-handler clojure.core/fn
+  blaze.rest-api.batch-handler-test/with-handler clojure.core/fn
   blaze.rest-api.capabilities-handler-test/with-handler clojure.core/let
   blaze.rest-api.metadata-handler-test/with-handler clojure.core/fn}}


### PR DESCRIPTION
Added forgotten blaze.rest-api.batch-handler-test/with-handler to lint-as because handler was considered the handler function at the same namespace and the type checking used that handler function to discover the return value of calling handler instead of the handler function defined by with-handler.