### PR TITLE
CQL Now Should return a LocalDateTime

### DIFF
--- a/modules/cql/src/blaze/elm/compiler/date_time_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/date_time_operators.clj
@@ -457,7 +457,7 @@
 (def ^:private now-expression
   (reify-expr core/Expression
     (-eval [_ {:keys [now]} _ _]
-      now)
+      (p/to-date-time now now))
     (-form [_]
       'now)))
 

--- a/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/date_time_operators_test.clj
@@ -12,6 +12,7 @@
    [blaze.elm.date-time :as date-time]
    [blaze.elm.literal :as elm]
    [blaze.elm.literal-spec]
+   [blaze.elm.protocols :as p]
    [blaze.fhir.spec.type.system :as system]
    [blaze.test-util :refer [given-thrown satisfies-prop]]
    [clojure.spec.alpha :as s]
@@ -883,7 +884,7 @@
 (deftest compile-now-test
   (are [elm res] (= res (core/-eval (c/compile {} elm) {:now ctu/now} nil nil))
     {:type "Now"}
-    ctu/now))
+    (p/to-date-time ctu/now ctu/now)))
 
 ;; 18.14. SameAs
 ;;


### PR DESCRIPTION
All the date calculation in CQL depends on local date/time. Now in the evaluation context needs to be an OffsetDateTime in order to deliver the offset but the actual now expression has to return a LocalDateTime relative to the offset from itself.