### PR TITLE
Make sure we return 422 on non-existing measure POST requests (Fixes #512)

### DIFF
--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
@@ -29,6 +29,14 @@
        :fhir/operation-outcome "MSG_PARAM_INVALID"
        :fhir.issue/expression name)))
 
+(defn- invalid-date-param-anom
+  [name value]
+  (ba/incorrect
+   (invalid-date-param-msg name value)
+   :fhir/issue "value"
+   :fhir/operation-outcome "MSG_PARAM_INVALID"
+   :fhir.issue/expression name))
+
 (defn- coerce-date
   "Coerces `value` into a System.Date.
 
@@ -37,11 +45,7 @@
   (-> (system/parse-date value)
       (ba/exceptionally
        (fn [_]
-         (ba/incorrect
-          (invalid-date-param-msg name value)
-          :fhir/issue "value"
-          :fhir/operation-outcome "MSG_PARAM_INVALID"
-          :fhir.issue/expression name)))))
+         (invalid-date-param-anom name value)))))
 
 (defn- invalid-report-type-param-msg [report-type]
   (format "Invalid parameter `reportType` with value `%s`. Should be one of `subject`, `subject-list` or `population`."
@@ -77,7 +81,8 @@
                           request "periodStart" coerce-date)
             period-end (get-required-param-value
                         request "periodEnd" coerce-date)
-            measure (get-param-value request "measure" (fn [_ v] v))
+            measure (get-param-value
+                     request "measure" (fn [_n v] v))
             report-type (get-param-value
                          request "reportType" coerce-report-type)
             subject-ref (coerce-subject-ref-param request)]


### PR DESCRIPTION
module: operation-evaluate-measure
* apply parinfer-required formatting
* add failing POST regression test for https://github.com/samply/blaze/issues/512
* major refactoring: tests: separate handler instance tests from handler
type tests (WIP)
* add missing test for "with missing measure parameter" POST requests
* other minor refactorings