### PR TITLE
Make more Reducible Collections Counted

### DIFF
--- a/cljfmt.edn
+++ b/cljfmt.edn
@@ -6,6 +6,7 @@
   if-ok [[:block 1]]
   try-one [[:block 2]]
   when-ok [[:block 1]]
+  with-open-coll [[:block 1]]
   do-sync [[:block 1]]
   do-async [[:block 1]]
   has-form [[:block 1]]

--- a/modules/coll/.clj-kondo/config.edn
+++ b/modules/coll/.clj-kondo/config.edn
@@ -1,2 +1,5 @@
 {:config-paths
- ["../../../.clj-kondo/root"]}
+ ["../../../.clj-kondo/root"]
+
+ :lint-as
+ {blaze.coll.core/with-open-coll clojure.core/with-open}}

--- a/modules/coll/src/blaze/coll/core.clj
+++ b/modules/coll/src/blaze/coll/core.clj
@@ -21,7 +21,7 @@
   [coll]
   (identical? ::empty (reduce #(reduced %2) ::empty coll)))
 
-(defn- inc-rf [sum _] (inc ^long sum))
+(defn inc-rf [sum _] (inc ^long sum))
 
 (defn eduction
   "Like `clojure.core/eduction` but implements Counted instead of Iterable."
@@ -67,4 +67,7 @@
      IReduceInit
      (reduce [_ rf# init#]
        (with-open ~bindings
-         (reduce rf# init# ~coll)))))
+         (reduce rf# init# ~coll)))
+     Counted
+     (count [coll#]
+       (.reduce coll# inc-rf 0))))

--- a/modules/cql/.clj-kondo/config.edn
+++ b/modules/cql/.clj-kondo/config.edn
@@ -8,8 +8,7 @@
   "../../module-test-util/resources/clj-kondo.exports/blaze/module-test-util"]
 
  :lint-as
- {blaze.db.impl.macros/with-open-coll clojure.core/with-open
-  blaze.elm.compiler.macros/defunop clojure.core/defn
+ {blaze.elm.compiler.macros/defunop clojure.core/defn
   blaze.elm.compiler.macros/defbinop clojure.core/defn
   blaze.elm.compiler.macros/defternop clojure.core/defn
   blaze.elm.compiler.macros/defnaryop clojure.core/defn

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -1152,7 +1152,7 @@
        [[:put {:fhir/type :fhir/Patient :id "0"}]]]
 
       (testing "has one list entry"
-        (is (= 1 (count (vec (d/type-list (d/db node) "Patient")))))
+        (is (= 1 (count (d/type-list (d/db node) "Patient"))))
         (is (= 1 (d/type-total (d/db node) "Patient"))))))
 
   (testing "a node with two patients in two transactions"
@@ -1233,11 +1233,11 @@
        [[:put {:fhir/type :fhir/Observation :id "0"}]]]
 
       (testing "has one patient list entry"
-        (is (= 1 (count (vec (d/type-list (d/db node) "Patient")))))
+        (is (= 1 (count (d/type-list (d/db node) "Patient"))))
         (is (= 1 (d/type-total (d/db node) "Patient"))))
 
       (testing "has one observation list entry"
-        (is (= 1 (count (vec (d/type-list (d/db node) "Observation")))))
+        (is (= 1 (count (d/type-list (d/db node) "Observation"))))
         (is (= 1 (d/type-total (d/db node) "Observation"))))))
 
   (testing "the database is immutable"
@@ -4382,7 +4382,7 @@
                                   :end #fhir/dateTime"2001-07"}}]]]
 
     (let [db (d/db node)
-          num-encounter #(count (vec (d/type-query db "Encounter" %)))]
+          num-encounter #(count (d/type-query db "Encounter" %))]
       (are [year n] (= n (num-encounter [["date" (format "gt%d-01-01" year)]
                                          ["date" (format "lt%d-01-01" (inc year))]]))
         1999 2
@@ -4428,7 +4428,7 @@
         [tx-ops]
 
         (let [db (d/db node)
-              num-encounter #(count (vec (d/type-query db "Encounter" %)))]
+              num-encounter #(count (d/type-query db "Encounter" %))]
           (= (num-encounter [["date" (str year)]])
              (num-encounter [["date" (format "sa%d-12-31" (dec year))]
                              ["date" (format "eb%d-01-01" (inc year))]])))))))
@@ -4441,7 +4441,7 @@
         [tx-ops]
 
         (let [db (d/db node)
-              num-encounter #(count (vec (d/type-query db "Encounter" %)))]
+              num-encounter #(count (d/type-query db "Encounter" %))]
           (= (num-encounter [["date" (str "ap" year)]])
              (num-encounter [["date" (format "ge%d-01-01" year)]
                              ["date" (format "lt%d-01-01" (inc year))]])))))))
@@ -6355,7 +6355,7 @@
           (let [db (d/db node)
                 patient (d/resource-handle db "Patient" "0")]
 
-            (is (coll/empty? (vec (d/rev-include db patient)))))))
+            (is (coll/empty? (d/rev-include db patient))))))
 
       (testing "with three resources"
         (with-system-data [{:blaze.db/keys [node]} config]
@@ -6684,7 +6684,7 @@
       [[[:put {:fhir/type :fhir/Patient :id "0"}]]]
 
       (with-open [batch-db (d/new-batch-db (d/db node))]
-        (is (= 1 (count (vec (d/type-list batch-db "Patient")))))
+        (is (= 1 (count (d/type-list batch-db "Patient"))))
         (is (= 1 (d/type-total batch-db "Patient"))))))
 
   (testing "compile-type-query"
@@ -6714,7 +6714,7 @@
       [[[:put {:fhir/type :fhir/Patient :id "0"}]]]
 
       (with-open [batch-db (d/new-batch-db (d/db node))]
-        (is (= 1 (count (vec (d/system-list batch-db)))))
+        (is (= 1 (count (d/system-list batch-db))))
         (is (= 1 (d/system-total batch-db))))))
 
   (testing "compile-compartment-query"


### PR DESCRIPTION
Before some reducible collections like from the iterators namespace and such created by the with-open-coll macro did not implement Counted. So they could not directly counted and instead had to be converted into a vector first.

Needed by #1382