### PR TITLE
Don't Create a Version for Double Deletes

### DIFF
--- a/modules/db/src/blaze/db/node/tx_indexer/verify.clj
+++ b/modules/db/src/blaze/db/node/tx_indexer/verify.clj
@@ -321,12 +321,14 @@
           {:keys [num-changes op] :or {num-changes 0} :as old-resource-handle}
           (d/resource-handle db-before type id)
           refs (some->> old-resource-handle (patient-refs search-param-registry db-before type))]
-      (cond->
-       (-> (update res :entries into (index-entries tid id t hash/deleted-hash (inc num-changes) :delete refs))
-           (update :del-resources conj [type id])
-           (update-in [:stats tid :num-changes] inc-0))
-        (and op (not (identical? :delete op)))
-        (update-in [:stats tid :total] (fnil dec 0))))))
+      (if (identical? :delete op)
+        res
+        (cond->
+         (-> (update res :entries into (index-entries tid id t hash/deleted-hash (inc num-changes) :delete refs))
+             (update :del-resources conj [type id])
+             (update-in [:stats tid :num-changes] inc-0))
+          op
+          (update-in [:stats tid :total] (fnil dec 0)))))))
 
 (def ^:private ^:const ^long delete-history-max 100000)
 

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -498,10 +498,10 @@
 
       (testing "doing a second delete"
         (let [db @(d/transact node [[:delete "Patient" "0"]])]
-          (testing "the patient is still deleted and has two changes"
+          (testing "the patient is still deleted and still only has one change"
             (given (d/resource-handle db "Patient" "0")
               :op := :delete
-              :num-changes := 2))))))
+              :num-changes := 1))))))
 
   (testing "patient with an observation referencing it"
     (with-system-data [{:blaze.db/keys [node]} config]

--- a/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
+++ b/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
@@ -294,32 +294,10 @@
     (with-system-data [{:blaze.db/keys [node]} config]
       [[[:delete "Patient" "0"]]]
 
-      (given (verify/verify-tx-cmds
-              search-param-registry
-              (d/db node) 2
-              [{:op "delete" :type "Patient" :id "0"}])
-
-        count := 5
-
-        [0 0] := :resource-as-of-index
-        [0 1 rao-tu/decode-key] := {:type "Patient" :id "0" :t 2}
-        [0 2 rts-tu/decode-val] := {:hash hash/deleted-hash :num-changes 2 :op :delete}
-
-        [1 0] := :type-as-of-index
-        [1 1 tao-tu/decode-key] := {:type "Patient" :t 2 :id "0"}
-        [1 2 rts-tu/decode-val] := {:hash hash/deleted-hash :num-changes 2 :op :delete}
-
-        [2 0] := :system-as-of-index
-        [2 1 sao-tu/decode-key] := {:t 2 :type "Patient" :id "0"}
-        [2 2 rts-tu/decode-val] := {:hash hash/deleted-hash :num-changes 2 :op :delete}
-
-        [3 0] := :type-stats-index
-        [3 1 ts-tu/decode-key] := {:type "Patient" :t 2}
-        [3 2 ts-tu/decode-val] := {:total 0 :num-changes 2}
-
-        [4 0] := :system-stats-index
-        [4 1 ss-tu/decode-key] := {:t 2}
-        [4 2 ss-tu/decode-val] := {:total 0 :num-changes 2})))
+      (is (empty? (verify/verify-tx-cmds
+                   search-param-registry
+                   (d/db node) 2
+                   [{:op "delete" :type "Patient" :id "0"}])))))
 
   (testing "deleting an existing Patient"
     (with-system-data [{:blaze.db/keys [node]} config]

--- a/modules/load-test/Makefile
+++ b/modules/load-test/Makefile
@@ -1,0 +1,1 @@
+.PHONY: fmt lint test-coverage cloc-prod cloc-test


### PR DESCRIPTION
Like for updates, we don't like to create a new version of an already deleted resource if it is deleted again. Instead we just ignore all subsequent deletes.