### PR TITLE
Refactor How Purging Reflects in Resource Handles

### DIFF
--- a/modules/db/test-perf/blaze/db/impl/index/resource_handle_test_perf.clj
+++ b/modules/db/test-perf/blaze/db/impl/index/resource_handle_test_perf.clj
@@ -18,7 +18,7 @@
   (.totalSize (GraphLayout/parseInstance (object-array xs))))
 
 (defn- resource-handle [id-size]
-  (rh/resource-handle! 0 (str/join (repeat id-size "0")) 0 (bb/allocate 40)))
+  (rh/resource-handle! 0 (str/join (repeat id-size "0")) 0 0 (bb/allocate 40)))
 
 (deftest resource-handle-test
   (testing "instance size"

--- a/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
@@ -13,8 +13,8 @@
 
 (s/fdef rh/resource-handle!
   :args (s/cat :tid :blaze.db/tid :id :blaze.resource/id
-               :t :blaze.db/t :vb byte-buffer?)
-  :ret :blaze.db/resource-handle)
+               :t :blaze.db/t :base-t :blaze.db/t :vb byte-buffer?)
+  :ret (s/nilable :blaze.db/resource-handle))
 
 (s/fdef rh/resource-handle?
   :args (s/cat :x any?)
@@ -47,10 +47,6 @@
 (s/fdef rh/op
   :args (s/cat :rh rh/resource-handle?)
   :ret :blaze.db/op)
-
-(s/fdef rh/purged-at
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.db/t)
 
 (s/fdef rh/reference
   :args (s/cat :rh rh/resource-handle?)

--- a/modules/db/test/blaze/db/impl/index/resource_handle_test.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_handle_test.clj
@@ -27,9 +27,7 @@
   ([tid id t hash num-changes]
    (resource-handle tid id t hash num-changes :create))
   ([tid id t hash num-changes op]
-   (resource-handle tid id t hash num-changes op Long/MAX_VALUE))
-  ([tid id t hash num-changes op purged-at]
-   (rh/->ResourceHandle tid id t hash num-changes op purged-at)))
+   (rh/->ResourceHandle tid id t hash num-changes op)))
 
 (deftest state->num-changes-test
   (are [state num-changes] (= num-changes
@@ -78,12 +76,6 @@
     (prop/for-all [op (s/gen :blaze.db/op)]
       (let [rh (resource-handle 0 "foo" 0 hash 0 op)]
         (= op (:op rh) (rh/op rh) (apply rh/op [rh]))))))
-
-(deftest purged-at-test
-  (satisfies-prop 10
-    (prop/for-all [purged-at (s/gen :blaze.db/t)]
-      (let [rh (resource-handle 0 "foo" 0 hash 0 :create purged-at)]
-        (= purged-at (:purged-at rh) (rh/purged-at rh) (apply rh/purged-at [rh]))))))
 
 (deftest reference-test
   (satisfies-prop 100


### PR DESCRIPTION
Before this commit, resource handles had the t at which it was purged as field called purged-at. That field was used later to decide whether a resource handle should be part of a history at a particular t.

After this commit, the resource-handle! function will take an additional argument called base-t and will only return resource handles not purged at this base-t. Doing so, there will be never a purged resource handle and so doesn't need to be checked at all. So the field purged-at is gone.