### PR TITLE
Improve Project Cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ clean-root:
 	rm -rf .clj-kondo/.cache .cpcache target
 
 clean: $(MODULES) clean-root
+	$(MAKE) -C job-ig clean
 
 build-frontend:
 	$(MAKE) -C modules/frontend build

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -28,7 +28,9 @@ cloc-prod:
 cloc-test:
 	cloc test
 
+IG_PROFILES := $(wildcard resources/blaze/db/[A-Z]*.json)
+
 clean:
-	rm -rf .clj-kondo/.cache .cpcache target
+	rm -rf .clj-kondo/.cache .cpcache target $(IG_PROFILES)
 
 .PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean


### PR DESCRIPTION
In order to initialize properly, the server needs the Job IG resource files in specific locations (see below).
Since those files are prepped only if they did not exist before, we need do delete them every time we make a `make clean`.

Context:

* the Job IG resource files are generated by `make -C job-ig build`, and saved in the folder `job-ig/fsh-generated/resources`.

* then, when `clojure -X:deps prep` is executed, the resource files are copied to the individual resources
path's (e.g.
`modules/job-re-index/resources/blaze/job/re_index/CodeSystem-ReIndexJobOutput.json`) via `build/copy-profiles`. But this only happens if the folders don't already exist. See
https://clojure.org/reference/deps_edn#prep_lib

If the server cannot find the files in their right locations, it will fail to initialize with the following error:
```
2024-11-11T16:30:08.301Z d2e461cd82fc main ERROR [blaze.core:21] - Error
while initializing Blaze.

    Error on key :blaze/admin-api when building system

    Cause:

    Config:
      ADMIN_INDEX_DB_DIR = /app/data/admin-index,
      ADMIN_TRANSACTION_DB_DIR = /app/data/admin-transaction,
      HOME = /,
      HOSTNAME = d2e461cd82fc,
      INDEX_DB_DIR = /app/data/index,
      JAVA_HOME = /opt/java/openjdk,
      JAVA_VERSION = jdk-21.0.5+11,
      JRE_CACERTS_PATH = /opt/java/openjdk/lib/security/cacerts,
      LANG = en_US.UTF-8,
      LANGUAGE = en_US:en,
      LC_ALL = en_US.UTF-8,
      LD_PRELOAD = libjemalloc.so.2,
PATH =
/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,
      PWD = /app,
      RESOURCE_DB_DIR = /app/data/resource,
      SHLVL = 0,
      STORAGE = standalone,
      TRANSACTION_DB_DIR = /app/data/transaction
```