### PR TITLE
Shorten Logging Output in Tests

### DIFF
--- a/dev/blaze/dev.clj
+++ b/dev/blaze/dev.clj
@@ -44,9 +44,9 @@
   (st/unstrument))
 
 (comment
-  (log/set-level! :trace)
-  (log/set-level! :debug)
-  (log/set-level! :info))
+  (log/set-min-level! :trace)
+  (log/set-min-level! :debug)
+  (log/set-min-level! :info))
 
 ;; Transaction Cache
 (comment

--- a/modules/cql/test/blaze/elm/expression/cache_test.clj
+++ b/modules/cql/test/blaze/elm/expression/cache_test.clj
@@ -17,7 +17,6 @@
    [blaze.elm.literal :as elm]
    [blaze.executors :as ex]
    [blaze.fhir.test-util]
-   [blaze.log]
    [blaze.metrics.spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :refer [given-thrown]]

--- a/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
+++ b/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
@@ -12,7 +12,6 @@
    [blaze.fhir.hash-spec]
    [blaze.fhir.spec :as fhir-spec]
    [blaze.fhir.test-util]
-   [blaze.log]
    [blaze.module.test-util :as mtu :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/db-resource-store/test/blaze/db/resource_store/kv_test.clj
+++ b/modules/db-resource-store/test/blaze/db/resource_store/kv_test.clj
@@ -15,7 +15,6 @@
    [blaze.fhir.hash-spec]
    [blaze.fhir.spec :as fhir-spec]
    [blaze.fhir.test-util]
-   [blaze.log]
    [blaze.metrics.spec]
    [blaze.module.test-util :as mtu :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]

--- a/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka/util_test.clj
+++ b/modules/db-tx-log-kafka/test/blaze/db/tx_log/kafka/util_test.clj
@@ -18,7 +18,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -26,7 +26,6 @@
    [blaze.fhir.spec.generators :as fg]
    [blaze.fhir.spec.type :as type]
    [blaze.fhir.spec.type.system :as system]
-   [blaze.log]
    [blaze.module.test-util :as mtu :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [satisfies-prop]]
    [clojure.spec.alpha :as s]

--- a/modules/db/test/blaze/db/impl/search_param/composite_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/composite_test.clj
@@ -27,7 +27,7 @@
    [blaze.fhir_path GetChildrenExpression TypedStartExpression]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/impl/search_param/date_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/date_test.clj
@@ -27,7 +27,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/impl/search_param/list_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/list_test.clj
@@ -12,7 +12,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/impl/search_param/number_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/number_test.clj
@@ -24,7 +24,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/quantity_test.clj
@@ -24,7 +24,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/impl/search_param/string_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/string_test.clj
@@ -24,7 +24,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/impl/search_param/util_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/util_test.clj
@@ -10,7 +10,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/node/tx_indexer/expand_test.clj
+++ b/modules/db/test/blaze/db/node/tx_indexer/expand_test.clj
@@ -14,7 +14,6 @@
    [blaze.fhir.hash-spec]
    [blaze.fhir.spec.spec]
    [blaze.fhir.spec.type]
-   [blaze.log]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu]
    [clojure.spec.test.alpha :as st]

--- a/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
+++ b/modules/db/test/blaze/db/node/tx_indexer/verify_test.clj
@@ -22,7 +22,6 @@
    [blaze.fhir.hash :as hash]
    [blaze.fhir.hash-spec]
    [blaze.fhir.spec.type]
-   [blaze.log]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [satisfies-prop]]
    [clojure.spec.alpha :as s]

--- a/modules/db/test/blaze/db/node_test.clj
+++ b/modules/db/test/blaze/db/node_test.clj
@@ -27,7 +27,6 @@
    [blaze.db.tx-log.local-spec]
    [blaze.db.tx-log.spec :refer [tx-log?]]
    [blaze.executors :as ex]
-   [blaze.log]
    [blaze.metrics.spec]
    [blaze.module.test-util :refer [given-failed-future with-system]]
    [blaze.scheduler.spec :refer [scheduler?]]

--- a/modules/db/test/blaze/db/tx_cache_test.clj
+++ b/modules/db/test/blaze/db/tx_cache_test.clj
@@ -15,7 +15,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/tx_log/local/codec_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local/codec_test.clj
@@ -11,7 +11,7 @@
    [java.time Instant]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -13,7 +13,6 @@
    [blaze.db.tx-log.spec]
    [blaze.fhir.hash :as hash]
    [blaze.fhir.hash-spec]
-   [blaze.log]
    [blaze.module.test-util :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/impl_test.clj
@@ -24,7 +24,7 @@
 (xml-name/alias-uri 'f "http://hl7.org/fhir")
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/interaction/test/blaze/interaction/conditional_delete_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/conditional_delete_type_test.clj
@@ -7,7 +7,6 @@
    [blaze.db.node :refer [node?]]
    [blaze.interaction.conditional-delete-type]
    [blaze.interaction.test-util :refer [wrap-error]]
-   [blaze.log]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]

--- a/modules/interaction/test/blaze/interaction/create_test.clj
+++ b/modules/interaction/test/blaze/interaction/create_test.clj
@@ -16,7 +16,6 @@
    [blaze.interaction.create]
    [blaze.interaction.test-util :refer [wrap-error]]
    [blaze.interaction.util-spec]
-   [blaze.log]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/interaction/test/blaze/interaction/delete_history_test.clj
+++ b/modules/interaction/test/blaze/interaction/delete_history_test.clj
@@ -6,7 +6,6 @@
    [blaze.db.api-stub :as api-stub :refer [with-system-data]]
    [blaze.db.node :refer [node?]]
    [blaze.interaction.delete-history]
-   [blaze.log]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]

--- a/modules/interaction/test/blaze/interaction/delete_test.clj
+++ b/modules/interaction/test/blaze/interaction/delete_test.clj
@@ -6,7 +6,6 @@
    [blaze.db.api-stub :as api-stub :refer [with-system-data]]
    [blaze.db.node :refer [node?]]
    [blaze.interaction.delete]
-   [blaze.log]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -22,7 +22,6 @@
    [blaze.interaction.transaction]
    [blaze.interaction.update]
    [blaze.interaction.util-spec]
-   [blaze.log]
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.db-spec]
    [blaze.page-store-spec]

--- a/modules/interaction/test/blaze/interaction/update_test.clj
+++ b/modules/interaction/test/blaze/interaction/update_test.clj
@@ -16,7 +16,6 @@
    [blaze.fhir.spec.type :as type]
    [blaze.interaction.test-util :refer [wrap-error]]
    [blaze.interaction.update]
-   [blaze.log]
    [blaze.test-util :as tu :refer [given-thrown satisfies-prop]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]

--- a/modules/job-async-interaction/test/blaze/job/async_interaction/util_test.clj
+++ b/modules/job-async-interaction/test/blaze/job/async_interaction/util_test.clj
@@ -11,7 +11,6 @@
    [blaze.job.async-interaction-spec]
    [blaze.job.async-interaction.util :as u]
    [blaze.job.async-interaction.util-spec]
-   [blaze.log]
    [blaze.module.test-util :as mtu :refer [given-failed-future with-system]]
    [blaze.test-util :as tu]
    [clojure.spec.test.alpha :as st]

--- a/modules/job-async-interaction/test/blaze/job/async_interaction_test.clj
+++ b/modules/job-async-interaction/test/blaze/job/async_interaction_test.clj
@@ -20,7 +20,6 @@
    [blaze.job.async-interaction-spec]
    [blaze.job.test-util :as jtu]
    [blaze.job.util :as job-util]
-   [blaze.log]
    [blaze.luid :as luid]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]

--- a/modules/job-compact/test/blaze/job/compact_test.clj
+++ b/modules/job-compact/test/blaze/job/compact_test.clj
@@ -16,7 +16,6 @@
    [blaze.job.compact-spec]
    [blaze.job.test-util :as jtu]
    [blaze.job.util :as job-util]
-   [blaze.log]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/job-re-index/test/blaze/job/re_index_test.clj
+++ b/modules/job-re-index/test/blaze/job/re_index_test.clj
@@ -19,7 +19,6 @@
    [blaze.job.re-index]
    [blaze.job.test-util :as jtu]
    [blaze.job.util :as job-util]
-   [blaze.log]
    [blaze.luid :as luid]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]

--- a/modules/job-scheduler/test/blaze/job_scheduler_test.clj
+++ b/modules/job-scheduler/test/blaze/job_scheduler_test.clj
@@ -20,7 +20,6 @@
    [blaze.job-scheduler.protocols :as p]
    [blaze.job.test-util :as jtu]
    [blaze.job.util :as job-util]
-   [blaze.log]
    [blaze.module.test-util :as mtu :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/kv/test/blaze/db/kv/iter_pool_test.clj
+++ b/modules/kv/test/blaze/db/kv/iter_pool_test.clj
@@ -6,7 +6,6 @@
    [blaze.db.kv-spec]
    [blaze.db.kv.iter-pool :as ip]
    [blaze.db.kv.protocols :as p]
-   [blaze.log]
    [blaze.test-util :as tu]
    [clojure.spec.test.alpha :as st]
    [clojure.test :as test :refer [are deftest is testing]]
@@ -20,7 +19,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/kv/test/blaze/db/kv/mem_test.clj
+++ b/modules/kv/test/blaze/db/kv/mem_test.clj
@@ -7,7 +7,6 @@
    [blaze.db.kv.mem]
    [blaze.db.kv.mem-spec]
    [blaze.db.kv.protocols :as p]
-   [blaze.log]
    [blaze.module.test-util :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [ba bb bytes= given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/metrics/test/blaze/metrics/handler_test.clj
+++ b/modules/metrics/test/blaze/metrics/handler_test.clj
@@ -14,7 +14,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/metrics/test/blaze/metrics/registry_test.clj
+++ b/modules/metrics/test/blaze/metrics/registry_test.clj
@@ -16,7 +16,7 @@
 (set! *warn-on-reflection* true)
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/openid-auth/test/blaze/openid_auth/impl_test.clj
+++ b/modules/openid-auth/test/blaze/openid_auth/impl_test.clj
@@ -14,7 +14,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/operation-compact/test/blaze/fhir/operation/compact_test.clj
+++ b/modules/operation-compact/test/blaze/fhir/operation/compact_test.clj
@@ -4,7 +4,6 @@
    [blaze.db.api-stub :as api-stub :refer [with-system-data]]
    [blaze.fhir.operation.compact]
    [blaze.handler.util :as handler-util]
-   [blaze.log]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]

--- a/modules/operation-graphql/test/blaze/fhir/operation/graphql/middleware/query_test.clj
+++ b/modules/operation-graphql/test/blaze/fhir/operation/graphql/middleware/query_test.clj
@@ -15,7 +15,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/operation-graphql/test/blaze/fhir/operation/graphql/middleware_test.clj
+++ b/modules/operation-graphql/test/blaze/fhir/operation/graphql/middleware_test.clj
@@ -1,7 +1,6 @@
 (ns blaze.fhir.operation.graphql.middleware-test
   (:require
    [blaze.fhir.operation.graphql.middleware :as middleware]
-   [blaze.log]
    [blaze.middleware.fhir.db-spec]
    [blaze.test-util :as tu]
    [clojure.spec.test.alpha :as st]
@@ -11,7 +10,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/operation-graphql/test/blaze/fhir/operation/graphql_test.clj
+++ b/modules/operation-graphql/test/blaze/fhir/operation/graphql_test.clj
@@ -6,7 +6,6 @@
    [blaze.executors :as ex]
    [blaze.fhir.operation.graphql :as graphql]
    [blaze.fhir.operation.graphql.test-util :refer [wrap-error]]
-   [blaze.log]
    [blaze.middleware.fhir.db :refer [wrap-db]]
    [blaze.middleware.fhir.db-spec]
    [blaze.module.test-util :refer [with-system]]
@@ -19,7 +18,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -14,7 +14,6 @@
    [blaze.fhir.operation.evaluate-measure.measure.util-spec]
    [blaze.fhir.spec :as fhir-spec]
    [blaze.fhir.spec.type :as type]
-   [blaze.log]
    [blaze.module.test-util :refer [given-failed-future]]
    [blaze.test-util :as tu]
    [clojure.java.io :as io]
@@ -1199,5 +1198,5 @@
       ::anom/message := "Error while parsing the ELM representation of a CQL library: Could not convert library to JSON using JAXB serializer.")))
 
 (comment
-  (log/set-level! :debug)
+  (log/set-min-level! :debug)
   (evaluate "q60-medication"))

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/middleware/params_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/middleware/params_test.clj
@@ -10,7 +10,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/operation-totals/test/blaze/fhir/operation/totals_test.clj
+++ b/modules/operation-totals/test/blaze/fhir/operation/totals_test.clj
@@ -4,7 +4,6 @@
    [blaze.fhir.operation.totals]
    [blaze.fhir.structure-definition-repo-spec]
    [blaze.fhir.structure-definition-repo.spec :refer [structure-definition-repo?]]
-   [blaze.log]
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.db-spec]
    [blaze.test-util :as tu :refer [given-thrown]]

--- a/modules/page-id-cipher/src/blaze/page_id_cipher.clj
+++ b/modules/page-id-cipher/src/blaze/page_id_cipher.clj
@@ -6,7 +6,6 @@
    [blaze.db.api :as d]
    [blaze.db.spec]
    [blaze.fhir.spec.type :as type]
-   [blaze.log]
    [blaze.luid :as luid]
    [blaze.module :as m]
    [blaze.page-id-cipher.impl :as impl]

--- a/modules/page-id-cipher/test/blaze/page_id_cipher_test.clj
+++ b/modules/page-id-cipher/test/blaze/page_id_cipher_test.clj
@@ -10,7 +10,6 @@
    [blaze.db.tx-log :as tx-log]
    [blaze.db.tx-log.local]
    [blaze.fhir.test-util :refer [structure-definition-repo]]
-   [blaze.log]
    [blaze.module.test-util :refer [with-system]]
    [blaze.page-id-cipher]
    [blaze.page-id-cipher.spec]

--- a/modules/page-store-cassandra/test/blaze/page_store/cassandra_test.clj
+++ b/modules/page-store-cassandra/test/blaze/page_store/cassandra_test.clj
@@ -22,7 +22,7 @@
    [java.security SecureRandom]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/rest-api/test/blaze/rest_api/async_status_cancel_handler_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/async_status_cancel_handler_test.clj
@@ -8,7 +8,6 @@
    [blaze.job-scheduler :as js]
    [blaze.job-scheduler.protocols :as p]
    [blaze.job.async-interaction :as job-async]
-   [blaze.log]
    [blaze.metrics.spec]
    [blaze.middleware.fhir.db :refer [wrap-db]]
    [blaze.rest-api :as-alias rest-api]

--- a/modules/rest-util/test/blaze/fhir/response/create_test.clj
+++ b/modules/rest-util/test/blaze/fhir/response/create_test.clj
@@ -11,7 +11,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/rest-util/test/blaze/middleware/output_test.clj
+++ b/modules/rest-util/test/blaze/middleware/output_test.clj
@@ -16,7 +16,7 @@
 (set! *warn-on-reflection* true)
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/modules/server/test/blaze/server_test.clj
+++ b/modules/server/test/blaze/server_test.clj
@@ -19,7 +19,7 @@
 
 (set! *warn-on-reflection* true)
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/test/blaze/handler/app_test.clj
+++ b/test/blaze/handler/app_test.clj
@@ -13,7 +13,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 

--- a/test/blaze/handler/health_test.clj
+++ b/test/blaze/handler/health_test.clj
@@ -10,7 +10,7 @@
    [taoensso.timbre :as log]))
 
 (st/instrument)
-(log/set-level! :trace)
+(log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
 


### PR DESCRIPTION
Removed the date from timestamp. Removed hostname. Shortened nREPL thread name.