### PR TITLE
Clarify that Include Ignores Dead Links

### DIFF
--- a/.github/scripts/include-without-referential-integrity.sh
+++ b/.github/scripts/include-without-referential-integrity.sh
@@ -1,13 +1,22 @@
 #!/bin/bash -e
 
+# This test creates two observations both referencing different patients where
+# only one of the patients exists.
+#
+# An observation query including the subjects of the observations is executed.
+# The expected result contains both observations and the single patient. It's
+# important that the dead reference doesn't result in an error. It is just
+# ignored.
+
 BASE="http://localhost:8080/fhir"
 
 curl -sXPUT -d '{"resourceType": "Observation", "id": "0", "subject": {"reference": "Patient/0"}}' -H 'Content-Type: application/fhir+json' "$BASE/Observation/0" > /dev/null
+curl -sXPUT -d '{"resourceType": "Observation", "id": "1", "subject": {"reference": "Patient/1"}}' -H 'Content-Type: application/fhir+json' "$BASE/Observation/1" > /dev/null
 curl -sXPUT -d '{"resourceType" : "Patient", "id": "0"}' -H 'Content-Type: application/fhir+json' "$BASE/Patient/0" > /dev/null
 
-RESULT=$(curl -s "$BASE/Observation?_include=Observation:subject" | jq -r '.entry[].search.mode' | tr '\n' '|')
+RESULT=$(curl -s "$BASE/Observation?_include=Observation:subject" | jq -r '[.entry[].search.mode] | join(",")')
 
-if [ "$RESULT" = "match|include|" ]; then
+if [ "$RESULT" = "match,match,include" ]; then
   echo "✅ include works"
 else
   echo "🆘 include doesn't work"


### PR DESCRIPTION
The spec says:

If there is no reference, or no matching resource, the resource cannot be retrieved (e.g. on a different server), then the resource is omitted, and no error is returned.

http://hl7.org/fhir/R4/search.html#include