### PR TITLE
Introduce Resource Handle Deleted Function

### DIFF
--- a/modules/cql/src/blaze/elm/compiler/arithmetic_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/arithmetic_operators.clj
@@ -123,8 +123,8 @@
       (core/resolve-refs-helper round-op expression-defs operand precision))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper round-op parameters operand precision))
-    (-optimize [_ node]
-      (core/optimize-helper round-op node operand precision))
+    (-optimize [_ db]
+      (core/optimize-helper round-op db operand precision))
     (-eval [_ context resource scope]
       (p/round (core/-eval operand context resource scope)
                (core/-eval precision context resource scope)))

--- a/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/clinical_operators.clj
@@ -24,8 +24,8 @@
     (-resolve-params [_ parameters]
       (core/resolve-params-helper-2 calculate-age-at-op parameters birth-date
                                     date chrono-precision precision))
-    (-optimize [_ node]
-      (core/optimize-helper-2 calculate-age-at-op node birth-date date
+    (-optimize [_ db]
+      (core/optimize-helper-2 calculate-age-at-op db birth-date date
                               chrono-precision precision))
     (-eval [_ context resource scope]
       (p/duration-between

--- a/modules/cql/src/blaze/elm/compiler/conditional_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/conditional_operators.clj
@@ -123,8 +123,8 @@
       (core/resolve-refs-helper if-op expression-defs condition then else))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper if-op parameters condition then else))
-    (-optimize [_ node]
-      (core/optimize-helper if-op node condition then else))
+    (-optimize [_ db]
+      (core/optimize-helper if-op db condition then else))
     (-eval [_ context resource scope]
       (if (core/-eval condition context resource scope)
         (core/-eval then context resource scope)

--- a/modules/cql/src/blaze/elm/compiler/date_time_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/date_time_operators.clj
@@ -43,8 +43,8 @@
        (core/resolve-refs-helper date-op expression-defs year))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper date-op parameters year))
-     (-optimize [_ node]
-       (core/optimize-helper date-op node year))
+     (-optimize [_ db]
+       (core/optimize-helper date-op db year))
      (-eval [_ context resource scope]
        (some-> (core/-eval year context resource scope) system/date))
      (-form [_]
@@ -71,8 +71,8 @@
        (core/resolve-refs-helper date-op expression-defs year month))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper date-op parameters year month))
-     (-optimize [_ node]
-       (core/optimize-helper date-op node year month))
+     (-optimize [_ db]
+       (core/optimize-helper date-op db year month))
      (-eval [_ context resource scope]
        (when-let [year (core/-eval year context resource scope)]
          (if-let [month (core/-eval month context resource scope)]
@@ -102,8 +102,8 @@
        (core/resolve-refs-helper date-op expression-defs year month day))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper date-op parameters year month day))
-     (-optimize [_ node]
-       (core/optimize-helper date-op node year month day))
+     (-optimize [_ db]
+       (core/optimize-helper date-op db year month day))
      (-eval [_ context resource scope]
        (when-let [year (core/-eval year context resource scope)]
          (if-let [month (core/-eval month context resource scope)]
@@ -333,8 +333,8 @@
       (core/resolve-refs-helper date-time-date-op expression-defs year month day))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper date-time-date-op parameters year month day))
-    (-optimize [_ node]
-      (core/optimize-helper date-time-date-op node year month day))
+    (-optimize [_ db]
+      (core/optimize-helper date-time-date-op db year month day))
     (-eval [_ context resource scope]
       (when-let [year (core/-eval year context resource scope)]
         (if-let [month (core/-eval month context resource scope)]
@@ -354,8 +354,8 @@
       (core/resolve-refs-helper date-time-year-month-op expression-defs year month))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper date-time-year-month-op parameters year month))
-    (-optimize [_ node]
-      (core/optimize-helper date-time-year-month-op node year month))
+    (-optimize [_ db]
+      (core/optimize-helper date-time-year-month-op db year month))
     (-eval [_ context resource scope]
       (when-let [year (core/-eval year context resource scope)]
         (if-let [month (core/-eval month context resource scope)]
@@ -372,8 +372,8 @@
       (core/resolve-refs-helper date-time-year-op expression-defs year))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper date-time-year-op parameters year))
-    (-optimize [_ node]
-      (core/optimize-helper date-time-year-op node year))
+    (-optimize [_ db]
+      (core/optimize-helper date-time-year-op db year))
     (-eval [_ context resource scope]
       (some-> (core/-eval year context resource scope) system/date-time))
     (-form [_]
@@ -486,8 +486,8 @@
        (core/resolve-refs-helper time-op expression-defs hour))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper time-op parameters hour))
-     (-optimize [_ node]
-       (core/optimize-helper time-op node hour))
+     (-optimize [_ db]
+       (core/optimize-helper time-op db hour))
      (-eval [_ context resource scope]
        (date-time/local-time (core/-eval hour context resource scope)))
      (-form [_]
@@ -500,8 +500,8 @@
        (core/resolve-refs-helper time-op expression-defs hour minute))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper time-op parameters hour minute))
-     (-optimize [_ node]
-       (core/optimize-helper time-op node hour minute))
+     (-optimize [_ db]
+       (core/optimize-helper time-op db hour minute))
      (-eval [_ context resource scope]
        (date-time/local-time
         (core/-eval hour context resource scope)
@@ -516,8 +516,8 @@
        (core/resolve-refs-helper time-op expression-defs hour minute second))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper time-op parameters hour minute second))
-     (-optimize [_ node]
-       (core/optimize-helper time-op node hour minute second))
+     (-optimize [_ db]
+       (core/optimize-helper time-op db hour minute second))
      (-eval [_ context resource scope]
        (date-time/local-time
         (core/-eval hour context resource scope)

--- a/modules/cql/src/blaze/elm/compiler/external_data.clj
+++ b/modules/cql/src/blaze/elm/compiler/external_data.clj
@@ -63,8 +63,8 @@
         (when reference
           (when-let [[type id] (fsr/split-literal-ref reference)]
             (when (and (= "Patient" type) (string? id))
-              (let [{:keys [op] :as handle} (d/resource-handle db "Patient" id)]
-                (when-not (identical? :delete op)
+              (when-let [handle (d/resource-handle db "Patient" id)]
+                (when-not (d/deleted? handle)
                   [(cr/mk-resource db handle)])))))))
     (-form [_]
       '(retrieve (Specimen) "Patient"))))

--- a/modules/cql/src/blaze/elm/compiler/list_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/list_operators.clj
@@ -82,8 +82,8 @@
     (-resolve-params [_ parameters]
       (core/resolve-params-helper-1 scoped-filter-op parameters source condition
                                     scope))
-    (-optimize [_ node]
-      (core/optimize-helper-1 scoped-filter-op node source condition scope))
+    (-optimize [_ db]
+      (core/optimize-helper-1 scoped-filter-op db source condition scope))
     (-eval [_ context resource scopes]
       (when-let [source (core/-eval source context resource scopes)]
         (filterv
@@ -99,8 +99,8 @@
       (core/resolve-refs-helper filter-op expression-defs source condition))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper filter-op parameters source condition))
-    (-optimize [_ node]
-      (core/optimize-helper filter-op node source condition))
+    (-optimize [_ db]
+      (core/optimize-helper filter-op db source condition))
     (-eval [_ context resource scopes]
       (when-let [source (core/-eval source context resource scopes)]
         (filterv (partial core/-eval condition context resource) source)))
@@ -146,8 +146,8 @@
     (-resolve-params [_ parameters]
       (core/resolve-params-helper-1 scoped-for-each parameters source element
                                     scope))
-    (-optimize [_ node]
-      (core/optimize-helper-1 scoped-for-each node source element scope))
+    (-optimize [_ db]
+      (core/optimize-helper-1 scoped-for-each db source element scope))
     (-eval [_ context resource scopes]
       (when-let [source (core/-eval source context resource scopes)]
         (mapv
@@ -163,8 +163,8 @@
       (core/resolve-refs-helper for-each expression-defs source element))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper for-each parameters source element))
-    (-optimize [_ node]
-      (core/optimize-helper for-each node source element))
+    (-optimize [_ db]
+      (core/optimize-helper for-each db source element))
     (-eval [_ context resource scopes]
       (when-let [source (core/-eval source context resource scopes)]
         (mapv (partial core/-eval element context resource) source)))
@@ -188,8 +188,8 @@
       (core/resolve-refs-helper index-of-op expression-defs source element))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper index-of-op parameters source element))
-    (-optimize [_ node]
-      (core/optimize-helper index-of-op node source element))
+    (-optimize [_ db]
+      (core/optimize-helper index-of-op db source element))
     (-eval [_ context resource scopes]
       (when-let [source (core/-eval source context resource scopes)]
         (when-let [element (core/-eval element context resource scopes)]
@@ -243,8 +243,8 @@
                 (core/-resolve-refs end-index expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper slice-op parameters source start-index end-index))
-    (-optimize [_ node]
-      (core/optimize-helper slice-op node source start-index end-index))
+    (-optimize [_ db]
+      (core/optimize-helper slice-op db source start-index end-index))
     (-eval [_ context resource scopes]
       (when-let [source (core/-eval source context resource scopes)]
         (let [start-index (or (core/-eval start-index context resource scopes) 0)

--- a/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
+++ b/modules/cql/src/blaze/elm/compiler/reusing_logic.clj
@@ -104,8 +104,8 @@
       (to-quantity-function-expr (core/-resolve-refs operand expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-quantity-function-expr parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-quantity-function-expr node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-quantity-function-expr db operand))
     (-eval [_ context resource scope]
       (-to-quantity (core/-eval operand context resource scope)))
     (-form [_]
@@ -122,8 +122,8 @@
       (to-code-function-expr (core/-resolve-refs operand expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-code-function-expr parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-code-function-expr node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-code-function-expr db operand))
     (-eval [_ context resource scope]
       (some-> (core/-eval operand context resource scope) to-code))
     (-form [_]
@@ -137,8 +137,8 @@
       (to-date-function-expr (core/-resolve-refs operand expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-date-function-expr parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-date-function-expr node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-date-function-expr db operand))
     (-eval [_ context resource scope]
       (type/value (core/-eval operand context resource scope)))
     (-form [_]
@@ -167,8 +167,8 @@
       (to-string-function-expr (core/-resolve-refs operand expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-string-function-expr parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-string-function-expr node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-string-function-expr db operand))
     (-eval [_ context resource scope]
       (some-> (type/value (core/-eval operand context resource scope)) str))
     (-form [_]

--- a/modules/cql/src/blaze/elm/compiler/string_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/string_operators.clj
@@ -22,8 +22,8 @@
        (combine-op (core/-resolve-refs source expression-defs)))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper combine-op parameters source))
-     (-optimize [_ node]
-       (core/optimize-helper combine-op node source))
+     (-optimize [_ db]
+       (core/optimize-helper combine-op db source))
      (-eval [_ context resource scope]
        (when-let [source (core/-eval source context resource scope)]
          (string/combine source)))
@@ -38,8 +38,8 @@
                    (core/-resolve-refs separator expression-defs)))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper combine-op parameters source separator))
-     (-optimize [_ node]
-       (core/optimize-helper combine-op node source separator))
+     (-optimize [_ db]
+       (core/optimize-helper combine-op db source separator))
      (-eval [_ context resource scope]
        (when-let [source (core/-eval source context resource scope)]
          (string/combine (core/-eval separator context resource scope)
@@ -78,8 +78,8 @@
                            (core/-resolve-refs string expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper last-position-of-op parameters pattern string))
-    (-optimize [_ node]
-      (core/optimize-helper last-position-of-op node pattern string))
+    (-optimize [_ db]
+      (core/optimize-helper last-position-of-op db pattern string))
     (-eval [_ context resource scope]
       (when-let [^String pattern (core/-eval pattern context resource scope)]
         (when-let [^String string (core/-eval string context resource scope)]
@@ -115,8 +115,8 @@
                       (core/-resolve-refs string expression-defs)))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper position-of-op parameters pattern string))
-    (-optimize [_ node]
-      (core/optimize-helper position-of-op node pattern string))
+    (-optimize [_ db]
+      (core/optimize-helper position-of-op db pattern string))
     (-eval [_ context resource scope]
       (when-let [^String pattern (core/-eval pattern context resource scope)]
         (when-let [^String string (core/-eval string context resource scope)]
@@ -143,8 +143,8 @@
       (core/resolve-refs-helper split-op expression-defs string separator))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper split-op parameters string separator))
-    (-optimize [_ node]
-      (core/optimize-helper split-op node string separator))
+    (-optimize [_ db]
+      (core/optimize-helper split-op db string separator))
     (-eval [_ context resource scope]
       (when-let [string (core/-eval string context resource scope)]
         (if (= "" string)
@@ -191,8 +191,8 @@
        (core/resolve-refs-helper substring-op expression-defs string start-index))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper substring-op parameters string start-index))
-     (-optimize [_ node]
-       (core/optimize-helper substring-op node string start-index))
+     (-optimize [_ db]
+       (core/optimize-helper substring-op db string start-index))
      (-eval [_ context resource scope]
        (when-let [^String string (core/-eval string context resource scope)]
          (when-let [start-index (core/-eval start-index context resource scope)]
@@ -208,8 +208,8 @@
        (core/resolve-refs-helper substring-op expression-defs string start-index length))
      (-resolve-params [_ parameters]
        (core/resolve-params-helper substring-op parameters string start-index length))
-     (-optimize [_ node]
-       (core/optimize-helper substring-op node string start-index length))
+     (-optimize [_ db]
+       (core/optimize-helper substring-op db string start-index length))
      (-eval [_ context resource scope]
        (when-let [^String string (core/-eval string context resource scope)]
          (when-let [start-index (core/-eval start-index context resource scope)]

--- a/modules/cql/src/blaze/elm/compiler/type_operators.clj
+++ b/modules/cql/src/blaze/elm/compiler/type_operators.clj
@@ -123,8 +123,8 @@
       (core/resolve-refs-helper converts-to-date-op expression-defs operand))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper converts-to-date-op parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper converts-to-date-op node operand))
+    (-optimize [_ db]
+      (core/optimize-helper converts-to-date-op db operand))
     (-eval [_ {:keys [now] :as context} resource scope]
       (when-let [operand (core/-eval operand context resource scope)]
         (when (some? operand)
@@ -145,8 +145,8 @@
       (core/resolve-refs-helper converts-to-date-time-op expression-defs operand))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper converts-to-date-time-op parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper converts-to-date-time-op node operand))
+    (-optimize [_ db]
+      (core/optimize-helper converts-to-date-time-op db operand))
     (-eval [_ {:keys [now] :as context} resource scope]
       (when-let [operand (core/-eval operand context resource scope)]
         (when (some? operand)
@@ -200,8 +200,8 @@
       (core/resolve-refs-helper converts-to-time-op expression-defs operand))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper converts-to-time-op parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper converts-to-time-op node operand))
+    (-optimize [_ db]
+      (core/optimize-helper converts-to-time-op db operand))
     (-eval [_ {:keys [now] :as context} resource scope]
       (when-some [operand (core/-eval operand context resource scope)]
         (some? (p/to-time operand now))))
@@ -298,8 +298,8 @@
       (core/resolve-refs-helper to-date-op expression-defs operand))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-date-op parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-date-op node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-date-op db operand))
     (-eval [_ {:keys [now] :as context} resource scope]
       (p/to-date (core/-eval operand context resource scope) now))
     (-form [_]
@@ -321,8 +321,8 @@
       (core/resolve-refs-helper to-date-time-op expression-defs operand))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-date-time-op parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-date-time-op node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-date-time-op db operand))
     (-eval [_ {:keys [now] :as context} resource scope]
       (p/to-date-time (core/-eval operand context resource scope) now))
     (-form [_]
@@ -372,8 +372,8 @@
       (core/resolve-refs-helper to-time-op expression-defs operand))
     (-resolve-params [_ parameters]
       (core/resolve-params-helper to-time-op parameters operand))
-    (-optimize [_ node]
-      (core/optimize-helper to-time-op node operand))
+    (-optimize [_ db]
+      (core/optimize-helper to-time-op db operand))
     (-eval [_ {:keys [now] :as context} resource scope]
       (p/to-time (core/-eval operand context resource scope) now))
     (-form [_]

--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -113,6 +113,11 @@
 (defn resource-handle? [x]
   (rh/resource-handle? x))
 
+(defn deleted?
+  "Returns `true` if `resource-handle` is deleted."
+  [resource-handle]
+  (rh/deleted? resource-handle))
+
 ;; ---- Type-Level Functions --------------------------------------------------
 
 (defn type-list

--- a/modules/db/src/blaze/db/api_spec.clj
+++ b/modules/db/src/blaze/db/api_spec.clj
@@ -50,6 +50,10 @@
   :args (s/cat :x any?)
   :ret boolean?)
 
+(s/fdef d/deleted?
+  :args (s/cat :resource-handle :blaze.db/resource-handle)
+  :ret boolean?)
+
 ;; ---- Type-Level Functions --------------------------------------------------
 
 (s/fdef d/type-list

--- a/modules/job-async-interaction/src/blaze/job/async_interaction/util.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction/util.clj
@@ -42,8 +42,8 @@
 
 (defn pull-request-bundle [node job]
   (if-ok [[type id] (request-bundle-ref job)]
-    (if-let [{:keys [op] :as handle} (d/resource-handle (d/db node) type id)]
-      (if-not (identical? :delete op)
+    (if-let [handle (d/resource-handle (d/db node) type id)]
+      (if-not (d/deleted? handle)
         (d/pull node handle)
         (ac/completed-future (deleted-anom job id)))
       (ac/completed-future (not-found-anom job id)))

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
@@ -1,7 +1,7 @@
 (ns blaze.fhir.operation.evaluate-measure
   "Main entry point into the $evaluate-measure operation."
   (:require
-   [blaze.anomaly :as ba]
+   [blaze.anomaly :as ba :refer [when-ok]]
    [blaze.async.comp :as ac]
    [blaze.coll.core :as coll]
    [blaze.db.api :as d]
@@ -105,8 +105,8 @@
   (format "The Measure resource with the id `%s` was deleted." id))
 
 (defn- find-measure-handle [db request]
-  (let [{:keys [op] :as measure-handle} (find-measure-handle* db request)]
-    (if (identical? :delete op)
+  (when-ok [measure-handle (find-measure-handle* db request)]
+    (if (d/deleted? measure-handle)
       (ba/not-found (measure-deleted-msg measure-handle)
                     :http/status 410
                     :fhir/issue "deleted")

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -385,8 +385,8 @@
   (format "Subject with type `%s` and id `%s` was not found." type id))
 
 (defn- subject-handle* [db type id]
-  (if-let [{:keys [op] :as handle} (d/resource-handle db type id)]
-    (if (identical? :delete op)
+  (if-let [handle (d/resource-handle db type id)]
+    (if (d/deleted? handle)
       (ba/incorrect (missing-subject-msg type id))
       handle)
     (ba/incorrect (missing-subject-msg type id))))

--- a/modules/operation-patient-everything/src/blaze/operation/patient/everything.clj
+++ b/modules/operation-patient-everything/src/blaze/operation/patient/everything.clj
@@ -20,8 +20,8 @@
 (def ^:private ^:const ^long max-size 10000)
 
 (defn- patient-handle [db id]
-  (when-let [{:keys [op] :as handle} (d/resource-handle db "Patient" id)]
-    (when-not (identical? :delete op)
+  (when-let [handle (d/resource-handle db "Patient" id)]
+    (when-not (d/deleted? handle)
       handle)))
 
 (defn- too-costly-msg [patient-id]

--- a/modules/page-id-cipher/src/blaze/page_id_cipher.clj
+++ b/modules/page-id-cipher/src/blaze/page_id_cipher.clj
@@ -31,9 +31,7 @@
 
 (defn- find-key-set-resource [db]
   (log/trace "try to find the key set resource")
-  (when-let [{:keys [op] :as handle} (coll/first (d/type-query db "DocumentReference" [["identifier" identifier]]))]
-    (when-not (identical? :delete op)
-      handle)))
+  (coll/first (d/type-query db "DocumentReference" [["identifier" identifier]])))
 
 (defn- b64-encode [bytes]
   (.encodeToString (Base64/getEncoder) bytes))

--- a/modules/rest-util/src/blaze/handler/fhir/util.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util.clj
@@ -151,8 +151,8 @@
      :fhir/issue "deleted")))
 
 (defn- resource-handle [db type id]
-  (if-let [{:keys [op] :as handle} (d/resource-handle db type id)]
-    (if (identical? :delete op)
+  (if-let [handle (d/resource-handle db type id)]
+    (if (d/deleted? handle)
       (deleted-anom db handle)
       handle)
     (ba/not-found (format "Resource `%s/%s` was not found." type id))))


### PR DESCRIPTION
The new blaze.db.api/deleted? function makes it more easy to detect whether a resource handle is deleted. Before that we had to test if the :op of the handle equals :deleted.