### PR TITLE
Use Equivalent Instead of Contains for Code Comparison

### DIFF
--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q10.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q10.cql
@@ -11,4 +11,4 @@ define InInitialPopulation:
       exists
         from S.extension E
         where E.url = 'https://fhir.bbmri.de/StructureDefinition/StorageTemperature'
-        and E.value.coding contains Code 'temperatureRoom' from StorageTemperature
+        and E.value as CodeableConcept ~ Code 'temperatureRoom' from StorageTemperature

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q16.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q16.cql
@@ -7,4 +7,4 @@ codesystem FastingStatus: 'http://terminology.hl7.org/CodeSystem/v2-0916'
 context Specimen
 
 define InInitialPopulation:
-  Specimen.collection.fastingStatus.coding contains Code 'NF' from FastingStatus
+  Specimen.collection.fastingStatus as CodeableConcept ~ Code 'NF' from FastingStatus

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q28-relationship-procedure-condition.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q28-relationship-procedure-condition.cql
@@ -14,7 +14,7 @@ define EwingSarkomMitStrahlentherapie:
     from [Condition: Code 'C41.9' from icd10] C
       with Strahlentherapien P
         such that P.reasonReference.reference = 'Condition/' + C.id
-    where exists from C.bodySite BS where BS.coding contains Code 'C44.6' from idco3
+    where exists from C.bodySite BS where BS as CodeableConcept ~ Code 'C44.6' from idco3
 
 define InInitialPopulation:
   EwingSarkomMitStrahlentherapie

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q3.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q3.cql
@@ -7,4 +7,4 @@ codesystem SampleMaterialType: 'https://fhir.bbmri.de/CodeSystem/SampleMaterialT
 context Specimen
 
 define InInitialPopulation:
-  Specimen.type.coding contains Code 'whole-blood' from SampleMaterialType
+  Specimen.type ~ Code 'whole-blood' from SampleMaterialType

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q45-histology.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q45-histology.cql
@@ -10,4 +10,4 @@ context Patient
 define InInitialPopulation:
   exists
     from [Observation: Code '59847-4' from loinc] O
-    where O.value.coding contains Code '8140/3' from icdo3
+    where O.value as CodeableConcept ~ Code '8140/3' from icdo3

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q6.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q6.cql
@@ -8,4 +8,4 @@ codesystem icd_o: 'urn:oid:2.16.840.1.113883.6.43.1'
 define InInitialPopulation:
   exists
     from [Specimen: Code 'whole-blood' from SampleMaterialType] S
-    where S.collection.bodySite.coding contains Code 'C26.1' from icd_o
+    where S.collection.bodySite as CodeableConcept ~ Code 'C26.1' from icd_o

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q9.cql
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/q9.cql
@@ -10,4 +10,4 @@ define InInitialPopulation:
   exists
     from Specimen.extension E
     where E.url = 'https://fhir.bbmri.de/StructureDefinition/StorageTemperature'
-      and E.value.coding contains Code 'temperatureRoom' from StorageTemperature
+      and E.value as CodeableConcept ~ Code 'temperatureRoom' from StorageTemperature


### PR DESCRIPTION
Using equivalent works since #1872 and has the advantage that version and display doesn't influence the equality.