### PR TITLE
Pass Parameters Expand Terminology Tests

### DIFF
--- a/.github/terminology-tests/parameters-expand.sh
+++ b/.github/terminology-tests/parameters-expand.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# remove test cases that need the R5 representation of the ValueSet resource
+jq -f "$SCRIPT_DIR/remove-r5-tests.jq" fhir-tx-ecosystem-ig/tests/test-cases.json > fhir-tx-ecosystem-ig/tests/test-cases-new.json
+mv fhir-tx-ecosystem-ig/tests/test-cases-new.json fhir-tx-ecosystem-ig/tests/test-cases.json
+
 java -jar validator_cli.jar -txTests -version 4.0.1 \
   -tx http://localhost:8080/fhir \
   -source fhir-tx-ecosystem-ig/tests \

--- a/.github/terminology-tests/remove-r5-tests.jq
+++ b/.github/terminology-tests/remove-r5-tests.jq
@@ -1,0 +1,10 @@
+del(.suites[].tests[] |
+select(
+ .name == "parameters-expand-all-definitions2" or
+ .name == "parameters-expand-all-property" or
+ .name == "parameters-expand-enum-definitions2" or
+ .name == "parameters-expand-enum-definitions3" or
+ .name == "parameters-expand-isa-definitions2" or
+ .name == "parameters-expand-enum-property" or
+ .name == "parameters-expand-isa-property"
+))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1384,6 +1384,9 @@ jobs:
     - name: Check Simple Expand
       run: .github/terminology-tests/simple-expand.sh
 
+    - name: Check Parameters Expand
+      run: .github/terminology-tests/parameters-expand.sh
+
   not-enforcing-referential-integrity-test:
     needs: build
     runs-on: ubuntu-24.04

--- a/modules/terminology-service/src/blaze/terminology_service/spec.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/spec.clj
@@ -27,6 +27,9 @@
 (s/def ::request/count
   nat-int?)
 
+(s/def ::request/include-designations
+  boolean?)
+
 (s/def ::request/include-definition
   boolean?)
 
@@ -50,6 +53,9 @@
 
 (s/def ::request/system-versions
   (s/coll-of :fhir/canonical))
+
+(s/def ::request/properties
+  (s/coll-of string?))
 
 (s/def ::request/tx-resource
   (s/or :code-system :fhir/CodeSystem :value-set :fhir/ValueSet))
@@ -76,9 +82,11 @@
     ::request/url
     ::request/value-set-version
     ::request/count
+    ::request/include-designations
     ::request/include-definition
     ::request/active-only
     ::request/exclude-nested
+    ::request/properties
     ::request/system-versions
     ::request/tx-resources]))
 


### PR DESCRIPTION
Test cases listed in `.github/terminology-tests/remove-r5-tests.jq` are excluded because they need R5 representations of the ValueSet resource.

Closes: #2290