### PR TITLE
Fix Binary Output in Case of Decoding Errors

### DIFF
--- a/modules/rest-util/test/blaze/middleware/fhir/output_test.clj
+++ b/modules/rest-util/test/blaze/middleware/fhir/output_test.clj
@@ -217,9 +217,9 @@
     (testing "failing binary emit (with invalid data)"
       (given (call (binary-resource-handler-200 {:content-type "application/pdf" :data "MTANjECg=="}) {:headers {"accept" "text/plain"}})
         :status := 500
-        [:headers "Content-Type"] := "application/pdf"
-        [:body :fhir/type] := :fhir/OperationOutcome
-        [:body :issue 0 :diagnostics] := "Input byte array has wrong 4-byte ending unit"))))
+        [:headers "Content-Type"] := "application/fhir+json"
+        [:body parse-json :fhir/type] := :fhir/OperationOutcome
+        [:body parse-json :issue 0 :diagnostics] := "Input byte array has wrong 4-byte ending unit"))))
 
 (deftest not-acceptable-test
   (is (nil? (call resource-handler-200-with-patient {:headers {"accept" "text/plain"}}))))


### PR DESCRIPTION
We did not serialize the OperationOutcome to JSON at all and did not change the Content-Type header to application/fhir+json.