### PR TITLE
Allow more Search Params in Optimization

### DIFF
--- a/modules/db/src/blaze/db/impl/search_param/token.clj
+++ b/modules/db/src/blaze/db/impl/search_param/token.clj
@@ -186,7 +186,9 @@
         (fn [value]
           (when (identical? :fhir/Reference (fhir-spec/fhir-type value))
             (when-let [reference (type/value (:reference value))]
-              (some-> (fsr/split-literal-ref reference) (coll/nth 1))))))
+              (when-let [[type id] (fsr/split-literal-ref reference)]
+                (when (= "Patient" type)
+                  id))))))
        values)))
 
   (-index-values [search-param resolver resource]

--- a/modules/db/test/blaze/db/search_param_registry_test.clj
+++ b/modules/db/test/blaze/db/search_param_registry_test.clj
@@ -159,7 +159,13 @@
               {:fhir/type :fhir/Observation :id "0"
                :subject #fhir/Reference{:reference "Patient/1"}})
         count := 1
-        [0] := ["Patient" "1"]))
+        [0] := ["Patient" "1"])
+
+      (testing "Group is no compartment"
+        (is (empty? (sr/linked-compartments
+                     search-param-registry
+                     {:fhir/type :fhir/Observation :id "0"
+                      :subject #fhir/Reference{:reference "Group/1"}})))))
 
     (testing "MedicationAdministration subject"
       (given (sr/linked-compartments


### PR DESCRIPTION
Also ensure that Resources with Group references with ID's identical to Patient ID are not found.