### PR TITLE
Prevent Recreation of Structure Definition Repo

### DIFF
--- a/modules/db/test/blaze/db/search_param_registry_test.clj
+++ b/modules/db/test/blaze/db/search_param_registry_test.clj
@@ -4,7 +4,6 @@
    [blaze.db.search-param-registry-spec]
    [blaze.fhir-path :as fhir-path]
    [blaze.fhir.spec.type]
-   [blaze.fhir.structure-definition-repo.spec :refer [structure-definition-repo?]]
    [blaze.fhir.test-util :refer [structure-definition-repo]]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
@@ -47,7 +46,7 @@
     (given-thrown (ig/init {:blaze.db/search-param-registry {:structure-definition-repo ::invalid}})
       :key := :blaze.db/search-param-registry
       :reason := ::ig/build-failed-spec
-      [:cause-data ::s/problems 0 :pred] := `structure-definition-repo?
+      [:cause-data ::s/problems 0 :via] := [:blaze.fhir/structure-definition-repo]
       [:cause-data ::s/problems 0 :val] := ::invalid))
 
   (testing "invalid extra-bundle-file"

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl/xml.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl/xml.clj
@@ -17,7 +17,8 @@
   {:arglists '([regex element])}
   [regex {{:keys [value] :as attrs} :attrs content :content}]
   (or (and (string? value) (.matches (re-matcher regex value)))
-      (or (some? (:id attrs)) (seq content))))
+      (some? (:id attrs))
+      (seq content)))
 
 (defn set-extension-tag [element]
   (some-> element (update :content (partial map #(assoc % :tag ::f/extension)))))

--- a/modules/fhir-structure/src/blaze/fhir/structure_definition_repo/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/structure_definition_repo/spec.clj
@@ -3,8 +3,5 @@
    [blaze.fhir.structure-definition-repo.protocols :as p]
    [clojure.spec.alpha :as s]))
 
-(defn structure-definition-repo? [x]
-  (satisfies? p/StructureDefinitionRepo x))
-
 (s/def :blaze.fhir/structure-definition-repo
-  structure-definition-repo?)
+  #(satisfies? p/StructureDefinitionRepo %))

--- a/modules/job-util/test/blaze/job/util_test.clj
+++ b/modules/job-util/test/blaze/job/util_test.clj
@@ -4,7 +4,6 @@
    [blaze.db.api :as d]
    [blaze.db.api-stub :refer [mem-node-config with-system-data]]
    [blaze.fhir.spec.type :as type]
-   [blaze.fhir.structure-definition-repo]
    [blaze.job.util :as job-util]
    [blaze.job.util-spec]
    [blaze.module.test-util :as mtu :refer [given-failed-future]]
@@ -12,7 +11,6 @@
    [clojure.spec.test.alpha :as st]
    [clojure.test :as test :refer [are deftest is testing]]
    [cognitect.anomalies :as anom]
-   [integrant.core :as ig]
    [juxt.iota :refer [given]]
    [taoensso.timbre :as log]))
 
@@ -20,10 +18,6 @@
 (log/set-min-level! :trace)
 
 (test/use-fixtures :each tu/fixture)
-
-(def structure-definition-repo
-  (:blaze.fhir/structure-definition-repo
-   (ig/init {:blaze.fhir/structure-definition-repo {}})))
 
 (defn- codeable-concept [system code]
   (type/codeable-concept

--- a/modules/operation-totals/test/blaze/fhir/operation/totals_test.clj
+++ b/modules/operation-totals/test/blaze/fhir/operation/totals_test.clj
@@ -3,7 +3,7 @@
    [blaze.db.api-stub :as api-stub :refer [with-system-data]]
    [blaze.fhir.operation.totals]
    [blaze.fhir.structure-definition-repo-spec]
-   [blaze.fhir.structure-definition-repo.spec :refer [structure-definition-repo?]]
+   [blaze.fhir.test-util :refer [structure-definition-repo]]
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.db-spec]
    [blaze.test-util :as tu :refer [given-thrown]]
@@ -36,14 +36,14 @@
     (given-thrown (ig/init {:blaze.fhir.operation/totals {:structure-definition-repo ::invalid}})
       :key := :blaze.fhir.operation/totals
       :reason := ::ig/build-failed-spec
-      [:cause-data ::s/problems 0 :pred] := `structure-definition-repo?
+      [:cause-data ::s/problems 0 :via] := [:blaze.fhir/structure-definition-repo]
       [:cause-data ::s/problems 0 :val] := ::invalid)))
 
 (def config
-  (assoc api-stub/mem-node-config
-         :blaze.fhir.operation/totals
-         {:structure-definition-repo (ig/ref :blaze.fhir/structure-definition-repo)}
-         :blaze.fhir/structure-definition-repo {}))
+  (assoc
+   api-stub/mem-node-config
+   :blaze.fhir.operation/totals
+   {:structure-definition-repo structure-definition-repo}))
 
 (defmacro with-handler [[handler-binding & [node-binding]] & more]
   (let [[txs body] (api-stub/extract-txs-body more)]

--- a/modules/rest-api/test/blaze/rest_api/batch_handler_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/batch_handler_test.clj
@@ -1,7 +1,6 @@
 (ns blaze.rest-api.batch-handler-test
   (:require
    [blaze.async.comp :as ac]
-   [blaze.fhir.structure-definition-repo.spec :refer [structure-definition-repo?]]
    [blaze.fhir.test-util :refer [structure-definition-repo]]
    [blaze.handler.util :as handler-util]
    [blaze.module.test-util :refer [with-system]]
@@ -56,7 +55,7 @@
       :reason := ::ig/build-failed-spec
       [:cause-data ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :capabilities-handler))
       [:cause-data ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :resource-patterns))
-      [:cause-data ::s/problems 2 :pred] := `structure-definition-repo?
+      [:cause-data ::s/problems 2 :via] := [:blaze.fhir/structure-definition-repo]
       [:cause-data ::s/problems 2 :val] := ::invalid))
 
   (testing "invalid capabilities-handler"

--- a/modules/rest-api/test/blaze/rest_api/metadata_handler_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/metadata_handler_test.clj
@@ -1,7 +1,6 @@
 (ns blaze.rest-api.metadata-handler-test
   (:require
    [blaze.fhir.structure-definition-repo-spec]
-   [blaze.fhir.structure-definition-repo.spec :refer [structure-definition-repo?]]
    [blaze.module.test-util :refer [with-system]]
    [blaze.rest-api.metadata-handler]
    [blaze.test-util :as tu :refer [given-thrown]]
@@ -34,7 +33,7 @@
     (given-thrown (ig/init {:blaze.rest-api/metadata-handler {:structure-definition-repo ::invalid}})
       :key := :blaze.rest-api/metadata-handler
       :reason := ::ig/build-failed-spec
-      [:cause-data ::s/problems 0 :pred] := `structure-definition-repo?
+      [:cause-data ::s/problems 0 :via] := [:blaze.fhir/structure-definition-repo]
       [:cause-data ::s/problems 0 :val] := ::invalid)))
 
 (def config

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb/impl_test.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb/impl_test.clj
@@ -198,7 +198,7 @@
   (.createColumnFamily ^RocksDB db (ColumnFamilyDescriptor. (from-hex name))))
 
 (deftest put-wb-test
-  (with-open [db (RocksDB/open (str (new-temp-dir!)))]
+  (with-open [db (RocksDB/open (new-temp-dir!))]
     (let [cfh-1 (cfh db "01")
           cfh-2 (cfh db "02")]
       (are [entries state-val] (let [state (atom [])]
@@ -234,7 +234,7 @@
       (swap! state conj [cfh (to-hex key)]))))
 
 (deftest delete-wb-test
-  (with-open [db (RocksDB/open (str (new-temp-dir!)))]
+  (with-open [db (RocksDB/open (new-temp-dir!))]
     (let [cfh-1 (cfh db "01")
           cfh-2 (cfh db "02")]
       (are [entries state-val] (let [state (atom [])]
@@ -264,7 +264,7 @@
       (swap! state conj [cfh (to-hex key) (to-hex val)]))))
 
 (deftest write-wb-test
-  (with-open [db (RocksDB/open (str (new-temp-dir!)))]
+  (with-open [db (RocksDB/open (new-temp-dir!))]
     (let [cfh-1 (cfh db "01")
           cfh-2 (cfh db "02")]
       (testing "put"
@@ -361,7 +361,7 @@
       ::anom/message := "msg-151628")))
 
 (deftest listener-test
-  (with-open [db (RocksDB/open (str (new-temp-dir!)))]
+  (with-open [db (RocksDB/open (new-temp-dir!))]
     (testing "compaction begin"
       (let [res (volatile! nil)]
         (.onCompactionBegin

--- a/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
+++ b/modules/rocksdb/test/blaze/db/kv/rocksdb_test.clj
@@ -125,7 +125,6 @@
       :key := ::rocksdb/table-reader-collector
       :reason := ::ig/build-failed-spec
       [:cause-data ::s/problems 0 :via] := [::metrics/stores]
-      [:cause-data ::s/problems 0 :pred] := `map?
       [:cause-data ::s/problems 0 :val] := ::invalid)))
 
 (defn- new-temp-dir! []


### PR DESCRIPTION
The structure definition repo should not be recreated for each test. There is a central instance in blaze.fhir.test-util.

Also use :via instead of :pre for init test with  structure definition repo.