### PR TITLE
Avoid Closing OutputStream Twice

### DIFF
--- a/modules/fhir-structure/src/blaze/fhir/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec.clj
@@ -62,6 +62,7 @@
   (primitive? (fhir-type x)))
 
 (defn write-json
+  "Writes `value` to output stream `out` closing it if done."
   [context out value]
   (res/write-json context out value))
 

--- a/modules/rest-api/src/blaze/rest_api/middleware/sync.clj
+++ b/modules/rest-api/src/blaze/rest_api/middleware/sync.clj
@@ -5,7 +5,7 @@
    [cognitect.anomalies :as anom]))
 
 (defn wrap-sync
-  "This middleware acts as a translation layer between the future-based asnyc
+  "This middleware acts as a translation layer between the future-based async
   handlers and traditional async ring handlers."
   [handler]
   (fn [request respond raise]

--- a/modules/rest-util/src/blaze/middleware/fhir/output.clj
+++ b/modules/rest-util/src/blaze/middleware/fhir/output.clj
@@ -17,7 +17,7 @@
    [ring.util.response :as ring]
    [taoensso.timbre :as log])
   (:import
-   [java.io ByteArrayOutputStream OutputStream]
+   [java.io ByteArrayOutputStream]
    [java.util Base64]))
 
 (set! *warn-on-reflection* true)
@@ -41,8 +41,7 @@
     (write-body-to-stream [_body _response output-stream]
       (log/trace "generate JSON")
       (with-open [_ (prom/timer generate-duration-seconds "json")]
-        (fhir-spec/write-json writing-context output-stream body)
-        (.close ^OutputStream output-stream)))))
+        (fhir-spec/write-json writing-context output-stream body)))))
 
 (defn- generate-xml** [body]
   (let [out (ByteArrayOutputStream.)]


### PR DESCRIPTION
Because fhir-spec/write-json already closes the output stream, we don't have to do that afterwards.