### PR TITLE
Fix Caching of prom-metrics Git Repo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -71,7 +71,14 @@
   {:mvn/version "1.5.2"}
 
   org.slf4j/slf4j-nop
-  {:mvn/version "2.0.17"}}
+  {:mvn/version "2.0.17"}
+
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :aliases
  {:build

--- a/job-ig/Makefile
+++ b/job-ig/Makefile
@@ -12,6 +12,6 @@ validate: validator_cli.jar
 
 clean:
 	rm -rf fsh-generated
-	rm validator_cli.jar
+	rm -f validator_cli.jar
 
 .PHONY: install build validate clean

--- a/modules/admin-api/deps.edn
+++ b/modules/admin-api/deps.edn
@@ -60,10 +60,6 @@
     info.cqframework/model
     org.apache.commons/commons-collections4]}
 
-  ;; CVE-2024-26308, we need at least 1.26.0
-  org.apache.commons/commons-compress
-  {:mvn/version "1.27.1"}
-
   ca.uhn.hapi.fhir/hapi-fhir-structures-r4
   {:mvn/version "7.6.1"
    :exclusions [com.google.code.findbugs/jsr305]}
@@ -74,12 +70,23 @@
   ca.uhn.hapi.fhir/hapi-fhir-caching-caffeine
   {:mvn/version "7.6.1"}
 
+  com.fasterxml.jackson.datatype/jackson-datatype-jsr310
+  {:mvn/version "2.19.0"}
+
+  ;; CVE-2024-26308, we need at least 1.26.0
+  org.apache.commons/commons-compress
+  {:mvn/version "1.27.1"}
+
   org.fhir/ucum
   {:mvn/version "1.0.10"
    :exclusions [xpp3/xpp3 xpp3/xpp3_xpath]}
 
-  com.fasterxml.jackson.datatype/jackson-datatype-jsr310
-  {:mvn/version "2.19.0"}}
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :aliases
  {:test

--- a/modules/cql/deps.edn
+++ b/modules/cql/deps.edn
@@ -31,6 +31,13 @@
   org.apache.commons/commons-text
   {:mvn/version "1.13.1"}
 
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}
+
   systems.uom/systems-quantity
   {:mvn/version "2.1"}
 

--- a/modules/extern-terminology-service/deps.edn
+++ b/modules/extern-terminology-service/deps.edn
@@ -2,9 +2,6 @@
  {blaze/fhir-client
   {:local/root "../fhir-client"}
 
-  blaze/module-base
-  {:local/root "../module-base"}
-
   blaze/terminology-service
   {:local/root "../terminology-service"}}
 

--- a/modules/fhir-structure/build.clj
+++ b/modules/fhir-structure/build.clj
@@ -7,4 +7,4 @@
    {:basis (b/create-basis {:project "deps.edn"})
     :src-dirs ["java"]
     :class-dir "target/classes"
-    :javac-opts ["-Xlint:all" "-source" "17" "-target" "17"]}))
+    :javac-opts ["-Xlint:all" "-proc:none" "-source" "17" "-target" "17"]}))

--- a/modules/frontend-e2e/Makefile
+++ b/modules/frontend-e2e/Makefile
@@ -21,7 +21,7 @@ cloc-test:
 	cloc src
 
 clean:
-	rm -r node_modules
+	rm -rf node_modules
 	$(MAKE) -C test-data clean
 
 .PHONY: fmt lint install test test-dev-chromium test-dev-ui test-coverage cloc-prod cloc-test clean

--- a/modules/frontend-e2e/test-data/Makefile
+++ b/modules/frontend-e2e/test-data/Makefile
@@ -2,6 +2,6 @@ install:
 	npm install
 
 clean:
-	rm -r node_modules
+	rm -rf node_modules
 
 .PHONY: install clean

--- a/modules/job-compact/deps.edn
+++ b/modules/job-compact/deps.edn
@@ -7,8 +7,12 @@
   blaze/kv
   {:local/root "../kv"}
 
-  blaze/module-base
-  {:local/root "../module-base"}}
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :deps/prep-lib
  {:alias :build

--- a/modules/job-scheduler/deps.edn
+++ b/modules/job-scheduler/deps.edn
@@ -8,10 +8,7 @@
   {:local/root "../luid"}
 
   blaze/job-util
-  {:local/root "../job-util"}
-
-  blaze/module-base
-  {:local/root "../module-base"}}
+  {:local/root "../job-util"}}
 
  :deps/prep-lib
  {:alias :build

--- a/modules/job-util/deps.edn
+++ b/modules/job-util/deps.edn
@@ -1,6 +1,13 @@
 {:deps
  {blaze/db
-  {:local/root "../db"}}
+  {:local/root "../db"}
+
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :aliases
  {:test

--- a/modules/kv/Makefile
+++ b/modules/kv/Makefile
@@ -7,7 +7,10 @@ lint:
 build:
 	clojure -T:build compile
 
-test: build
+prep: build
+	clojure -X:deps prep
+
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
 test-coverage: build

--- a/modules/kv/build.clj
+++ b/modules/kv/build.clj
@@ -7,4 +7,4 @@
    {:basis (b/create-basis {:project "deps.edn"})
     :src-dirs ["java"]
     :class-dir "target/classes"
-    :javac-opts ["-Xlint:all" "-source" "17" "-target" "17"]}))
+    :javac-opts ["-Xlint:all" "-proc:none" "-source" "17" "-target" "17"]}))

--- a/modules/luid/deps.edn
+++ b/modules/luid/deps.edn
@@ -1,8 +1,5 @@
 {:deps
- {blaze/module-base
-  {:local/root "../module-base"}
-
-  blaze/spec
+ {blaze/spec
   {:local/root "../spec"}}
 
  :aliases

--- a/modules/operation-code-system-validate-code/deps.edn
+++ b/modules/operation-code-system-validate-code/deps.edn
@@ -1,8 +1,5 @@
 {:deps
- {blaze/module-base
-  {:local/root "../module-base"}
-
-  blaze/rest-util
+ {blaze/rest-util
   {:local/root "../rest-util"}
 
   blaze/terminology-service

--- a/modules/operation-measure-evaluate-measure/deps.edn
+++ b/modules/operation-measure-evaluate-measure/deps.edn
@@ -24,7 +24,14 @@
   {:local/root "../spec"}
 
   blaze/thread-pool-executor-collector
-  {:local/root "../thread-pool-executor-collector"}}
+  {:local/root "../thread-pool-executor-collector"}
+
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :aliases
  {:test

--- a/modules/operation-value-set-expand/deps.edn
+++ b/modules/operation-value-set-expand/deps.edn
@@ -1,8 +1,5 @@
 {:deps
- {blaze/module-base
-  {:local/root "../module-base"}
-
-  blaze/rest-util
+ {blaze/rest-util
   {:local/root "../rest-util"}
 
   blaze/terminology-service

--- a/modules/operation-value-set-validate-code/deps.edn
+++ b/modules/operation-value-set-validate-code/deps.edn
@@ -1,8 +1,5 @@
 {:deps
- {blaze/module-base
-  {:local/root "../module-base"}
-
-  blaze/rest-util
+ {blaze/rest-util
   {:local/root "../rest-util"}
 
   blaze/terminology-service

--- a/modules/rest-api/deps.edn
+++ b/modules/rest-api/deps.edn
@@ -2,9 +2,6 @@
  {blaze/async
   {:local/root "../async"}
 
-  blaze/module-base
-  {:local/root "../module-base"}
-
   blaze/job-async-interaction
   {:local/root "../job-async-interaction"}
 
@@ -22,7 +19,14 @@
 
   buddy/buddy-auth
   {:mvn/version "3.0.323"
-   :exclusions [buddy/buddy-sign]}}
+   :exclusions [buddy/buddy-sign]}
+
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :aliases
  {:test

--- a/modules/server/build.clj
+++ b/modules/server/build.clj
@@ -7,4 +7,4 @@
    {:basis (b/create-basis {:project "deps.edn"})
     :src-dirs ["java"]
     :class-dir "target/classes"
-    :javac-opts ["-Xlint:all" "-source" "17" "-target" "17"]}))
+    :javac-opts ["-Xlint:all" "-proc:none" "-source" "17" "-target" "17"]}))

--- a/modules/terminology-service/deps.edn
+++ b/modules/terminology-service/deps.edn
@@ -16,7 +16,14 @@
 
   org.fhir/ucum
   {:mvn/version "1.0.10"
-   :exclusions [xpp3/xpp3 xpp3/xpp3_xpath]}}
+   :exclusions [xpp3/xpp3 xpp3/xpp3_xpath]}
+
+  ;; this dependency is only here because otherwise it gets loaded concurrently
+  ;; which breaks caching
+  prom-metrics/prom-metrics
+  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
+   :git/tag "v0.6-alpha.8"
+   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
 
  :deps/prep-lib
  {:alias :build


### PR DESCRIPTION
Clojure Deps tries to cache the prom-metrics repo concurrently which will break. The workaround is to put the dependency right into the deps.edn file of affected modules.