### PR TITLE
Update HAPI from v7.6.1 to v8.2.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -141,10 +141,10 @@
   :outdated
   {:replace-deps
    {com.github.liquidz/antq
-    {:mvn/version "2.11.1264"}
+    {:mvn/version "2.11.1276"}
 
     org.slf4j/slf4j-nop
-    {:mvn/version "2.0.16"}}
+    {:mvn/version "2.0.17"}}
 
    :main-opts
    ["-m" "antq.core"

--- a/modules/admin-api/deps.edn
+++ b/modules/admin-api/deps.edn
@@ -42,40 +42,51 @@
    :exclusions [javax.xml.bind/jaxb-api]}
 
   ca.uhn.hapi.fhir/hapi-fhir-validation
-  {:mvn/version "7.6.1"
+  {:mvn/version "8.2.0"
    :exclusions
-   [net.sf.saxon/Saxon-HE
-    org.ogce/xpp3
-    ognl/ognl
-    org.attoparser/attoparser
-    org.unbescape/unbescape
-    org.xerial/sqlite-jdbc
+   [com.nimbusds/nimbus-jose-jwt
     commons-beanutils/commons-beanutils
-    org.apache.httpcomponents/httpclient
     info.cqframework/cql
     info.cqframework/qdm
     info.cqframework/quick
     info.cqframework/cql-to-elm
     info.cqframework/elm
     info.cqframework/model
-    org.apache.commons/commons-collections4]}
+    io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations
+    net.sf.saxon/Saxon-HE
+    net.sourceforge.plantuml/plantuml-mit
+    org.ogce/xpp3
+    ognl/ognl
+    org.attoparser/attoparser
+    org.unbescape/unbescape
+    org.xerial/sqlite-jdbc
+    org.apache.commons/commons-collections4
+    org.apache.httpcomponents/httpclient]}
 
   ca.uhn.hapi.fhir/hapi-fhir-structures-r4
-  {:mvn/version "7.6.1"
-   :exclusions [com.google.code.findbugs/jsr305]}
+  {:mvn/version "8.2.0"
+   :exclusions
+   [com.google.code.findbugs/jsr305
+    commons-net/commons-net
+    io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations
+    ;; Remove after https://github.com/hapifhir/hapi-fhir/issues/7005 is fixed
+    org.apache.jena/jena-shex]}
 
   ca.uhn.hapi.fhir/hapi-fhir-validation-resources-r4
-  {:mvn/version "7.6.1"}
+  {:mvn/version "8.2.0"
+   :exclusions
+   [com.google.code.findbugs/jsr305
+    io.opentelemetry/opentelemetry-api
+    io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations
+    org.slf4j/jcl-over-slf4j]}
 
   ca.uhn.hapi.fhir/hapi-fhir-caching-caffeine
-  {:mvn/version "7.6.1"}
+  {:mvn/version "8.2.0"
+   :exclusions
+   [io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations]}
 
   com.fasterxml.jackson.datatype/jackson-datatype-jsr310
   {:mvn/version "2.19.0"}
-
-  ;; CVE-2024-26308, we need at least 1.26.0
-  org.apache.commons/commons-compress
-  {:mvn/version "1.27.1"}
 
   org.fhir/ucum
   {:mvn/version "1.0.10"

--- a/modules/admin-api/test/blaze/admin_api_test.clj
+++ b/modules/admin-api/test/blaze/admin_api_test.clj
@@ -906,7 +906,7 @@
           "resourceType" := "OperationOutcome"
           ["issue" 0 "severity"] := "error"
           ["issue" 0 "code"] := "processing"
-          ["issue" 0 "diagnostics"] := "The pattern [system https://samply.github.io/blaze/fhir/CodeSystem/JobType, code re-index, and display '(Re)Index a Search Parameter'] defined in the profile https://samply.github.io/blaze/fhir/StructureDefinition/ReIndexJob not found. Issues: [ValidationMessage[level=ERROR,type=VALUE,location=Task.code.coding.code,message=Value is 'compact' but must be 're-index'], ValidationMessage[level=ERROR,type=VALUE,location=Task.code.coding.display,message=Value is 'Compact a Database Column Family' but must be '(Re)Index a Search Parameter']]"))))
+          ["issue" 0 "diagnostics"] := "The pattern [system https://samply.github.io/blaze/fhir/CodeSystem/JobType, code re-index, and display '(Re)Index a Search Parameter'] defined in the profile https://samply.github.io/blaze/fhir/StructureDefinition/ReIndexJob not found. Issues: [ValidationMessage[level=ERROR,type=VALUE,location=Task.code.coding.code,message=Value is 'compact' but is fixed to 're-index' in the profile https://samply.github.io/blaze/fhir/StructureDefinition/ReIndexJob#Task], ValidationMessage[level=ERROR,type=VALUE,location=Task.code.coding.display,message=Value is 'Compact a Database Column Family' but is fixed to '(Re)Index a Search Parameter' in the profile https://samply.github.io/blaze/fhir/StructureDefinition/ReIndexJob#Task]]"))))
 
   (testing "re-index job"
     (testing "non-absolute search-param-url"

--- a/modules/fhir-test-util/deps.edn
+++ b/modules/fhir-test-util/deps.edn
@@ -18,4 +18,6 @@
   {:local/root "../module-test-util"}
 
   com.google.crypto.tink/tink
-  {:mvn/version "1.17.0"}}}
+  {:mvn/version "1.17.0"
+   :exclusions
+   [com.google.code.findbugs/jsr305]}}}

--- a/modules/page-id-cipher/deps.edn
+++ b/modules/page-id-cipher/deps.edn
@@ -12,7 +12,9 @@
   {:local/root "../scheduler"}
 
   com.google.crypto.tink/tink
-  {:mvn/version "1.17.0"}}
+  {:mvn/version "1.17.0"
+   :exclusions
+   [com.google.code.findbugs/jsr305]}}
 
  :aliases
  {:test


### PR DESCRIPTION
Update went smooth except for
https://github.com/hapifhir/hapi-fhir/issues/7005 were additional dependencies were introduced by accident.

I was able to remove a bunch of other dependencies, namely:

* com.google.code.findbugs/jsr305
* com.nimbusds/nimbus-jose-jwt
* commons-net/commons-net
* io.opentelemetry/opentelemetry-api
* io.opentelemetry/opentelemetry-context
* io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations
* net.sourceforge.plantuml/plantuml-mit
* org.slf4j/jcl-over-slf4j