### PR TITLE
Remove Choice Type Cache from Module fhir-structure

### DIFF
--- a/modules/fhir-structure/deps.edn
+++ b/modules/fhir-structure/deps.edn
@@ -13,9 +13,6 @@
   blaze/module-base
   {:local/root "../module-base"}
 
-  com.github.ben-manes.caffeine/caffeine
-  {:mvn/version "3.2.0"}
-
   com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
   {:mvn/version "2.19.0"}
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -11,7 +11,6 @@
    [clojure.data.xml.node :as xml-node]
    [clojure.string :as str])
   (:import
-   [com.github.benmanes.caffeine.cache CacheLoader Caffeine LoadingCache]
    [java.net URLEncoder]
    [java.nio.charset StandardCharsets]))
 
@@ -286,15 +285,8 @@
         (recur keys))
       (dissoc m key))))
 
-(def ^:private choice-type-key-cache
-  (-> (Caffeine/newBuilder)
-      (.build
-       (reify CacheLoader
-         (load [_ [key type]]
-           (keyword (str (name key) (su/capital (name type)))))))))
-
 (defn- choice-type-key [key type]
-  (.get ^LoadingCache choice-type-key-cache [key type]))
+  (keyword (str (name key) (su/capital (name type)))))
 
 (defn add-choice-type
   "Add the type suffix to the key of a choice typed data element."


### PR DESCRIPTION
Remove a cache of the rather simple calculation

```clojure
(keyword (str (name key) (su/capital (name type))))
```

I've found nothing in the git history that proves the effectiveness of this cache. Also after #2488 that cache was only used for XML processing which is not as widely used as JSON.

Without this cache, we can remove the caffeine dependency from fhir-structure.