### PR TITLE
Remove Dependencies

### DIFF
--- a/modules/byte-buffer/Makefile
+++ b/modules/byte-buffer/Makefile
@@ -10,6 +10,12 @@ test:
 test-coverage:
 	clojure -M:test:coverage
 
+deps-tree:
+	clojure -X:deps tree
+
+deps-list:
+	clojure -X:deps list
+
 cloc-prod:
 	cloc src
 

--- a/modules/byte-string/Makefile
+++ b/modules/byte-string/Makefile
@@ -10,6 +10,12 @@ test:
 test-coverage:
 	clojure -M:test:coverage
 
+deps-tree:
+	clojure -X:deps tree
+
+deps-list:
+	clojure -X:deps list
+
 cloc-prod:
 	cloc src
 

--- a/modules/byte-string/deps.edn
+++ b/modules/byte-string/deps.edn
@@ -7,13 +7,10 @@
   com.google.guava/guava
   {:mvn/version "33.4.8-jre"
    :exclusions
-   [com.google.code.findbugs/jsr305
-    org.checkerframework/checker-qual
-    com.google.errorprone/error_prone_annotations
-    com.google.j2objc/j2objc-annotations]}
-
-  com.fasterxml.jackson.core/jackson-databind
-  {:mvn/version "2.19.0"}}
+   [com.google.errorprone/error_prone_annotations
+    com.google.guava/listenablefuture
+    com.google.j2objc/j2objc-annotations
+    org.jspecify/jspecify]}}
 
  :aliases
  {:test

--- a/modules/byte-string/src/blaze/byte_string.clj
+++ b/modules/byte-string/src/blaze/byte_string.clj
@@ -7,9 +7,6 @@
    [clojure.lang IObj]
    [com.google.common.io BaseEncoding]
    [com.google.protobuf ByteString]
-   [com.fasterxml.jackson.core JsonGenerator]
-   [com.fasterxml.jackson.databind.module SimpleModule]
-   [com.fasterxml.jackson.databind.ser.std StdSerializer]
    [java.io Writer]
    [java.nio ByteBuffer]
    [java.nio.charset StandardCharsets]))
@@ -144,15 +141,6 @@
 
 (defn as-read-only-byte-buffer [bs]
   (.asReadOnlyByteBuffer ^ByteString bs))
-
-(def ^:private serializer
-  (proxy [StdSerializer] [ByteString]
-    (serialize [^ByteString bs ^JsonGenerator gen _]
-      (.writeBinary gen (.toByteArray bs)))))
-
-(def object-mapper-module
-  (doto (SimpleModule. "ByteString")
-    (.addSerializer ByteString serializer)))
 
 (defmethod print-method ByteString [^ByteString bs ^Writer w]
   (.write w "#blaze/byte-string\"")

--- a/modules/cache-collector/deps.edn
+++ b/modules/cache-collector/deps.edn
@@ -6,7 +6,10 @@
   {:local/root "../module-base"}
 
   com.github.ben-manes.caffeine/caffeine
-  {:mvn/version "3.2.0"}}
+  {:mvn/version "3.2.0"
+   :exclusions
+   [org.jspecify/jspecify
+    com.google.errorprone/error_prone_annotations]}}
 
  :aliases
  {:test

--- a/modules/db/test/blaze/db/tx_log/local_test.clj
+++ b/modules/db/test/blaze/db/tx_log/local_test.clj
@@ -1,7 +1,6 @@
 (ns blaze.db.tx-log.local-test
   (:require
    [blaze.async.comp :as ac]
-   [blaze.byte-string :as bs]
    [blaze.db.kv :as kv]
    [blaze.db.kv.mem]
    [blaze.db.kv.mem-spec]
@@ -13,6 +12,7 @@
    [blaze.db.tx-log.spec]
    [blaze.fhir.hash :as hash]
    [blaze.fhir.hash-spec]
+   [blaze.fhir.test-util]
    [blaze.module.test-util :refer [given-failed-future with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]
@@ -38,8 +38,7 @@
 (def ^:private cbor-object-mapper
   (j/object-mapper
    {:factory (CBORFactory.)
-    :decode-key-fn true
-    :modules [bs/object-mapper-module]}))
+    :decode-key-fn true}))
 
 (def patient-hash-0 (hash/generate {:fhir/type :fhir/Patient :id "0"}))
 (def observation-hash-0 (hash/generate {:fhir/type :fhir/Observation :id "0"}))

--- a/modules/fhir-test-util/deps.edn
+++ b/modules/fhir-test-util/deps.edn
@@ -20,4 +20,5 @@
   com.google.crypto.tink/tink
   {:mvn/version "1.17.0"
    :exclusions
-   [com.google.code.findbugs/jsr305]}}}
+   [com.google.code.findbugs/jsr305
+    com.google.errorprone/error_prone_annotations]}}}

--- a/modules/luid/deps.edn
+++ b/modules/luid/deps.edn
@@ -1,6 +1,14 @@
 {:deps
  {blaze/spec
-  {:local/root "../spec"}}
+  {:local/root "../spec"}
+
+  com.google.guava/guava
+  {:mvn/version "33.4.8-jre"
+   :exclusions
+   [com.google.errorprone/error_prone_annotations
+    com.google.guava/listenablefuture
+    com.google.j2objc/j2objc-annotations
+    org.jspecify/jspecify]}}
 
  :aliases
  {:test

--- a/modules/module-base/deps.edn
+++ b/modules/module-base/deps.edn
@@ -10,10 +10,10 @@
   com.google.guava/guava
   {:mvn/version "33.4.8-jre"
    :exclusions
-   [com.google.code.findbugs/jsr305
-    org.checkerframework/checker-qual
-    com.google.errorprone/error_prone_annotations
-    com.google.j2objc/j2objc-annotations]}
+   [com.google.errorprone/error_prone_annotations
+    com.google.guava/listenablefuture
+    com.google.j2objc/j2objc-annotations
+    org.jspecify/jspecify]}
 
   integrant/integrant
   {:mvn/version "0.13.1"}

--- a/modules/page-id-cipher/deps.edn
+++ b/modules/page-id-cipher/deps.edn
@@ -14,7 +14,8 @@
   com.google.crypto.tink/tink
   {:mvn/version "1.17.0"
    :exclusions
-   [com.google.code.findbugs/jsr305]}}
+   [com.google.code.findbugs/jsr305
+    com.google.errorprone/error_prone_annotations]}}
 
  :aliases
  {:test

--- a/modules/test-util/deps.edn
+++ b/modules/test-util/deps.edn
@@ -1,13 +1,5 @@
 {:deps
- {com.google.guava/guava
-  {:mvn/version "33.4.8-jre"
-   :exclusions
-   [com.google.code.findbugs/jsr305
-    org.checkerframework/checker-qual
-    com.google.errorprone/error_prone_annotations
-    com.google.j2objc/j2objc-annotations]}
-
-  com.taoensso/timbre
+ {com.taoensso/timbre
   {:mvn/version "6.7.1"}
 
   org.clojars.akiel/iota


### PR DESCRIPTION
Removed the dependencies:

* com.google.errorprone/error_prone_annotations
* com.google.guava/failureaccess
* com.google.guava/listenablefuture
* org.jspecify/jspecify

I could remove the object-mapper-module from byte-string because we no longer serialize byte strings as CBOR. We serialize our own Hash class instead.