### PR TITLE
Revert to Node 22 LTS

### DIFF
--- a/modules/frontend/Dockerfile
+++ b/modules/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-alpine@sha256:a34e14ef1df25b58258956049ab5a71ea7f0d498e41d0b514f4b8de09af09456
+FROM node:22-alpine@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d19508288107e
 
 COPY build /app
 COPY package*.json /app/


### PR DESCRIPTION
Docker scout complains about an unapproved base image tag. Only the newest version 24 and the LTS version 22 are listed as supported tags under: https://hub.docker.com/_/node