### PR TITLE
Move LUID Creation Helper for Components

### DIFF
--- a/modules/admin-api/deps.edn
+++ b/modules/admin-api/deps.edn
@@ -22,9 +22,6 @@
   blaze/job-re-index
   {:local/root "../job-re-index"}
 
-  blaze/luid
-  {:local/root "../luid"}
-
   blaze/module-base
   {:local/root "../module-base"}
 

--- a/modules/anomaly/src/blaze/anomaly.clj
+++ b/modules/anomaly/src/blaze/anomaly.clj
@@ -89,7 +89,11 @@
 (defn unsupported [msg & {:as kvs}]
   (anomaly* ::anom/unsupported msg kvs))
 
-(defn not-found [msg & {:as kvs}]
+(defn not-found
+  "Creates an anomaly with category `not-found`.
+
+  Typical keys are: :http/status, :http/headers, :fhir/issue"
+  [msg & {:as kvs}]
   (anomaly* ::anom/not-found msg kvs))
 
 (defn conflict

--- a/modules/db-resource-store/src/blaze/db/resource_store_spec.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store_spec.clj
@@ -17,5 +17,5 @@
 
 (s/fdef rs/put!
   :args (s/cat :store :blaze.db/resource-store
-               :entries (s/map-of :blaze.resource/hash :blaze/resource))
+               :entries (s/map-of :blaze.resource/hash :fhir/Resource))
   :ret ac/completable-future?)

--- a/modules/db/src/blaze/db/search_param_registry_spec.clj
+++ b/modules/db/src/blaze/db/search_param_registry_spec.clj
@@ -32,7 +32,7 @@
 
 (s/fdef sr/linked-compartments
   :args (s/cat :search-param-registry :blaze.db/search-param-registry
-               :resource :blaze/resource)
+               :resource :fhir/Resource)
   :ret (s/or :compartments (s/coll-of (s/tuple string? :blaze.resource/id))
              :anomaly ::anom/anomaly))
 

--- a/modules/db/src/blaze/db/spec.clj
+++ b/modules/db/src/blaze/db/spec.clj
@@ -58,7 +58,7 @@
 
 (defmethod tx-op :create [_]
   (s/cat :op #{:create}
-         :resource :blaze/resource
+         :resource :fhir/Resource
          :if-none-exist (s/? :blaze.db.tx-cmd/if-none-exist)))
 
 (defmulti put-precond-op "Put precondition operator" first)
@@ -76,7 +76,7 @@
 
 (defmethod tx-op :put [_]
   (s/cat :op #{:put}
-         :resource :blaze/resource
+         :resource :fhir/Resource
          :precondition (s/? :blaze.db.tx-op.put/precondition)))
 
 (defmethod tx-op :keep [_]

--- a/modules/db/test/blaze/db/impl/search_param_spec.clj
+++ b/modules/db/test/blaze/db/impl/search_param_spec.clj
@@ -76,13 +76,13 @@
 
 (s/fdef search-param/compartment-ids
   :args (s/cat :search-param :blaze.db/search-param
-               :resource :blaze/resource)
+               :resource :fhir/Resource)
   :ret (s/or :ids (s/coll-of :blaze.resource/id) :anomaly ::anom/anomaly))
 
 (s/fdef search-param/index-entries
   :args (s/cat :search-param :blaze.db/search-param
                :linked-compartments (s/nilable (s/coll-of (s/tuple string? string?)))
                :hash :blaze.resource/hash
-               :resource :blaze/resource)
+               :resource :fhir/Resource)
   :ret (s/or :entries (cs/coll-of :blaze.db.kv/put-entry)
              :anomaly ::anom/anomaly))

--- a/modules/db/test/blaze/db/node/transaction_spec.clj
+++ b/modules/db/test/blaze/db/node/transaction_spec.clj
@@ -7,4 +7,4 @@
 
 (s/fdef tx/prepare-ops
   :args (s/cat :context :blaze.db.node.transaction/context :tx-ops :blaze.db/tx-ops)
-  :ret (s/tuple :blaze.db/tx-cmds (s/map-of :blaze.resource/hash :blaze/resource)))
+  :ret (s/tuple :blaze.db/tx-cmds (s/map-of :blaze.resource/hash :fhir/Resource)))

--- a/modules/fhir-client/src/blaze/fhir_client_spec.clj
+++ b/modules/fhir-client/src/blaze/fhir_client_spec.clj
@@ -22,12 +22,12 @@
   :ret ac/completable-future?)
 
 (s/fdef fhir-client/create
-  :args (s/cat :base-uri string? :resource :blaze/resource
+  :args (s/cat :base-uri string? :resource :fhir/Resource
                :opts (s/? ::fhir-client/options))
   :ret ac/completable-future?)
 
 (s/fdef fhir-client/update
-  :args (s/cat :base-uri string? :resource :blaze/resource
+  :args (s/cat :base-uri string? :resource :fhir/Resource
                :opts (s/? ::fhir-client/options))
   :ret ac/completable-future?)
 
@@ -42,7 +42,7 @@
   :ret ac/completable-future?)
 
 (s/fdef fhir-client/transact
-  :args (s/cat :base-uri string? :bundle :blaze/resource
+  :args (s/cat :base-uri string? :bundle :fhir/Resource
                :opts (s/? ::fhir-client/options))
   :ret ac/completable-future?)
 

--- a/modules/fhir-structure/src/blaze/fhir/hash_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/hash_spec.clj
@@ -32,5 +32,5 @@
   :ret int?)
 
 (s/fdef hash/generate
-  :args (s/cat :resource :blaze/resource)
+  :args (s/cat :resource :fhir/Resource)
   :ret :blaze.resource/hash)

--- a/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
@@ -28,7 +28,7 @@
 (s/def :blaze.resource/variant
   #{:complete :summary})
 
-(s/def :blaze/resource
+(s/def :fhir/Resource
   #(s2/valid? :fhir/Resource %))
 
 (s/def :fhir/CodeableConcept

--- a/modules/fhir-structure/src/blaze/fhir/spec_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec_spec.clj
@@ -27,12 +27,12 @@
 (s/fdef fhir-spec/parse-json
   :args (s/cat :context :blaze.fhir/parsing-context :type (s/? string?)
                :source some?)
-  :ret (s/or :resource :blaze/resource :anomaly ::anom/anomaly))
+  :ret (s/or :resource :fhir/Resource :anomaly ::anom/anomaly))
 
 (s/fdef fhir-spec/parse-cbor
   :args (s/cat :context :blaze.fhir/parsing-context :type string?
                :source bytes? :variant (s/? :blaze.resource/variant))
-  :ret (s/or :resource :blaze/resource :anomaly ::anom/anomaly))
+  :ret (s/or :resource :fhir/Resource :anomaly ::anom/anomaly))
 
 (s/fdef fhir-spec/write-json
   :args (s/cat :context :blaze.fhir/writing-context :out some? :value any?))
@@ -51,7 +51,7 @@
 
 (s/fdef fhir-spec/conform-xml
   :args (s/cat :x any?)
-  :ret (s/or :resource :blaze/resource :anomaly ::anom/anomaly))
+  :ret (s/or :resource :fhir/Resource :anomaly ::anom/anomaly))
 
 (s/fdef fhir-spec/unform-xml
   :args (s/cat :resource any?))

--- a/modules/interaction/deps.edn
+++ b/modules/interaction/deps.edn
@@ -2,9 +2,6 @@
  {blaze/async
   {:local/root "../async"}
 
-  blaze/luid
-  {:local/root "../luid"}
-
   blaze/job-async-interaction
   {:local/root "../job-async-interaction"}
 

--- a/modules/interaction/src/blaze/interaction/create.clj
+++ b/modules/interaction/src/blaze/interaction/create.clj
@@ -45,7 +45,7 @@
   (fn [{{{:fhir.resource/keys [type]} :data} ::reitit/match
         :keys [headers body]
         :as request}]
-    (let [id (handler-util/luid context)
+    (let [id (m/luid context)
           conditional-clauses (conditional-clauses headers)
           tx-op (create-op (assoc (iu/strip-meta body) :id id) conditional-clauses)]
       (-> (d/transact node [tx-op])

--- a/modules/interaction/src/blaze/interaction/history/util.clj
+++ b/modules/interaction/src/blaze/interaction/history/util.clj
@@ -3,8 +3,8 @@
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
-   [blaze.handler.util :as handler-util]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
+   [blaze.module :as m]
    [blaze.util :as u]
    [reitit.core :as reitit])
   (:import
@@ -121,7 +121,7 @@
 
 (defn build-bundle [context total query-params]
   {:fhir/type :fhir/Bundle
-   :id (handler-util/luid context)
+   :id (m/luid context)
    :type #fhir/code"history"
    :total (total-value total)
    :link [(self-link context query-params)]})

--- a/modules/interaction/src/blaze/interaction/search_compartment.clj
+++ b/modules/interaction/src/blaze/interaction/search_compartment.clj
@@ -64,7 +64,7 @@
 
 (defn- bundle* [context handles clauses]
   {:fhir/type :fhir/Bundle
-   :id (handler-util/luid context)
+   :id (m/luid context)
    :type #fhir/code"searchset"
    :total (type/->UnsignedInt (count handles))
    :link [(self-link context clauses)]})

--- a/modules/interaction/src/blaze/interaction/search_system.clj
+++ b/modules/interaction/src/blaze/interaction/search_system.clj
@@ -62,7 +62,7 @@
     {{route-name :name} :data} ::reitit/match :as context} entries]
   (cond->
    {:fhir/type :fhir/Bundle
-    :id (handler-util/luid context)
+    :id (m/luid context)
     :type #fhir/code"searchset"
     :total (type/->UnsignedInt (d/system-total db))
     :entry (if (< page-size (count entries))
@@ -85,7 +85,7 @@
 (defn- search-summary [{:blaze/keys [db] :as context}]
   (ac/completed-future
    {:fhir/type :fhir/Bundle
-    :id (handler-util/luid context)
+    :id (m/luid context)
     :type #fhir/code"searchset"
     :total (type/->UnsignedInt (d/system-total db))
     :link [(self-link context)]}))

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -172,7 +172,7 @@
   generating a token for the first link, we don't need in this case."
   [context clauses]
   {:fhir/type :fhir/Bundle
-   :id (handler-util/luid context)
+   :id (m/luid context)
    :type #fhir/code"searchset"
    :total #fhir/unsignedInt 0
    :link [(self-link context clauses)]})
@@ -182,7 +182,7 @@
    total]
   (cond->
    {:fhir/type :fhir/Bundle
-    :id (handler-util/luid context)
+    :id (m/luid context)
     :type #fhir/code"searchset"
     :entry entries
     :link [(first-link context token clauses)]}
@@ -212,7 +212,7 @@
 (defn- summary-response [context total clauses]
   (ring/response
    {:fhir/type :fhir/Bundle
-    :id (handler-util/luid context)
+    :id (m/luid context)
     :type #fhir/code"searchset"
     :total (type/->UnsignedInt total)
     :link [(self-link context clauses)]}))

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -248,7 +248,7 @@
 
 (defn- response-bundle [context type entries]
   {:fhir/type :fhir/Bundle
-   :id (handler-util/luid context)
+   :id (m/luid context)
    :type (type/code (str (type/value type) "-response"))
    :entry entries})
 

--- a/modules/interaction/test/blaze/interaction/create_test.clj
+++ b/modules/interaction/test/blaze/interaction/create_test.clj
@@ -16,6 +16,7 @@
    [blaze.interaction.create]
    [blaze.interaction.test-util :refer [wrap-error]]
    [blaze.interaction.util-spec]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/interaction/test/blaze/interaction/history/util_spec.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_spec.clj
@@ -4,6 +4,7 @@
    [blaze.handler.fhir.util-spec]
    [blaze.http.spec]
    [blaze.interaction.history.util :as util]
+   [blaze.module-spec]
    [blaze.spec]
    [clojure.spec.alpha :as s]
    [reitit.core :as reitit]))
@@ -34,4 +35,4 @@
 
 (s/fdef util/build-entry
   :args (s/cat :context (s/keys :req [:blaze/base-url ::reitit/router])
-               :resource :blaze/resource))
+               :resource :fhir/Resource))

--- a/modules/interaction/test/blaze/interaction/search_compartment_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_compartment_test.clj
@@ -17,6 +17,7 @@
    [blaze.middleware.fhir.db-spec]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
    [blaze.middleware.fhir.decrypt-page-id-spec]
+   [blaze.module-spec]
    [blaze.page-id-cipher.spec]
    [blaze.page-store-spec]
    [blaze.page-store.local]

--- a/modules/interaction/test/blaze/interaction/search_system_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_system_test.clj
@@ -16,6 +16,7 @@
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.db-spec]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
+   [blaze.module-spec]
    [blaze.page-id-cipher.spec]
    [blaze.page-store-spec]
    [blaze.page-store.local]

--- a/modules/interaction/test/blaze/interaction/search_type_test.clj
+++ b/modules/interaction/test/blaze/interaction/search_type_test.clj
@@ -20,6 +20,7 @@
    [blaze.middleware.fhir.db-spec]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
    [blaze.middleware.fhir.decrypt-page-id-spec]
+   [blaze.module-spec]
    [blaze.page-id-cipher.spec]
    [blaze.page-store-spec]
    [blaze.page-store.local]

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -26,6 +26,7 @@
    [blaze.interaction.util-spec]
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.db-spec]
+   [blaze.module-spec]
    [blaze.page-store-spec]
    [blaze.page-store.local]
    [blaze.test-util :as tu :refer [given-thrown]]

--- a/modules/interaction/test/blaze/interaction/util_spec.clj
+++ b/modules/interaction/test/blaze/interaction/util_spec.clj
@@ -21,14 +21,14 @@
   :ret :blaze.db.query/search-clauses)
 
 (s/fdef iu/update-tx-op
-  :args (s/cat :db :blaze.db/db :resource :blaze/resource
+  :args (s/cat :db :blaze.db/db :resource :fhir/Resource
                :if-match (s/nilable string?)
                :if-none-match (s/nilable string?))
   :ret (s/or :tx-op :blaze.db/tx-op :anomaly ::anom/anomaly))
 
 (s/fdef iu/strip-meta
-  :args (s/cat :resource :blaze/resource)
-  :ret :blaze/resource)
+  :args (s/cat :resource :fhir/Resource)
+  :ret :fhir/Resource)
 
 (s/fdef iu/keep?
   :args (s/cat :tx-op (s/nilable :blaze.db/tx-op))

--- a/modules/job-async-interaction/src/blaze/job/async_interaction.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction.clj
@@ -5,7 +5,6 @@
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.handler.fhir.util.spec]
-   [blaze.handler.util :as handler-util]
    [blaze.job-scheduler.protocols :as p]
    [blaze.job.async-interaction.spec]
    [blaze.job.async-interaction.util :as u]
@@ -87,7 +86,7 @@
 
 (defn- response-bundle [context entries]
   {:fhir/type :fhir/Bundle
-   :id (handler-util/luid context)
+   :id (m/luid context)
    :type #fhir/code"batch-response"
    :entry entries})
 

--- a/modules/job-async-interaction/src/blaze/job/async_interaction/request.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction/request.clj
@@ -5,7 +5,7 @@
    [blaze.handler.util :as handler-util]
    [blaze.job-scheduler :as js]
    [blaze.job.async-interaction :as job-async]
-   [blaze.luid :as luid]
+   [blaze.module :as m]
    [clojure.string :as str]
    [java-time.api :as time]
    [ring.util.response :as ring]
@@ -15,9 +15,6 @@
 
 (defn- strip-context-path [context-path uri]
   (subs uri (inc (count context-path))))
-
-(defn- luid [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))
 
 (defn- request-bundle
   [id context-path {:keys [request-method uri headers query-string body]}]
@@ -40,7 +37,7 @@
   [{:keys [context-path clock] :or {context-path ""} :as context}
    {:blaze/keys [job-scheduler db] :as request}]
   (let [authored-on (time/offset-date-time clock)
-        bundle-id (luid context)]
+        bundle-id (m/luid context)]
     (log/debug "Initiate async response...")
     (do-sync [job (js/create-job job-scheduler
                                  (job-async/job authored-on bundle-id (d/t db))

--- a/modules/job-async-interaction/src/blaze/job/async_interaction/request_spec.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction/request_spec.clj
@@ -3,6 +3,7 @@
    [blaze.async.comp :as ac]
    [blaze.job.async-interaction.request :as req]
    [blaze.job.async-interaction.request.spec]
+   [blaze.module-spec]
    [clojure.spec.alpha :as s]))
 
 (s/fdef req/handle-async

--- a/modules/job-async-interaction/src/blaze/job/async_interaction/util.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction/util.clj
@@ -34,17 +34,19 @@
         (ba/incorrect (format "Invalid request bundle reference `%s`." reference)))
     (ba/incorrect "Missing request bundle reference.")))
 
-(defn- deleted-anom [{job-id :id} bundle-id]
-  (ba/not-found (format "The request bundle with id `%s` of job with id `%s` was deleted." bundle-id job-id)))
+(defn- deleted-msg [{job-id :id} bundle-id]
+  (format "The request bundle with id `%s` of job with id `%s` was deleted."
+          bundle-id job-id))
 
-(defn- not-found-anom [{job-id :id} bundle-id]
-  (ba/not-found (format "Can't find the request bundle with id `%s` of job with id `%s`." bundle-id job-id)))
+(defn- not-found-msg [{job-id :id} bundle-id]
+  (format "Can't find the request bundle with id `%s` of job with id `%s`."
+          bundle-id job-id))
 
 (defn pull-request-bundle [node job]
   (if-ok [[type id] (request-bundle-ref job)]
     (if-let [handle (d/resource-handle (d/db node) type id)]
       (if-not (d/deleted? handle)
         (d/pull node handle)
-        (ac/completed-future (deleted-anom job id)))
-      (ac/completed-future (not-found-anom job id)))
+        (ac/completed-future (ba/not-found (deleted-msg job id))))
+      (ac/completed-future (ba/not-found (not-found-msg job id))))
     ac/completed-future))

--- a/modules/job-async-interaction/src/blaze/job/async_interaction_spec.clj
+++ b/modules/job-async-interaction/src/blaze/job/async_interaction_spec.clj
@@ -3,6 +3,7 @@
    [blaze.db.tx-log.spec]
    [blaze.fhir.spec.spec]
    [blaze.job.async-interaction :as job-async]
+   [blaze.module-spec]
    [clojure.spec.alpha :as s]))
 
 (s/fdef job-async/job

--- a/modules/job-scheduler/deps.edn
+++ b/modules/job-scheduler/deps.edn
@@ -4,9 +4,6 @@
  {blaze/db
   {:local/root "../db"}
 
-  blaze/luid
-  {:local/root "../luid"}
-
   blaze/job-util
   {:local/root "../job-util"}}
 

--- a/modules/job-scheduler/src/blaze/job_scheduler_spec.clj
+++ b/modules/job-scheduler/src/blaze/job_scheduler_spec.clj
@@ -5,11 +5,12 @@
    [blaze.job-scheduler :as js]
    [blaze.job-scheduler.spec]
    [blaze.job.util-spec]
+   [blaze.module-spec]
    [clojure.spec.alpha :as s]))
 
 (s/fdef js/create-job
-  :args (s/cat :scheduler :blaze/job-scheduler :job :blaze/resource
-               :other-resources (s/* :blaze/resource))
+  :args (s/cat :scheduler :blaze/job-scheduler :job :fhir/Resource
+               :other-resources (s/* :fhir/Resource))
   :ret ac/completable-future?)
 
 (s/fdef js/cancel-job

--- a/modules/job-util/src/blaze/job/util_spec.clj
+++ b/modules/job-util/src/blaze/job/util_spec.clj
@@ -53,7 +53,7 @@
 
 (s/fdef job-util/update-job+
   :args (s/cat :node :blaze.db/node :job :fhir/Task
-               :other-resources (s/nilable (s/coll-of :blaze/resource))
+               :other-resources (s/nilable (s/coll-of :fhir/Resource))
                :f fn? :args (s/* any?))
   :ret ac/completable-future?)
 

--- a/modules/module-base/deps.edn
+++ b/modules/module-base/deps.edn
@@ -4,6 +4,9 @@
  {blaze/anomaly
   {:local/root "../anomaly"}
 
+  blaze/luid
+  {:local/root "../luid"}
+
   com.taoensso/timbre
   {:mvn/version "6.7.1"}
 

--- a/modules/module-base/src/blaze/module.clj
+++ b/modules/module-base/src/blaze/module.clj
@@ -1,7 +1,14 @@
 (ns blaze.module
   (:require
+   [blaze.luid :as luid]
    [clojure.spec.alpha :as s]
    [integrant.core :as ig]))
+
+(defn luid
+  "Creates an LUID from :clock :rng-fn in `context`."
+  {:arglists '([context])}
+  [{:keys [clock rng-fn]}]
+  (luid/luid clock (rng-fn)))
 
 (defmacro reg-collector
   "Registers a metrics collector to the central registry."

--- a/modules/module-base/src/blaze/module_spec.clj
+++ b/modules/module-base/src/blaze/module_spec.clj
@@ -1,0 +1,10 @@
+(ns blaze.module-spec
+  (:require
+   [blaze.luid.spec]
+   [blaze.module :as m]
+   [blaze.spec]
+   [clojure.spec.alpha :as s]))
+
+(s/fdef m/luid
+  :args (s/cat :context (s/keys :req-un [:blaze/clock :blaze/rng-fn]))
+  :ret :blaze/luid)

--- a/modules/module-base/test/blaze/module_test.clj
+++ b/modules/module-base/test/blaze/module_test.clj
@@ -1,18 +1,27 @@
 (ns blaze.module-test
   (:require
    [blaze.module :as m :refer [reg-collector]]
-   [blaze.test-util  :as tu :refer [given-thrown]]
+   [blaze.module-spec]
+   [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]
    [clojure.test :as test :refer [deftest is testing]]
    [integrant.core :as ig]
+   [java-time.api :as time]
    [prometheus.alpha :refer [defcounter]])
   (:import
-   [io.prometheus.client Collector]))
+   [io.prometheus.client Collector]
+   [java.util.concurrent ThreadLocalRandom]))
 
+(set! *warn-on-reflection* true)
 (st/instrument)
 
 (test/use-fixtures :each tu/fixture)
+
+(deftest luid-test
+  (let [context {:clock (time/system-clock)
+                 :rng-fn #(ThreadLocalRandom/current)}]
+    (is (s/valid? :blaze/luid (m/luid context)))))
 
 (defcounter collector
   "Collector")

--- a/modules/operation-measure-evaluate-measure/deps.edn
+++ b/modules/operation-measure-evaluate-measure/deps.edn
@@ -8,9 +8,6 @@
   blaze/job-async-interaction
   {:local/root "../job-async-interaction"}
 
-  blaze/luid
-  {:local/root "../luid"}
-
   blaze/metrics
   {:local/root "../metrics"}
 

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure.clj
@@ -16,7 +16,6 @@
    [blaze.fhir.response.create :as response]
    [blaze.handler.util :as handler-util]
    [blaze.job.async-interaction.request :as req]
-   [blaze.luid :as luid]
    [blaze.module :as m :refer [reg-collector]]
    [blaze.spec]
    [blaze.util :as u]
@@ -31,9 +30,6 @@
    [java.util.concurrent TimeUnit]))
 
 (set! *warn-on-reflection* true)
-
-(defn- luid [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))
 
 (defn- tx-ops [{:keys [tx-ops resource]} id]
   (conj (or tx-ops []) [:create (assoc resource :id id)]))
@@ -67,7 +63,7 @@
                (ac/completed-future (ring/response (:resource result)))
 
                (= :post request-method)
-               (let [id (luid context)]
+               (let [id (m/luid context)]
                  (-> (d/transact node (tx-ops result id))
                      (ac/then-compose
                       (fn [db-after]

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_spec.clj
@@ -39,5 +39,5 @@
    [::measure/subject-ref]))
 
 (s/fdef measure/evaluate-measure
-  :args (s/cat :context ::context :measure :blaze/resource :params ::params)
+  :args (s/cat :context ::context :measure :fhir/Resource :params ::params)
   :ret ac/completable-future?)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_test.clj
@@ -953,7 +953,7 @@
 
   (let [result (evaluate "q1" "subject-list")]
     (testing "MeasureReport is valid"
-      (is (s/valid? :blaze/resource (:resource result))))
+      (is (s/valid? :fhir/Resource (:resource result))))
 
     (given (first-population result)
       :count := 2
@@ -968,7 +968,7 @@
 (deftest stratifier-integration-test
   (let [result (evaluate "q19-stratifier-ageclass")]
     (testing "MeasureReport is valid"
-      (is (s/valid? :blaze/resource (:resource result))))
+      (is (s/valid? :fhir/Resource (:resource result))))
 
     (testing "MeasureReport type is `summary`"
       (is (= #fhir/code"summary" (-> result :resource :type))))
@@ -989,7 +989,7 @@
 
   (let [result (evaluate "q19-stratifier-ageclass" "subject-list")]
     (testing "MeasureReport is valid"
-      (is (s/valid? :blaze/resource (:resource result))))
+      (is (s/valid? :fhir/Resource (:resource result))))
 
     (testing "MeasureReport type is `subject-list`"
       (is (= #fhir/code"subject-list" (-> result :resource :type))))
@@ -1055,7 +1055,7 @@
 
   (let [result (evaluate "q23-stratifier-ageclass-and-gender" "subject-list")]
     (testing "MeasureReport is valid"
-      (is (s/valid? :blaze/resource (:resource result))))
+      (is (s/valid? :fhir/Resource (:resource result))))
 
     (given (first-stratifier-strata result)
       count := 4

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure_test.clj
@@ -15,6 +15,7 @@
    [blaze.metrics.spec]
    [blaze.middleware.fhir.db :refer [wrap-db]]
    [blaze.middleware.fhir.db-spec]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu :refer [given-thrown]]
    [clojure.spec.alpha :as s]

--- a/modules/operation-patient-everything/deps.edn
+++ b/modules/operation-patient-everything/deps.edn
@@ -2,9 +2,6 @@
  {blaze/async
   {:local/root "../async"}
 
-  blaze/luid
-  {:local/root "../luid"}
-
   blaze/metrics
   {:local/root "../metrics"}
 

--- a/modules/operation-patient-everything/test/blaze/operation/patient/everything_test.clj
+++ b/modules/operation-patient-everything/test/blaze/operation/patient/everything_test.clj
@@ -9,6 +9,7 @@
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
    [blaze.middleware.fhir.decrypt-page-id-spec]
+   [blaze.module-spec]
    [blaze.operation.patient.everything]
    [blaze.page-id-cipher.spec]
    [blaze.test-util :as tu :refer [given-thrown]]
@@ -153,7 +154,7 @@
           :fhir/type := :fhir/OperationOutcome
           [:issue 0 :severity] := #fhir/code"error"
           [:issue 0 :code] := #fhir/code"not-found"
-          [:issue 0 :diagnostics] := "The Patient with id `145801` was not found."))))
+          [:issue 0 :diagnostics] := "Resource `Patient/145801` was not found."))))
 
   (testing "Patient deleted"
     (with-handler [handler]
@@ -163,13 +164,13 @@
       (let [{:keys [status body]}
             @(handler {:path-params {:id "150158"}})]
 
-        (is (= 404 status))
+        (is (= 410 status))
 
         (given body
           :fhir/type := :fhir/OperationOutcome
           [:issue 0 :severity] := #fhir/code"error"
-          [:issue 0 :code] := #fhir/code"not-found"
-          [:issue 0 :diagnostics] := "The Patient with id `150158` was not found."))))
+          [:issue 0 :code] := #fhir/code"deleted"
+          [:issue 0 :diagnostics] := "Resource `Patient/150158` was deleted."))))
 
   (testing "invalid start date"
     (with-handler [handler]

--- a/modules/page-id-cipher/deps.edn
+++ b/modules/page-id-cipher/deps.edn
@@ -2,9 +2,6 @@
  {blaze/db
   {:local/root "../db"}
 
-  blaze/luid
-  {:local/root "../luid"}
-
   blaze/module-base
   {:local/root "../module-base"}
 

--- a/modules/page-id-cipher/src/blaze/page_id_cipher.clj
+++ b/modules/page-id-cipher/src/blaze/page_id_cipher.clj
@@ -6,7 +6,6 @@
    [blaze.db.api :as d]
    [blaze.db.spec]
    [blaze.fhir.spec.type :as type]
-   [blaze.luid :as luid]
    [blaze.module :as m]
    [blaze.page-id-cipher.impl :as impl]
    [blaze.page-id-cipher.spec]
@@ -22,9 +21,6 @@
    [java.util.concurrent Flow$Subscriber]))
 
 (set! *warn-on-reflection* true)
-
-(defn- luid [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))
 
 (def ^:private ^:const identifier
   "page-id-cipher")
@@ -50,7 +46,7 @@
 
 (defn- key-set-resource [context]
   {:fhir/type :fhir/DocumentReference
-   :id (luid context)
+   :id (m/luid context)
    :identifier [(type/map->Identifier {:value identifier})]
    :status #fhir/code"current"
    :content

--- a/modules/page-id-cipher/test/blaze/page_id_cipher_test.clj
+++ b/modules/page-id-cipher/test/blaze/page_id_cipher_test.clj
@@ -12,6 +12,7 @@
    [blaze.fhir.parsing-context]
    [blaze.fhir.test-util :refer [structure-definition-repo]]
    [blaze.fhir.writing-context]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.page-id-cipher]
    [blaze.page-id-cipher.spec]

--- a/modules/rest-util/src/blaze/handler/fhir/util.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util.clj
@@ -157,7 +157,7 @@
       ["ETag" (etag tx)]]
      :fhir/issue "deleted")))
 
-(defn- resource-handle [db type id]
+(defn resource-handle [db type id]
   (if-let [handle (d/resource-handle db type id)]
     (if (d/deleted? handle)
       (deleted-anom db handle)

--- a/modules/rest-util/src/blaze/handler/fhir/util_spec.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util_spec.clj
@@ -73,6 +73,10 @@
   :args (s/cat :tx :blaze.db/tx)
   :ret string?)
 
+(s/fdef fhir-util/resource-handle
+  :args (s/cat :db :blaze.db/db :type :fhir.resource/type :id :blaze.resource/id)
+  :ret ac/completable-future?)
+
 (s/fdef fhir-util/pull
   :args (s/cat :db :blaze.db/db :type :fhir.resource/type :id :blaze.resource/id
                :variant (s/? :blaze.resource/variant))

--- a/modules/rest-util/src/blaze/handler/util.clj
+++ b/modules/rest-util/src/blaze/handler/util.clj
@@ -5,7 +5,6 @@
    [blaze.async.comp :as ac]
    [blaze.fhir.spec.type :as type]
    [blaze.http.util :as hu]
-   [blaze.luid :as luid]
    [clojure.string :as str]
    [cognitect.anomalies :as anom]
    [io.aviso.exception :as aviso]
@@ -236,9 +235,3 @@
   "A handler returning failed futures."
   (reitit.ring/create-default-handler
    {:method-not-allowed method-not-allowed-batch-handler}))
-
-(defn luid
-  "Creates an LUID from :clock :rng-fn in `context`."
-  {:arglists '([context])}
-  [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))

--- a/modules/rest-util/src/blaze/handler/util_spec.clj
+++ b/modules/rest-util/src/blaze/handler/util_spec.clj
@@ -2,8 +2,6 @@
   (:require
    [blaze.anomaly-spec]
    [blaze.handler.util :as handler-util]
-   [blaze.luid.spec]
-   [blaze.spec]
    [clojure.spec.alpha :as s]))
 
 (s/fdef handler-util/preference
@@ -13,7 +11,3 @@
 (s/fdef handler-util/error-response
   :args (s/cat :error some?)
   :ret map?)
-
-(s/fdef handler-util/luid
-  :args (s/cat :context (s/keys :req-un [:blaze/clock :blaze/rng-fn]))
-  :ret :blaze/luid)

--- a/modules/rest-util/src/blaze/interaction/search/util.clj
+++ b/modules/rest-util/src/blaze/interaction/search/util.clj
@@ -9,6 +9,7 @@
   #fhir/BundleEntrySearch{:mode #fhir/code"include"})
 
 (defn entry
+  {:arglists '([context resource] [context resource mode])}
   ([context resource]
    (entry context resource match))
   ([context {:fhir/keys [type] :keys [id] :as resource} mode]

--- a/modules/rest-util/src/blaze/interaction/search/util_spec.clj
+++ b/modules/rest-util/src/blaze/interaction/search/util_spec.clj
@@ -9,5 +9,5 @@
 
 (s/fdef search-util/entry
   :args (s/cat :context (s/keys :req [:blaze/base-url ::reitit/router])
-               :resource :blaze/resource
+               :resource :fhir/Resource
                :mode (s/? map?)))

--- a/modules/rest-util/test/blaze/handler/util_test.clj
+++ b/modules/rest-util/test/blaze/handler/util_test.clj
@@ -5,16 +5,11 @@
    [blaze.luid.spec]
    [blaze.module.test-util :refer [given-failed-future]]
    [blaze.test-util :as tu]
-   [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]
-   [clojure.test :as test :refer [are deftest is testing]]
+   [clojure.test :as test :refer [are deftest testing]]
    [cognitect.anomalies :as anom]
-   [java-time.api :as time]
-   [juxt.iota :refer [given]])
-  (:import
-   [java.util.concurrent ThreadLocalRandom]))
+   [juxt.iota :refer [given]]))
 
-(set! *warn-on-reflection* true)
 (st/instrument)
 
 (test/use-fixtures :each tu/fixture)
@@ -175,8 +170,3 @@
     ::anom/message := "Method POST not allowed on `/Patient/0` endpoint."
     :http/status := 405
     :fhir/issue := "processing"))
-
-(deftest luid-test
-  (let [context {:clock (time/system-clock)
-                 :rng-fn #(ThreadLocalRandom/current)}]
-    (is (s/valid? :blaze/luid (handler-util/luid context)))))

--- a/modules/terminology-service/deps.edn
+++ b/modules/terminology-service/deps.edn
@@ -4,8 +4,8 @@
  {blaze/db
   {:local/root "../db"}
 
-  blaze/luid
-  {:local/root "../luid"}
+  blaze/module-base
+  {:local/root "../module-base"}
 
   org.clojure/data.csv
   {:mvn/version "1.1.0"}

--- a/modules/terminology-service/src/blaze/terminology_service/local.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local.clj
@@ -33,7 +33,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defn camel->kebab [s]
+(defn- camel->kebab [s]
   (.to CaseFormat/LOWER_CAMEL CaseFormat/LOWER_HYPHEN s))
 
 (defn- plural [s]

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/bcp_13.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/bcp_13.clj
@@ -8,7 +8,7 @@
    [blaze.coll.core :as coll]
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
-   [blaze.luid :as luid]
+   [blaze.module :as m]
    [blaze.terminology-service.local.code-system.core :as c]
    [blaze.terminology-service.local.code-system.util :as cs-u]
    [clojure.string :as str]
@@ -77,12 +77,9 @@
 (defn- bcp-13-query [db]
   (d/type-query db "CodeSystem" [["url" "urn:ietf:bcp:13"]]))
 
-(defn- luid [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))
-
 (defn- create-code-system [{:keys [node] :as context}]
   (log/debug "Create BCP-13 code system...")
-  (d/transact node [(cs-u/tx-op code-system (luid context))]))
+  (d/transact node [(cs-u/tx-op code-system (m/luid context))]))
 
 (defn ensure-code-system
   "Ensures that the BCP-13 code system is present in the database node."

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/bcp_47.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/bcp_47.clj
@@ -8,7 +8,7 @@
    [blaze.coll.core :as coll]
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
-   [blaze.luid :as luid]
+   [blaze.module :as m]
    [blaze.terminology-service.local.code-system.core :as c]
    [blaze.terminology-service.local.code-system.util :as cs-u]
    [clojure.string :as str]
@@ -87,12 +87,9 @@
 (defn- bcp-47-query [db]
   (d/type-query db "CodeSystem" [["url" "urn:ietf:bcp:47"]]))
 
-(defn- luid [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))
-
 (defn- create-code-system [{:keys [node] :as context}]
   (log/debug "Create BCP-47 code system...")
-  (d/transact node [(cs-u/tx-op code-system (luid context))]))
+  (d/transact node [(cs-u/tx-op code-system (m/luid context))]))
 
 (defn ensure-code-system
   "Ensures that the BCP-47 code system is present in the database node."

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/ucum.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/ucum.clj
@@ -5,7 +5,7 @@
    [blaze.coll.core :as coll]
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
-   [blaze.luid :as luid]
+   [blaze.module :as m]
    [blaze.terminology-service.local.code-system.core :as c]
    [blaze.terminology-service.local.code-system.util :as cs-u]
    [taoensso.timbre :as log])
@@ -71,12 +71,9 @@
 (defn- ucum-query [db]
   (d/type-query db "CodeSystem" [["url" "http://unitsofmeasure.org"]]))
 
-(defn- luid [{:keys [clock rng-fn]}]
-  (luid/luid clock (rng-fn)))
-
 (defn- create-code-system [{:keys [node] :as context}]
   (log/debug "Create UCUM code system...")
-  (d/transact node [(cs-u/tx-op code-system (luid context))]))
+  (d/transact node [(cs-u/tx-op code-system (m/luid context))]))
 
 (defn ensure-code-system
   "Ensures that the UCUM code system is present in the database node."

--- a/modules/terminology-service/test/blaze/terminology_service/local/code_system/bcp_13_test.clj
+++ b/modules/terminology-service/test/blaze/terminology_service/local/code_system/bcp_13_test.clj
@@ -3,6 +3,7 @@
    [blaze.db.api :as d]
    [blaze.db.api-stub :refer [mem-node-config]]
    [blaze.fhir.test-util]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.terminology-service.local.code-system.bcp-13 :as bcp-13]
    [blaze.test-util :as tu]

--- a/modules/terminology-service/test/blaze/terminology_service/local/code_system/bcp_47_test.clj
+++ b/modules/terminology-service/test/blaze/terminology_service/local/code_system/bcp_47_test.clj
@@ -3,6 +3,7 @@
    [blaze.db.api :as d]
    [blaze.db.api-stub :refer [mem-node-config]]
    [blaze.fhir.test-util]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.terminology-service.local.code-system.bcp-47 :as bcp-47]
    [blaze.test-util :as tu]

--- a/modules/terminology-service/test/blaze/terminology_service/local/code_system/ucum_test.clj
+++ b/modules/terminology-service/test/blaze/terminology_service/local/code_system/ucum_test.clj
@@ -3,6 +3,7 @@
    [blaze.db.api :as d]
    [blaze.db.api-stub :refer [mem-node-config]]
    [blaze.fhir.test-util]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.terminology-service.local.code-system.ucum :as ucum]
    [blaze.test-util :as tu]


### PR DESCRIPTION
Moved the luid function taking a context into blaze.module namespace because it existed multiple times for each component that needed it.

Also renamed the spec :blaze/resource into :fhir/Resource to be inline with other FHIR specs.