### PR TITLE
Remove Clojure 1.11 for Test Coverage

### DIFF
--- a/modules/byte-string/deps.edn
+++ b/modules/byte-string/deps.edn
@@ -30,10 +30,6 @@
   :coverage
   {:extra-deps
    {lambdaisland/kaocha-cloverage
-    {:mvn/version "1.1.89"}
-
-    ;; TODO: remove after Cloverage reflection problems are solved. https://github.com/cloverage/cloverage/issues/345
-    org.clojure/clojure
-    {:mvn/version "1.11.4"}}
+    {:mvn/version "1.1.89"}}
 
    :main-opts ["-m" "kaocha.runner" "--profile" "coverage"]}}}

--- a/modules/byte-string/src/blaze/byte_string.clj
+++ b/modules/byte-string/src/blaze/byte_string.clj
@@ -9,7 +9,8 @@
    [com.google.protobuf ByteString]
    [java.io Writer]
    [java.nio ByteBuffer]
-   [java.nio.charset StandardCharsets]))
+   [java.nio.charset StandardCharsets]
+   [java.util Comparator]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -107,16 +108,16 @@
   (.concat ^ByteString a b))
 
 (defn < [a b]
-  (neg? (.compare (ByteString/unsignedLexicographicalComparator) a b)))
+  (neg? (.compare ^Comparator (ByteString/unsignedLexicographicalComparator) a b)))
 
 (defn <=
   ([a b]
-   (clojure.core/<= (.compare (ByteString/unsignedLexicographicalComparator) a b) 0))
+   (clojure.core/<= (.compare ^Comparator (ByteString/unsignedLexicographicalComparator) a b) 0))
   ([a b c]
    (and (<= a b) (<= b c))))
 
 (defn > [a b]
-  (pos? (.compare (ByteString/unsignedLexicographicalComparator) a b)))
+  (pos? (.compare ^Comparator (ByteString/unsignedLexicographicalComparator) a b)))
 
 (defn hex
   "Returns an upper-case hexadecimal string representation of `bs`."

--- a/modules/db/deps.edn
+++ b/modules/db/deps.edn
@@ -88,10 +88,6 @@
   :coverage
   {:extra-deps
    {lambdaisland/kaocha-cloverage
-    {:mvn/version "1.1.89"}
-
-    ;; TODO: remove after Cloverage reflection problems are solved. https://github.com/cloverage/cloverage/issues/345
-    org.clojure/clojure
-    {:mvn/version "1.11.4"}}
+    {:mvn/version "1.1.89"}}
 
    :main-opts ["-m" "kaocha.runner" "--profile" "coverage"]}}}

--- a/modules/db/src/blaze/db/impl/codec.clj
+++ b/modules/db/src/blaze/db/impl/codec.clj
@@ -5,7 +5,7 @@
    [blaze.fhir.spec.type.system])
   (:import
    [com.github.benmanes.caffeine.cache CacheLoader Caffeine]
-   [com.google.common.hash Hashing]
+   [com.google.common.hash HashFunction Hashing]
    [java.nio.charset StandardCharsets]
    [java.util Arrays]))
 
@@ -39,8 +39,8 @@
   Returns an integer."
   (memoize-1
    (fn [type]
-     (-> (Hashing/murmur3_32_fixed)
-         (.hashBytes (.getBytes ^String type StandardCharsets/ISO_8859_1))
+     (-> (.hashBytes ^HashFunction (Hashing/murmur3_32_fixed)
+                     (.getBytes ^String type StandardCharsets/ISO_8859_1))
          (.asInt)))))
 
 (let [kvs [[-2146857976 "ClinicalImpression"]
@@ -239,8 +239,8 @@
   (bit-and (bit-not (unchecked-long l)) 0xFFFFFFFFFFFFFF))
 
 (defn c-hash [code]
-  (-> (Hashing/murmur3_32_fixed)
-      (.hashString code StandardCharsets/UTF_8)
+  (-> (.hashString ^HashFunction (Hashing/murmur3_32_fixed) code
+                   StandardCharsets/UTF_8)
       (.asInt)))
 
 (def c-hash->code
@@ -286,8 +286,8 @@
     "version"]))
 
 (defn v-hash [value]
-  (-> (Hashing/murmur3_32_fixed)
-      (.hashString value StandardCharsets/UTF_8)
+  (-> (.hashString ^HashFunction (Hashing/murmur3_32_fixed) value
+                   StandardCharsets/UTF_8)
       (.asBytes)
       bs/from-byte-array))
 

--- a/modules/page-store/deps.edn
+++ b/modules/page-store/deps.edn
@@ -26,10 +26,6 @@
   :coverage
   {:extra-deps
    {lambdaisland/kaocha-cloverage
-    {:mvn/version "1.1.89"}
-
-    ;; TODO: remove after Cloverage reflection problems are solved. https://github.com/cloverage/cloverage/issues/345
-    org.clojure/clojure
-    {:mvn/version "1.11.4"}}
+    {:mvn/version "1.1.89"}}
 
    :main-opts ["-m" "kaocha.runner" "--profile" "coverage"]}}}

--- a/modules/page-store/src/blaze/page_store/local/hash.clj
+++ b/modules/page-store/src/blaze/page_store/local/hash.clj
@@ -1,6 +1,6 @@
 (ns blaze.page-store.local.hash
   (:import
-   [com.google.common.hash HashCode Hashing]
+   [com.google.common.hash HashCode Hasher Hashing]
    [com.google.common.io BaseEncoding]
    [java.nio.charset StandardCharsets]))
 
@@ -10,14 +10,14 @@
   "Calculates a SHA256 hash of `clause`."
   [clause]
   (let [hasher (.newHasher (Hashing/sha256))]
-    (run! #(.putString hasher (str %) StandardCharsets/UTF_8) clause)
+    (run! #(.putString ^Hasher hasher (str %) StandardCharsets/UTF_8) clause)
     (.hash hasher)))
 
 (defn hash-hashes
   "Calculates a SHA256 hash of `hashes`."
   [hashes]
   (let [hasher (.newHasher (Hashing/sha256))]
-    (run! #(.putBytes hasher (.asBytes ^HashCode %)) hashes)
+    (run! #(.putBytes ^Hasher hasher (.asBytes ^HashCode %)) hashes)
     (.hash hasher)))
 
 (defn encode


### PR DESCRIPTION
I found a way to just add type hints in order to not need the new Cloverage version that fixes
https://github.com/cloverage/cloverage/issues/345. That type hints can be removed in the future if Cloverage gets updated.