### PR TITLE
Fix Key Shape of Terminology Service Graph Cache

### DIFF
--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/default.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/default.clj
@@ -37,7 +37,7 @@
 
 (defn- get-graph
   [cache {:keys [id] {version :versionId} :meta :as code-system}]
-  (let [key (str id (type/value version))]
+  (let [key [id (type/value version)]]
     (.get ^Cache cache key (fn [_] (graph/build-graph (:concept code-system))))))
 
 (defmethod c/find :default


### PR DESCRIPTION
The key can't be a string concatenated from id and meta.versionId (t) because the chars allowed in t are also valid in the id. So for example the id `A12` and t `3` would yield the same key as the id `A1` and the t `23`.

We could use a separator like `|` but just using a vector is simpler.