### PR TITLE
Improve JSON Serialization Performance

### DIFF
--- a/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/impl.clj
@@ -333,7 +333,7 @@
   {:arglists '([element])}
   [{:keys [attrs content]}]
   (transduce
-    ;; remove mixed character content
+   ;; remove mixed character content
    (filter xml/element?)
    (completing
     (fn [ret {:keys [tag] :as element}]

--- a/modules/fhir-structure/src/blaze/fhir/spec/resource.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/resource.clj
@@ -23,7 +23,7 @@
    [blaze.fhir.spec.type.string-util :as su]
    [blaze.fhir.spec.type.system :as system]
    [blaze.fhir.util :as fu]
-   [blaze.util :refer [conj-vec str]]
+   [blaze.util :as u :refer [str]]
    [clojure.string :as str]
    [cognitect.anomalies :as anom])
   (:import
@@ -690,7 +690,7 @@
             (fn [resource]
               (-> (assoc! resource :fhir/type (fhir-type-keyword type))
                   (persistent!)
-                  (update :meta update-meta :tag conj-vec fu/subsetted)))
+                  (update :meta update-meta :tag u/conj-vec fu/subsetted)))
             #(persistent! (assoc! % :fhir/type (fhir-type-keyword type))))]
       (condp = kind
         :resource

--- a/modules/fhir-structure/src/blaze/fhir/spec/type.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type.clj
@@ -917,7 +917,7 @@
   (-assoc-value [_ value] (create-date-time value))
   (-has-primary-content [_] true)
   (-serialize-json [date-time generator]
-    (.writeString ^JsonGenerator generator ^String (system/-to-string date-time)))
+    (.writeString ^JsonGenerator generator (.format DateTimeFormatter/ISO_DATE_TIME date-time)))
   (-has-secondary-content [_] false)
   (-serialize-json-secondary [_ generator]
     (.writeNull ^JsonGenerator generator))
@@ -940,7 +940,7 @@
   (-assoc-value [_ value] (create-date-time value))
   (-has-primary-content [_] true)
   (-serialize-json [date-time generator]
-    (.writeString ^JsonGenerator generator ^String (system/-to-string date-time)))
+    (.writeString ^JsonGenerator generator (.format DateTimeFormatter/ISO_LOCAL_DATE_TIME date-time)))
   (-has-secondary-content [_] false)
   (-serialize-json-secondary [_ generator]
     (.writeNull ^JsonGenerator generator))
@@ -1333,7 +1333,16 @@
 
 (declare extension)
 
-(def-complex-type Extension [^String id extension ^String url ^:polymorph ^:primitive value]
+(def-complex-type Extension
+  [^String id extension ^String url ^:polymorph ^:primitive
+   ^{:types [base64Binary boolean canonical code date dateTime decimal id
+             instant integer markdown oid positiveInt string time unsignedInt
+             uri url uuid Address Age Annotation Attachment CodeableConcept
+             Coding ContactPoint Count Distance Duration HumanName Identifier
+             Money Period Quantity Range Ratio Reference SampledData Signature
+             Timing ContactDetail Contributor DataRequirement Expression
+             ParameterDefinition RelatedArtifact TriggerDefinition UsageContext
+             Dosage Meta]} value]
   :hash-num 39
   :interned (and (nil? id) (p/-interned extension) (p/-interned value)))
 

--- a/modules/fhir-structure/src/blaze/fhir/spec/type/string_util.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/type/string_util.clj
@@ -8,8 +8,12 @@
 
 (set! *warn-on-reflection* true)
 
-(defn capital [s]
-  (str (str/upper-case (subs s 0 1)) (subs s 1)))
+(defn capital
+  "Converts the first character of `s` into upper case."
+  [s]
+  (if (or (empty? s) (Character/isUpperCase ^char (.charAt ^String s 0)))
+    s
+    (str (str/upper-case (subs s 0 1)) (subs s 1))))
 
 (defn pascal->kebab [s]
   (.to CaseFormat/UPPER_CAMEL CaseFormat/LOWER_HYPHEN s))

--- a/modules/fhir-structure/src/blaze/fhir/spec_spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec_spec.clj
@@ -17,6 +17,10 @@
   (s/spec (s/cat :op #(= `s2/or %)
                  :choices (s/* (s/cat :key keyword? :spec some?)))))
 
+(s/fdef fhir-spec/fhir-type
+  :args (s/cat :x any?)
+  :ret (s/nilable :fhir/type))
+
 (s/fdef fhir-spec/primitive?
   :args (s/cat :spec any?)
   :ret boolean?)
@@ -56,7 +60,3 @@
 
 (s/fdef fhir-spec/unform-xml
   :args (s/cat :resource any?))
-
-(s/fdef fhir-spec/fhir-type
-  :args (s/cat :x any?)
-  :ret (s/nilable :fhir/type))

--- a/modules/fhir-structure/test/blaze/fhir/spec/references_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/references_test.clj
@@ -21,7 +21,9 @@
 
   (testing "invalid refs"
     (are [ref] (nil? (fsr/split-literal-ref ref))
-      "http://localhost:8080/fhir/Patient/0"))
+      "http://localhost:8080/fhir/Patient/0"
+      "patient/0"
+      "Patient/_"))
 
   (testing "works on arbitrary strings"
     (satisfies-prop 10000

--- a/modules/fhir-structure/test/blaze/fhir/spec/type/string_util_spec.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type/string_util_spec.clj
@@ -1,0 +1,12 @@
+(ns blaze.fhir.spec.type.string-util-spec
+  (:require
+   [blaze.fhir.spec.type.string-util :as su]
+   [clojure.spec.alpha :as s]))
+
+(s/fdef su/capital
+  :args (s/cat :s string?)
+  :ret string?)
+
+(s/fdef su/pascal->kebab
+  :args (s/cat :s string?)
+  :ret string?)

--- a/modules/fhir-structure/test/blaze/fhir/spec/type/string_util_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/type/string_util_test.clj
@@ -1,0 +1,16 @@
+(ns blaze.fhir.spec.type.string-util-test
+  (:require
+   [blaze.fhir.spec.type.string-util :as su]
+   [blaze.fhir.spec.type.string-util-spec]
+   [clojure.test :refer [are deftest is]]))
+
+(deftest capital-test
+  (are [s c] (= c (su/capital s))
+    "" ""
+    "ab" "Ab"
+    "aB" "AB"
+    "Ab" "Ab"
+    "AB" "AB"))
+
+(deftest pascal->kebab-test
+  (is (= "ab-cd" (su/pascal->kebab "AbCd"))))


### PR DESCRIPTION
The commit contains the following optimizations:

* pre-calculate polymorphic field names
* use a PropertyHandler class instead of a map to speed up lookup of contained data
* use of run! instead of a loop because we have to call a function anyway and value is a vector which implements fast reduce