### PR TITLE
Separate Slow DB Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,8 +186,63 @@ jobs:
         name: coverage-report-${{ matrix.module }}
         path: modules/${{ matrix.module }}/target/coverage/codecov.json
 
+  test-slow:
+    strategy:
+      matrix:
+        module:
+        - db
+
+        java-version:
+        - '17'
+        - '21'
+
+    needs: job-ig
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Setup Java
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java-version }}
+
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08 # 13.4
+      with:
+        cli: '1.12.0.1479'
+
+    - name: Check out Git repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+    - name: Cache Local Maven Repo
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-temurin-${{ matrix.java-version }}-maven-${{ matrix.module }}-${{ hashFiles(format('modules/{0}/deps.edn', matrix.module)) }}
+
+    - name: Cache Clojure GitLibs
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: ~/.gitlibs
+        key: ${{ runner.os }}-gitlibs-${{ matrix.module }}-${{ hashFiles(format('modules/{0}/deps.edn', matrix.module)) }}
+
+    - name: Download Job IG Profiles
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: job-ig-profiles
+        path: job-ig/fsh-generated/resources
+
+    - name: Test
+      run: make -C modules/${{ matrix.module }} test-slow
+
   # Special treatment, because it runs much longer as the other modules.
   test-coverage-db:
+    strategy:
+      matrix:
+        kind:
+        - 'normal'
+        - 'slow'
+
     needs: job-ig
     runs-on: ubuntu-24.04
 
@@ -225,12 +280,17 @@ jobs:
         path: job-ig/fsh-generated/resources
 
     - name: Test Coverage
+      if: ${{ matrix.kind == 'normal' }}
       run: make -C modules/db test-coverage
+
+    - name: Test Coverage Slow
+      if: ${{ matrix.kind == 'slow' }}
+      run: make -C modules/db test-coverage-slow
 
     - name: Upload Coverage Report
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: coverage-report-db
+        name: coverage-report-db-${{ matrix.kind }}
         path: modules/db/target/coverage/codecov.json
 
   test-root:
@@ -2355,6 +2415,7 @@ jobs:
     - fmt
     - lint
     - test
+    - test-slow
     - test-root
     - image-scan
     - cql-expr-cache-test

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -11,10 +11,16 @@ prep: build
 	clojure -X:deps prep
 
 test: prep
-	clojure -M:test:kaocha --profile :ci
+	clojure -M:test:kaocha --profile :ci --skip-meta :slow
+
+test-slow: prep
+	clojure -M:test:kaocha --profile :ci --focus-meta :slow
 
 test-coverage: prep
-	clojure -M:test:coverage
+	clojure -M:test:coverage --skip-meta :slow
+
+test-coverage-slow: prep
+	clojure -M:test:coverage --focus-meta :slow
 
 deps-tree:
 	clojure -X:deps tree

--- a/modules/db/test/blaze/db/api_test.clj
+++ b/modules/db/test/blaze/db/api_test.clj
@@ -5510,7 +5510,7 @@
      :period (fg/period :extension (gen/return nil)
                         :start date-time :end date-time))))
 
-(deftest type-query-date-encounter-eq-sa-eb-test
+(deftest ^:slow type-query-date-encounter-eq-sa-eb-test
   (satisfies-prop 100
     (prop/for-all [year (gen/choose 1999 2001)
                    tx-ops (create-tx encounter-gen 10)]
@@ -5523,7 +5523,7 @@
              (num-encounter [["date" (format "sa%d-12-31" (dec year))]
                              ["date" (format "eb%d-01-01" (inc year))]])))))))
 
-(deftest type-query-date-encounter-ap-gt-lt-test
+(deftest ^:slow type-query-date-encounter-ap-gt-lt-test
   (satisfies-prop 100
     (prop/for-all [year (gen/choose 1999 2001)
                    tx-ops (create-tx encounter-gen 10)]
@@ -5672,7 +5672,7 @@
    :encounter (gen/return nil)
    :value (gen/return nil)))
 
-(deftest type-query-date-equal-generative-test
+(deftest ^:slow type-query-date-equal-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5680,7 +5680,7 @@
         [tx-ops]
         (every-found-observation-matches? equal node "" date-time)))))
 
-(deftest type-query-date-not-equal-generative-test
+(deftest ^:slow type-query-date-not-equal-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5688,7 +5688,7 @@
         [tx-ops]
         (every-found-observation-matches? not-equal node "ne" date-time)))))
 
-(deftest type-query-date-greater-than-generative-test
+(deftest ^:slow type-query-date-greater-than-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5696,7 +5696,7 @@
         [tx-ops]
         (every-found-observation-matches? greater-than node "gt" date-time)))))
 
-(deftest type-query-date-less-than-generative-test
+(deftest ^:slow type-query-date-less-than-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5704,7 +5704,7 @@
         [tx-ops]
         (every-found-observation-matches? less-than node "lt" date-time)))))
 
-(deftest type-query-date-greater-equal-generative-test
+(deftest ^:slow type-query-date-greater-equal-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5712,7 +5712,7 @@
         [tx-ops]
         (every-found-observation-matches? greater-equal node "ge" date-time)))))
 
-(deftest type-query-date-less-equal-generative-test
+(deftest ^:slow type-query-date-less-equal-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5720,7 +5720,7 @@
         [tx-ops]
         (every-found-observation-matches? less-equal node "le" date-time)))))
 
-(deftest type-query-date-starts-after-generative-test
+(deftest ^:slow type-query-date-starts-after-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5728,7 +5728,7 @@
         [tx-ops]
         (every-found-observation-matches? starts-after node "sa" date-time)))))
 
-(deftest type-query-date-ends-before-generative-test
+(deftest ^:slow type-query-date-ends-before-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -5736,7 +5736,7 @@
         [tx-ops]
         (every-found-observation-matches? ends-before node "eb" date-time)))))
 
-(deftest type-query-date-approximately-generative-test
+(deftest ^:slow type-query-date-approximately-generative-test
   (satisfies-prop num-date-tests
     (prop/for-all [date-time (fg/dateTime-value)
                    tx-ops (create-tx observation-gen num-date-tests)]
@@ -6321,7 +6321,7 @@
                    node "Patient" [[:sort "_lastUpdated" :asc]])]
         (is (= [[:sort "_lastUpdated" :asc]] (d/query-clauses query)))))))
 
-(deftest count-query-test
+(deftest ^:slow count-query-test
   (testing "different sizes"
     (satisfies-prop 25
       (prop/for-all [n (gen/large-integer* {:min 1 :max 10000})]
@@ -8210,7 +8210,7 @@
 (defn- condition-create-op [id]
   [:create {:fhir/type :fhir/Condition :id (format "%05d" id)}])
 
-(deftest re-index-test
+(deftest ^:slow re-index-test
   (testing "unknown search param"
     (with-system [{:blaze.db/keys [node]} config]
       (given (d/re-index-total (d/db node) "unknown")


### PR DESCRIPTION
Separate slow DB tests so that they can run in parallel to the other DB tests.