### PR TITLE
Move luid-generator into module-base

### DIFF
--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -76,7 +76,7 @@
         (when-ok [entries (validate-entries entries)]
           (-> (reduce
                prepare-entry
-               {::luid/generator (iu/luid-generator context) :entries []}
+               {::luid/generator (m/luid-generator context) :entries []}
                entries)
               :entries))
         entries))))

--- a/modules/interaction/src/blaze/interaction/util.clj
+++ b/modules/interaction/src/blaze/interaction/util.clj
@@ -6,7 +6,6 @@
    [blaze.fhir.hash :as hash]
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
-   [blaze.luid :as luid]
    [blaze.util :as u]
    [clojure.string :as str]
    [ring.util.response :as ring]))
@@ -56,9 +55,6 @@
 
 (defn search-clauses [query-params]
   (into [] query-params->clauses-xf query-params))
-
-(defn luid-generator [{:keys [clock rng-fn]}]
-  (luid/generator clock (rng-fn)))
 
 (defn- prep-if-none-match [if-none-match]
   (if (= "*" if-none-match)

--- a/modules/module-base/src/blaze/module.clj
+++ b/modules/module-base/src/blaze/module.clj
@@ -10,6 +10,11 @@
   [{:keys [clock rng-fn]}]
   (luid/luid clock (rng-fn)))
 
+(defn luid-generator
+  {:arglists '([context])}
+  [{:keys [clock rng-fn]}]
+  (luid/generator clock (rng-fn)))
+
 (defmacro reg-collector
   "Registers a metrics collector to the central registry."
   [key collector]

--- a/modules/module-base/src/blaze/module_spec.clj
+++ b/modules/module-base/src/blaze/module_spec.clj
@@ -8,3 +8,7 @@
 (s/fdef m/luid
   :args (s/cat :context (s/keys :req-un [:blaze/clock :blaze/rng-fn]))
   :ret :blaze/luid)
+
+(s/fdef m/luid-generator
+  :args (s/cat :context (s/keys :req-un [:blaze/clock :blaze/rng-fn]))
+  :ret :blaze.luid/generator)

--- a/modules/module-base/test/blaze/module_test.clj
+++ b/modules/module-base/test/blaze/module_test.clj
@@ -1,5 +1,6 @@
 (ns blaze.module-test
   (:require
+   [blaze.luid :as luid]
    [blaze.module :as m :refer [reg-collector]]
    [blaze.module-spec]
    [blaze.test-util :as tu :refer [given-thrown]]
@@ -22,6 +23,11 @@
   (let [context {:clock (time/system-clock)
                  :rng-fn #(ThreadLocalRandom/current)}]
     (is (s/valid? :blaze/luid (m/luid context)))))
+
+(deftest luid-generator-test
+  (let [context {:clock (time/system-clock)
+                 :rng-fn #(ThreadLocalRandom/current)}]
+    (is (s/valid? :blaze/luid (luid/head (m/luid-generator context))))))
 
 (defcounter collector
   "Collector")

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -18,6 +18,7 @@
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.luid :as luid]
+   [blaze.module :as m]
    [blaze.util :refer [str]]
    [clojure.spec.alpha :as s]
    [java-time.api :as time]
@@ -378,9 +379,6 @@
     (seq result)
     (assoc :group result)))
 
-(defn- luid-generator [{:keys [clock rng-fn]}]
-  (luid/generator clock (rng-fn)))
-
 (defn- missing-subject-msg [type id]
   (format "Subject with type `%s` and id `%s` was not found." type id))
 
@@ -450,7 +448,7 @@
                 :parameters parameter-default-values
                 :subject-type subject-type
                 :report-type report-type
-                ::luid/generator (luid-generator context))
+                ::luid/generator (m/luid-generator context))
                 function-defs
                 (assoc :function-defs function-defs))]
           (when-ok [expression-defs (library/eval-unfiltered context expression-defs)

--- a/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_spec.clj
+++ b/modules/operation-measure-evaluate-measure/test/blaze/fhir/operation/evaluate_measure/measure_spec.clj
@@ -11,6 +11,7 @@
    [blaze.fhir.operation.evaluate-measure.measure.spec]
    [blaze.fhir.spec]
    [blaze.http.spec]
+   [blaze.module-spec]
    [blaze.spec]
    [clojure.spec.alpha :as s]
    [reitit.core :as reitit])

--- a/modules/rest-api/src/blaze/rest_api/structure_definitions.clj
+++ b/modules/rest-api/src/blaze/rest_api/structure_definitions.clj
@@ -8,6 +8,7 @@
    [blaze.fhir.spec.type :as type]
    [blaze.fhir.structure-definition-repo :as sdr]
    [blaze.luid :as luid]
+   [blaze.module :as m]
    [clojure.string :as str]
    [jsonista.core :as j]
    [taoensso.timbre :as log]))
@@ -27,9 +28,6 @@
   (do-sync [structure-definitions (structure-definitions db)]
     (into #{} (comp (map (comp type/value :url)) url-filter) structure-definitions)))
 
-(defn- luid-generator [{:keys [clock rng-fn]}]
-  (luid/generator clock (rng-fn)))
-
 (defn- tx-op [{:keys [url] :as structure-definition} luid-generator]
   [:create (assoc structure-definition :id (luid/head luid-generator))
    [["url" (type/value url)]]])
@@ -43,7 +41,7 @@
       (-> (update ret :tx-ops conj (tx-op structure-definition luid-generator))
           (update :luid-generator luid/next))))
    {:tx-ops []
-    :luid-generator (luid-generator context)}
+    :luid-generator (m/luid-generator context)}
    structure-definitions))
 
 (defn- conform [parsing-context resource]

--- a/modules/rest-api/test/blaze/rest_api/structure_definitions_test.clj
+++ b/modules/rest-api/test/blaze/rest_api/structure_definitions_test.clj
@@ -4,6 +4,7 @@
    [blaze.db.api-stub :refer [mem-node-config]]
    [blaze.fhir.parsing-context]
    [blaze.fhir.test-util :refer [structure-definition-repo]]
+   [blaze.module-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.rest-api.structure-definitions :as structure-definitions]
    [blaze.test-util :as tu]

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/util.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/util.clj
@@ -3,7 +3,8 @@
    [blaze.async.comp :refer [do-sync]]
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
-   [blaze.luid :as luid]))
+   [blaze.luid :as luid]
+   [blaze.module :as m]))
 
 (defn code-systems [db url]
   (d/pull-many db (d/type-query db "CodeSystem" [["url" url]])))
@@ -11,9 +12,6 @@
 (defn code-system-versions [db url]
   (do-sync [code-systems (code-systems db url)]
     (into #{} (map (comp type/value :version)) code-systems)))
-
-(defn- luid-generator [{:keys [clock rng-fn]}]
-  (luid/generator clock (rng-fn)))
 
 (defn tx-op [{:keys [url version] :as code-system} id]
   [:create (assoc code-system :id id)
@@ -29,5 +27,5 @@
       (-> (update ret :tx-ops conj (tx-op code-system (luid/head luid-generator)))
           (update :luid-generator luid/next))))
    {:tx-ops []
-    :luid-generator (luid-generator context)}
+    :luid-generator (m/luid-generator context)}
    code-systems))


### PR DESCRIPTION
It's used in interaction, operation-measure-evaluate-measure, rest-api and terminology-service.