### PR TITLE
Exclude Artefact si.uom/si-quantity

### DIFF
--- a/modules/cql/deps.edn
+++ b/modules/cql/deps.edn
@@ -42,7 +42,8 @@
   {:mvn/version "2.2"}
 
   systems.uom/systems-ucum
-  {:mvn/version "2.2"}}
+  {:mvn/version "2.2"
+   :exclusions [si.uom/si-quantity]}}
 
  :aliases
  {:test


### PR DESCRIPTION
I have to exclude the artefact si.uom/si-quantity because it's classes are already contained in si.uom/si-units.

See: https://github.com/unitsofmeasurement/uom-systems/issues/206