### PR TITLE
Fix Paths in CodeCov Files

### DIFF
--- a/.github/scripts/fix-codecov-path.sh
+++ b/.github/scripts/fix-codecov-path.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+#
+# Adds module path prefix to the paths in codecov.json files.
+#
+
+MODULE="$1"
+FILE="modules/$MODULE/target/coverage/codecov.json"
+
+jq --arg prefix "modules/$MODULE/src/" '.coverage |= with_entries(.key = $prefix + .key)' "$FILE" > "$FILE.fix"
+mv "$FILE.fix" "$FILE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,10 @@ jobs:
       if: ${{ matrix.java-version == '21' && matrix.module != 'db' && matrix.module != 'jepsen' }}
       run: make -C modules/${{ matrix.module }} test-coverage
 
+    - name: Fix Codecov Path
+      if: ${{ matrix.java-version == '21' && matrix.module != 'db' && matrix.module != 'jepsen' }}
+      run: .github/scripts/fix-codecov-path.sh ${{ matrix.module }}
+
     - name: Upload Coverage Report
       if: ${{ matrix.java-version == '21' && matrix.module != 'db' && matrix.module != 'jepsen' }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -289,6 +293,9 @@ jobs:
     - name: Test Coverage Slow
       if: ${{ matrix.kind == 'slow' }}
       run: make -C modules/db test-coverage-slow
+
+    - name: Fix Codecov Path
+      run: .github/scripts/fix-codecov-path.sh db
 
     - name: Upload Coverage Report
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
Added the module prefix to match the repository structure. Before path were module relative.