### PR TITLE
Fix Multiple Patient FHIR Search Integration Test

### DIFF
--- a/.github/scripts/patient-ids.sh
+++ b/.github/scripts/patient-ids.sh
@@ -7,4 +7,4 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 BASE="http://localhost:8080/fhir"
 PATIENT_IDENTIFIERS="${1//[[:space:]]/}"
-curl -s "$BASE/Patient?identifier=$PATIENT_IDENTIFIERS" | jq -r '.entry[].resource.id' | paste -sd, -
+curl -s "$BASE/Patient?identifier=$PATIENT_IDENTIFIERS&_count=1000" | jq -r '.entry[].resource.id' | paste -sd, -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1390,7 +1390,7 @@ jobs:
           999-84-6431,999-53-9409,999-57-9047,999-98-1131,999-23-9506,999-79-6781,
           999-10-3828,999-31-2101,999-42-5310,999-46-3927,999-68-3132,999-45-8011,
           999-11-7186,999-58-3121,999-48-7111,999-24-3722
-      run: .github/scripts/download-resources-query.sh Condition "code=$SNOMED_CODES&patient=$(.github/scripts/patient-ids.sh "$PATIENT_SSNS")" 144
+      run: .github/scripts/download-resources-query.sh Condition "code=$SNOMED_CODES&patient=$(.github/scripts/patient-ids.sh "$PATIENT_SSNS")" 281
 
     - name: Download Vital Sign Resources
       run: .github/scripts/download-resources-query.sh Observation "category=vital-signs" 152877


### PR DESCRIPTION
The script `.github/scripts/patient-ids.sh` did only select at most 50 patients because of default max page size of 50. However it was used to determine the IDs of 100 patients.