### PR TITLE
Use a Random Page Size for Download Tests

### DIFF
--- a/.github/scripts/download-resources-query-sort.sh
+++ b/.github/scripts/download-resources-query-sort.sh
@@ -7,7 +7,7 @@ SORT=$3
 EXPECTED_SIZE=$4
 FILE_NAME_PREFIX="$(uuidgen)"
 
-blazectl --server "$BASE" download "$TYPE" -q "_sort=$SORT&$QUERY" -o "$FILE_NAME_PREFIX-get.ndjson"
+blazectl --server "$BASE" download "$TYPE" -q "_sort=$SORT&$QUERY&_count=$(shuf -i 50-500 -n 1)" -o "$FILE_NAME_PREFIX-get.ndjson"
 
 SIZE=$(wc -l "$FILE_NAME_PREFIX-get.ndjson" | xargs | cut -d ' ' -f1)
 if [ "$EXPECTED_SIZE" = "$SIZE" ]; then

--- a/.github/scripts/download-resources-query.sh
+++ b/.github/scripts/download-resources-query.sh
@@ -20,7 +20,7 @@ total_count() {
 test "_summary=count count" "$(summary_count)" "$EXPECTED_SIZE"
 test "_total=accurate count" "$(total_count)" "$EXPECTED_SIZE"
 
-blazectl --server "$BASE" download "$TYPE" -q "$QUERY" -o "$FILE_NAME_PREFIX-get.ndjson" 2> /dev/null
+blazectl --server "$BASE" download "$TYPE" -q "$QUERY&_count=$(shuf -i 50-500 -n 1)" -o "$FILE_NAME_PREFIX-get.ndjson" 2> /dev/null
 
 SIZE=$(wc -l "$FILE_NAME_PREFIX-get.ndjson" | xargs | cut -d ' ' -f1)
 if [ "$EXPECTED_SIZE" = "$SIZE" ]; then


### PR DESCRIPTION
Using a random page size further ensures that paging delivers the same results even with varying page sizes. The random page size is only used at the GET version of the download command, leaving the POST version with the default page size as reference.