### PR TITLE
Ignore cql.hl7.org Certificate

### DIFF
--- a/modules/cql/Makefile
+++ b/modules/cql/Makefile
@@ -8,7 +8,9 @@ prep:
 	clojure -X:deps prep
 
 cql-test:
-	wget https://cql.hl7.org/tests.zip
+    # Please remove --no-check-certificate if the certificate is ok gain.
+    # We can do that because the check the SHA256 of the ZIP file.
+	wget --no-check-certificate https://cql.hl7.org/tests.zip
 	echo "0d48a7441c43b6ee46e71d73decfa0cf4ea81e2ce70951f20e9163c3bebfc49a  tests.zip" | sha256sum --check --status
 	unzip -jd cql-test tests.zip
 	rm tests.zip


### PR DESCRIPTION
It is expired again. I had the same situation end of 2023. I notified the right people. We can ignore the certificate, because we check the SHA26 of the downloaded ZIP file.