### PR TITLE
Fix Next Link Detection

### DIFF
--- a/modules/fhir-client/src/blaze/fhir_client/impl.clj
+++ b/modules/fhir-client/src/blaze/fhir_client/impl.clj
@@ -150,7 +150,7 @@
    handle-error))
 
 (defn- next-url [page]
-  (type/value (:url (first (filter (comp #{"next"} :relation) (:link page))))))
+  (type/value (:url (first (filter (comp #{"next"} type/value :relation) (:link page))))))
 
 (deftype PagingSubscription
          [^Flow$Subscriber subscriber volatile-uri opts]


### PR DESCRIPTION
In R5 the link relation in a bundle is a code instead of a string like in R4. Because a string without extensions is just a string itself, calling type/value isn't needed. But in R5 we need to call type/value because a code isn't a string.

Also fixed reflection warnings in test.