### PR TITLE
Extract Bundle Link Creation into a Function

### DIFF
--- a/modules/admin-api/test/blaze/admin_api_test.clj
+++ b/modules/admin-api/test/blaze/admin_api_test.clj
@@ -22,6 +22,7 @@
    [blaze.interaction.history.instance]
    [blaze.interaction.read]
    [blaze.interaction.search-type]
+   [blaze.interaction.search.util :as search-util]
    [blaze.job-scheduler :as js]
    [blaze.middleware.fhir.db-spec]
    [blaze.middleware.fhir.output-spec]
@@ -227,16 +228,20 @@
      :blaze.interaction/read {}
 
      :blaze.interaction.history/instance
-     {:clock (ig/ref :blaze.test/fixed-clock)
+     {::search-util/link (ig/ref ::search-util/link)
+      :clock (ig/ref :blaze.test/fixed-clock)
       :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
       :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
 
      :blaze.interaction/search-type
-     {:clock (ig/ref :blaze.test/fixed-clock)
+     {::search-util/link (ig/ref ::search-util/link)
+      :clock (ig/ref :blaze.test/fixed-clock)
       :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
       :page-store (ig/ref :blaze/page-store)
       :page-id-cipher (ig/ref :blaze.test/page-id-cipher)
       :context-path "/fhir"}
+
+     ::search-util/link {:fhir/version "4.0.1"}
 
      :blaze.page-store/local {}
 

--- a/modules/fhir-test-util/src/blaze/fhir/test_util.clj
+++ b/modules/fhir-test-util/src/blaze/fhir/test_util.clj
@@ -64,7 +64,7 @@
    (ig/init {:blaze.fhir/structure-definition-repo {}})))
 
 (defn link-url [body link-relation]
-  (->> body :link (filter (comp #{link-relation} :relation)) first :url type/value))
+  (->> body :link (filter (comp #{link-relation} type/value :relation)) first :url type/value))
 
 (defmethod ig/init-key :blaze.test/page-id-cipher
   [_ _]

--- a/modules/interaction/src/blaze/interaction/history/instance.clj
+++ b/modules/interaction/src/blaze/interaction/history/instance.clj
@@ -9,6 +9,8 @@
    [blaze.db.spec]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.interaction.history.util :as history-util]
+   [blaze.interaction.search.util :as search-util]
+   [blaze.interaction.search.util.spec]
    [blaze.module :as m]
    [blaze.page-id-cipher.spec]
    [blaze.spec]
@@ -19,10 +21,10 @@
    [ring.util.response :as ring]
    [taoensso.timbre :as log]))
 
-(defn- next-link [context query-params resource-handle]
-  {:fhir/type :fhir.Bundle/link
-   :relation "next"
-   :url (history-util/page-nav-url context query-params (:t resource-handle))})
+(defn- next-link
+  [{::search-util/keys [link] :as context} query-params resource-handle]
+  (->> (history-util/page-nav-url context query-params (:t resource-handle))
+       (link "next")))
 
 (defn- build-response
   [{:blaze/keys [db] :as context} query-params total version-handles since]
@@ -50,7 +52,8 @@
               (update :link conj (next-link (peek paged-version-handles))))))))))
 
 (defmethod m/pre-init-spec :blaze.interaction.history/instance [_]
-  (s/keys :req-un [:blaze/clock :blaze/rng-fn :blaze/page-id-cipher]))
+  (s/keys :req [::search-util/link]
+          :req-un [:blaze/clock :blaze/rng-fn :blaze/page-id-cipher]))
 
 (defmethod ig/init-key :blaze.interaction.history/instance [_ context]
   (log/info "Init FHIR history instance interaction handler")

--- a/modules/interaction/src/blaze/interaction/history/util.clj
+++ b/modules/interaction/src/blaze/interaction/history/util.clj
@@ -4,6 +4,7 @@
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
+   [blaze.interaction.search.util :as search-util]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
    [blaze.module :as m]
    [blaze.util :as u :refer [str]]
@@ -48,10 +49,8 @@
   (let [path (reitit/match->path match (select-keys query-params ["_count"]))]
     (str base-url path)))
 
-(defn self-link [context query-params]
-  {:fhir/type :fhir.Bundle/link
-   :relation "self"
-   :url (nav-url context query-params)})
+(defn self-link [{::search-util/keys [link] :as context} query-params]
+  (link "self" (nav-url context query-params)))
 
 (defn page-nav-url
   "Returns a nav URL which points to a page with it's first entry described by

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -14,6 +14,7 @@
    [blaze.interaction.search.params :as params]
    [blaze.interaction.search.query-plan :as query-plan]
    [blaze.interaction.search.util :as search-util]
+   [blaze.interaction.search.util.spec]
    [blaze.job.async-interaction.request :as req]
    [blaze.module :as m]
    [blaze.page-id-cipher.spec]
@@ -162,22 +163,19 @@
                (assoc :clauses (d/query-clauses query)))))))
     ac/completed-future))
 
-(defn- link [relation url]
-  {:fhir/type :fhir.Bundle/link
-   :relation relation
-   :url (type/uri url)})
-
-(defn- self-link [{:keys [self-link-url-fn]} clauses]
+(defn- self-link
+  [{::search-util/keys [link] :keys [self-link-url-fn]} clauses]
   (link "self" (self-link-url-fn clauses)))
 
-(defn- first-link [{:keys [first-link-url-fn]} token clauses]
+(defn- first-link
+  [{::search-util/keys [link] :keys [first-link-url-fn]} token clauses]
   (link "first" (first-link-url-fn token clauses)))
 
 (defn- next-link-offset [next-handle]
   {"__page-id" (:id next-handle)})
 
 (defn- next-link
-  [{:keys [next-link-url-fn]} token clauses next-handle]
+  [{::search-util/keys [link] :keys [next-link-url-fn]} token clauses next-handle]
   (->> (next-link-url-fn token clauses (next-link-offset next-handle))
        (link "next")))
 
@@ -325,7 +323,8 @@
         (assoc :blaze.preference/respond-async true)))))
 
 (defmethod m/pre-init-spec :blaze.interaction/search-type [_]
-  (s/keys :req-un [:blaze/clock :blaze/rng-fn :blaze/page-store
+  (s/keys :req [::search-util/link]
+          :req-un [:blaze/clock :blaze/rng-fn :blaze/page-store
                    :blaze/page-id-cipher]
           :opt-un [:blaze/context-path]))
 

--- a/modules/interaction/test/blaze/interaction/history/type_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/type_test.clj
@@ -13,6 +13,8 @@
    [blaze.fhir.test-util :refer [link-url]]
    [blaze.interaction.history.type]
    [blaze.interaction.history.util-spec]
+   [blaze.interaction.search.util :as search-util]
+   [blaze.interaction.search.util-spec]
    [blaze.interaction.test-util :refer [coding v3-ObservationValue wrap-error]]
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.db-spec]
@@ -90,10 +92,12 @@
   (assoc
    api-stub/mem-node-config
    :blaze.interaction.history/type
-   {:node (ig/ref :blaze.db/node)
+   {::search-util/link (ig/ref ::search-util/link)
+    :node (ig/ref :blaze.db/node)
     :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
+   ::search-util/link {:fhir/version "4.0.1"}
    :blaze.test/fixed-rng-fn {}
    :blaze.test/page-id-cipher {}))
 
@@ -108,9 +112,17 @@
     (given-failed-system {:blaze.interaction.history/type {}}
       :key := :blaze.interaction.history/type
       :reason := ::ig/build-failed-spec
-      [:cause-data ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :clock))
-      [:cause-data ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :rng-fn))
-      [:cause-data ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :page-id-cipher))))
+      [:cause-data ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% ::search-util/link))
+      [:cause-data ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :clock))
+      [:cause-data ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :rng-fn))
+      [:cause-data ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :page-id-cipher))))
+
+  (testing "invalid link function"
+    (given-failed-system (assoc-in config [:blaze.interaction.history/type ::search-util/link] ::invalid)
+      :key := :blaze.interaction.history/type
+      :reason := ::ig/build-failed-spec
+      [:cause-data ::s/problems 0 :via] := [::search-util/link]
+      [:cause-data ::s/problems 0 :val] := ::invalid))
 
   (testing "invalid clock"
     (given-failed-system (assoc-in config [:blaze.interaction.history/type :clock] ::invalid)

--- a/modules/interaction/test/blaze/interaction/history/util_spec.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_spec.clj
@@ -4,6 +4,7 @@
    [blaze.handler.fhir.util-spec]
    [blaze.http.spec]
    [blaze.interaction.history.util :as util]
+   [blaze.interaction.search.util :as-alias search-util]
    [blaze.module-spec]
    [blaze.spec]
    [blaze.util-spec]
@@ -21,7 +22,7 @@
 (s/fdef util/self-link
   :args
   (s/cat
-   :context (s/keys :req [:blaze/base-url ::reitit/match])
+   :context (s/keys :req [::search-util/link :blaze/base-url ::reitit/match])
    :query-params (s/nilable :ring.request/query-params)))
 
 (s/fdef util/page-nav-url
@@ -37,3 +38,9 @@
 (s/fdef util/build-entry
   :args (s/cat :context (s/keys :req [:blaze/base-url ::reitit/router])
                :resource :fhir/Resource))
+
+(s/fdef util/build-bundle
+  :args (s/cat
+         :context (s/keys :req [::search-util/link :blaze/base-url ::reitit/match])
+         :total nat-int?
+         :query-params (s/nilable :ring.request/query-params)))

--- a/modules/interaction/test/blaze/interaction/history/util_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_test.clj
@@ -4,6 +4,8 @@
    [blaze.fhir.test-util]
    [blaze.interaction.history.util :as history-util]
    [blaze.interaction.history.util-spec]
+   [blaze.interaction.search.util :as search-util]
+   [blaze.interaction.search.util-spec]
    [blaze.module.test-util :refer [with-system]]
    [blaze.test-util :as tu]
    [clojure.spec.test.alpha :as st]
@@ -142,10 +144,12 @@
 
 (def ^:private config
   {::context
-   {:clock (ig/ref :blaze.test/fixed-clock)
+   {::search-util/link (ig/ref ::search-util/link)
+    :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :blaze/base-url ""
     :reitit.core/match (reitit/map->Match {})}
+   ::search-util/link {:fhir/version "4.0.1"}
    :blaze.test/fixed-clock {}
    :blaze.test/fixed-rng-fn {}})
 

--- a/modules/interaction/test/blaze/interaction/transaction_test.clj
+++ b/modules/interaction/test/blaze/interaction/transaction_test.clj
@@ -21,6 +21,7 @@
    [blaze.interaction.delete]
    [blaze.interaction.read]
    [blaze.interaction.search-type]
+   [blaze.interaction.search.util :as search-util]
    [blaze.interaction.test-util :refer [wrap-error]]
    [blaze.interaction.transaction]
    [blaze.interaction.update]
@@ -135,7 +136,7 @@
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
 
    :blaze.interaction/search-type
-   {:job-scheduler (ig/ref :blaze/job-scheduler)
+   {::search-util/link (ig/ref ::search-util/link)
     :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-store (ig/ref :blaze.page-store/local)
@@ -180,6 +181,7 @@
     :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)}
 
+   ::search-util/link {:fhir/version "4.0.1"}
    :blaze.test/fixed-rng-fn {}
    :blaze.page-store/local {}
    :blaze.test/fixed-rng {}

--- a/modules/operation-patient-everything/test/blaze/operation/patient/everything_test.clj
+++ b/modules/operation-patient-everything/test/blaze/operation/patient/everything_test.clj
@@ -6,6 +6,8 @@
    [blaze.fhir.test-util :refer [link-url]]
    [blaze.handler.fhir.util-spec]
    [blaze.handler.util :as handler-util]
+   [blaze.interaction.search.util :as search-util]
+   [blaze.interaction.search.util-spec]
    [blaze.middleware.fhir.db :as db]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
    [blaze.middleware.fhir.decrypt-page-id-spec]
@@ -35,9 +37,11 @@
   (assoc
    api-stub/mem-node-config
    :blaze.operation.patient/everything
-   {:clock (ig/ref :blaze.test/fixed-clock)
+   {::search-util/link (ig/ref ::search-util/link)
+    :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
+   ::search-util/link {:fhir/version "4.0.1"}
    :blaze.test/fixed-rng-fn {}
    :blaze.test/page-id-cipher {}))
 
@@ -52,9 +56,17 @@
     (given-failed-system {:blaze.operation.patient/everything {}}
       :key := :blaze.operation.patient/everything
       :reason := ::ig/build-failed-spec
-      [:cause-data ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :clock))
-      [:cause-data ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :rng-fn))
-      [:cause-data ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :page-id-cipher))))
+      [:cause-data ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% ::search-util/link))
+      [:cause-data ::s/problems 1 :pred] := `(fn ~'[%] (contains? ~'% :clock))
+      [:cause-data ::s/problems 2 :pred] := `(fn ~'[%] (contains? ~'% :rng-fn))
+      [:cause-data ::s/problems 3 :pred] := `(fn ~'[%] (contains? ~'% :page-id-cipher))))
+
+  (testing "invalid link function"
+    (given-failed-system (assoc-in config [:blaze.operation.patient/everything ::search-util/link] ::invalid)
+      :key := :blaze.operation.patient/everything
+      :reason := ::ig/build-failed-spec
+      [:cause-data ::s/problems 0 :via] := [::search-util/link]
+      [:cause-data ::s/problems 0 :val] := ::invalid))
 
   (testing "invalid clock"
     (given-failed-system (assoc-in config [:blaze.operation.patient/everything :clock] ::invalid)

--- a/modules/rest-util/src/blaze/interaction/search/util/spec.clj
+++ b/modules/rest-util/src/blaze/interaction/search/util/spec.clj
@@ -8,3 +8,6 @@
 
 (s/def ::search-util/context
   (s/keys :req [:blaze/base-url ::reitit/router]))
+
+(s/def ::search-util/link
+  fn?)

--- a/modules/rest-util/test/blaze/interaction/search/util_test.clj
+++ b/modules/rest-util/test/blaze/interaction/search/util_test.clj
@@ -1,12 +1,18 @@
 (ns blaze.interaction.search.util-test
   (:require
+   [blaze.fhir.spec.type :as type]
    [blaze.fhir.test-util]
    [blaze.interaction.search.util :as search-util]
    [blaze.interaction.search.util-spec]
-   [blaze.test-util :as tu :refer [given-thrown]]
+   [blaze.module.test-util :refer [given-failed-system with-system]]
+   [blaze.spec]
+   [blaze.test-util :as tu :refer [given-thrown satisfies-prop]]
    [clojure.spec.alpha :as s]
    [clojure.spec.test.alpha :as st]
-   [clojure.test :as test :refer [deftest]]
+   [clojure.test :as test :refer [deftest testing]]
+   [clojure.test.check.generators :as gen]
+   [clojure.test.check.properties :as prop]
+   [integrant.core :as ig]
    [juxt.iota :refer [given]]
    [reitit.core :as reitit]))
 
@@ -73,3 +79,35 @@
     :fhir/type := :fhir.Bundle/entry
     [:resource :fhir/type] := :fhir/OperationOutcome
     [:search :mode] #fhir/code"outcome"))
+
+(deftest link-test
+  (testing "init"
+    (testing "nil config"
+      (given-failed-system {::search-util/link nil}
+        :key := ::search-util/link
+        :reason := ::ig/build-failed-spec
+        [:cause-data ::s/problems 0 :pred] := `map?))
+
+    (testing "missing config"
+      (given-failed-system {::search-util/link {}}
+        :key := ::search-util/link
+        :reason := ::ig/build-failed-spec
+        [:cause-data ::s/problems 0 :pred] := `(fn ~'[%] (contains? ~'% :fhir/version)))))
+
+  (testing "FHIR v4.0.1"
+    (with-system [{::search-util/keys [link]} {::search-util/link {:fhir/version "4.0.1"}}]
+      (satisfies-prop 10
+        (prop/for-all [relation gen/string url gen/string]
+          (= (link relation url)
+             {:fhir/type :fhir.Bundle/link
+              :relation (type/string relation)
+              :url (type/uri url)})))))
+
+  (testing "FHIR v6.0.0-ballot3"
+    (with-system [{::search-util/keys [link]} {::search-util/link {:fhir/version "6.0.0-ballot3"}}]
+      (satisfies-prop 10
+        (prop/for-all [relation gen/string url gen/string]
+          (= (link relation url)
+             {:fhir/type :fhir.Bundle/link
+              :relation (type/code relation)
+              :url (type/uri url)}))))))

--- a/modules/spec/src/blaze/spec.clj
+++ b/modules/spec/src/blaze/spec.clj
@@ -17,6 +17,9 @@
 (s/def :blaze/release-date
   string?)
 
+(s/def :fhir/version
+  #{"4.0.1" "6.0.0-ballot3"})
+
 ;; The context path of Blaze that is appended to the :blaze/base-url
 (s/def :blaze/context-path
   (s/and

--- a/profiling/blaze/profiling.clj
+++ b/profiling/blaze/profiling.clj
@@ -9,6 +9,7 @@
    [blaze.elm.expression.cache :as ec]
    [blaze.system :as system]
    [blaze.util :refer [str]]
+   [clojure.repl :refer [pst]]
    [clojure.tools.namespace.repl :refer [refresh]]
    [taoensso.timbre :as log]))
 

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -123,17 +123,20 @@
   ;; which provides read and write access to the actual resources.
   ;;
   :blaze.interaction.history/system
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-id-cipher #blaze/ref :blaze/page-id-cipher}
 
   :blaze.interaction.history/type
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-id-cipher #blaze/ref :blaze/page-id-cipher}
 
   :blaze.interaction.history/instance
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-id-cipher #blaze/ref :blaze/page-id-cipher}
 
@@ -155,20 +158,23 @@
   :blaze.interaction/vread {}
 
   :blaze.interaction/search-system
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-store #blaze/ref :blaze/page-store
    :page-id-cipher #blaze/ref :blaze/page-id-cipher}
 
   :blaze.interaction/search-type
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-store #blaze/ref :blaze/page-store
    :page-id-cipher #blaze/ref :blaze/page-id-cipher
    :context-path #blaze/cfg ["CONTEXT_PATH" string? "/fhir"]}
 
   :blaze.interaction/search-compartment
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-store #blaze/ref :blaze/page-store
    :page-id-cipher #blaze/ref :blaze/page-id-cipher}
@@ -209,6 +215,9 @@
 
   :blaze.rest-api/async-status-cancel-handler
   {:job-scheduler #blaze/ref :blaze/job-scheduler}
+
+  :blaze.interaction.search.util/link
+  {:fhir/version #blaze/cfg ["FHIR_VERSION" :fhir/version "4.0.1"]}
 
   ;;
   ;; CQL Evaluation Engine
@@ -255,7 +264,8 @@
   ;; FHIR Operation Patient Everything
   ;;
   :blaze.operation.patient/everything
-  {:clock #blaze/ref :blaze/clock
+  {:blaze.interaction.search.util/link #blaze/ref :blaze.interaction.search.util/link
+   :clock #blaze/ref :blaze/clock
    :rng-fn #blaze/ref :blaze/rng-fn
    :page-id-cipher #blaze/ref :blaze/page-id-cipher}
 

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -8,6 +8,7 @@
   (:require
    [blaze.log]
    [blaze.path :refer [dir? path]]
+   [blaze.spec]
    [blaze.util :as u :refer [str]]
    [clojure.java.io :as io]
    [clojure.spec.alpha :as s]

--- a/test/blaze/system_test.clj
+++ b/test/blaze/system_test.clj
@@ -13,6 +13,7 @@
    [blaze.interaction.search-compartment]
    [blaze.interaction.search-system]
    [blaze.interaction.search-type]
+   [blaze.interaction.search.util :as search-util]
    [blaze.interaction.transaction]
    [blaze.interaction.vread]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
@@ -178,22 +179,26 @@
    :blaze.interaction/conditional-delete-type
    {:node (ig/ref :blaze.db/node)}
    :blaze.interaction/search-system
-   {:clock (ig/ref :blaze.test/fixed-clock)
+   {::search-util/link (ig/ref ::search-util/link)
+    :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-store (ig/ref ::page-store)
     :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
    :blaze.interaction/search-type
-   {:clock (ig/ref :blaze.test/fixed-clock)
+   {::search-util/link (ig/ref ::search-util/link)
+    :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-store (ig/ref ::page-store)
     :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
    :blaze.interaction/search-compartment
-   {:clock (ig/ref :blaze.test/fixed-clock)
+   {::search-util/link (ig/ref ::search-util/link)
+    :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-store (ig/ref ::page-store)
     :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
    :blaze.interaction.history/type
-   {:clock (ig/ref :blaze.test/fixed-clock)
+   {::search-util/link (ig/ref ::search-util/link)
+    :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :page-id-cipher (ig/ref :blaze.test/page-id-cipher)}
    ::rest-api/async-status-handler
@@ -245,6 +250,7 @@
     :clock (ig/ref :blaze.test/fixed-clock)
     :rng-fn (ig/ref :blaze.test/fixed-rng-fn)
     :graph-cache (ig/ref ::ts-local/graph-cache)}
+   ::search-util/link {:fhir/version "4.0.1"}
    :blaze.test/executor {}
    :blaze.test/fixed-clock {}
    :blaze.test/fixed-rng-fn {}


### PR DESCRIPTION
The function will create bundle links depending of the FHIR version in use. This is the first function doing so. The function is build as component which takes the FHIR version at initialization and returns an appropriate function. Although the implementation for FHIR v6.0.0-ballot3 is already given, and could be even used by setting the env var `FHIR_VERSION` accordingly, this is not supported until full R6 availability is documented.