### PR TITLE
Replace Dependency io.aviso/pretty

### DIFF
--- a/modules/anomaly/deps.edn
+++ b/modules/anomaly/deps.edn
@@ -4,8 +4,8 @@
  {blaze/spec
   {:local/root "../spec"}
 
-  io.aviso/pretty
-  {:mvn/version "1.4.4"}}
+  org.clj-commons/pretty
+  {:mvn/version "3.6.3"}}
 
  :aliases
  {:test

--- a/modules/anomaly/src/blaze/anomaly.clj
+++ b/modules/anomaly/src/blaze/anomaly.clj
@@ -1,8 +1,8 @@
 (ns blaze.anomaly
   (:refer-clojure :exclude [map])
   (:require
-   [cognitect.anomalies :as anom]
-   [io.aviso.exception :as aviso])
+   [clj-commons.format.exceptions :as e]
+   [cognitect.anomalies :as anom])
   (:import
    [clojure.lang APersistentMap ExceptionInfo]
    [java.util Map]
@@ -141,8 +141,8 @@
 
   Used to output stack traces in OperationOutcome's."
   [e]
-  (binding [aviso/*fonts* nil]
-    (aviso/format-exception e)))
+  (binding [e/*fonts* nil]
+    (e/format-exception e)))
 
 (defprotocol ToAnomaly
   (-anomaly [x]))

--- a/modules/rest-util/src/blaze/handler/util.clj
+++ b/modules/rest-util/src/blaze/handler/util.clj
@@ -7,9 +7,9 @@
    [blaze.fhir.spec.type :as type]
    [blaze.http.util :as hu]
    [blaze.util :refer [str]]
+   [clj-commons.format.exceptions :as e]
    [clojure.string :as str]
    [cognitect.anomalies :as anom]
-   [io.aviso.exception :as aviso]
    [reitit.ring]
    [ring.util.response :as ring]
    [taoensso.timbre :as log])
@@ -110,8 +110,8 @@
 
   Used to output stack traces in OperationOutcome's."
   [e]
-  (binding [aviso/*fonts* nil]
-    (aviso/format-exception e)))
+  (binding [e/*fonts* nil]
+    (e/format-exception e)))
 
 (defn- headers [response {:http/keys [headers]}]
   (reduce #(apply ring/header %1 %2) response headers))


### PR DESCRIPTION
We use now org.clj-commons/pretty, which is the successor.