### PR TITLE
Small Database Module Refactorings

### DIFF
--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -144,7 +144,7 @@
 (defn- index-tx-data!
   "This is the main transaction handling function.
 
-  If indexes resources and transaction data and commits either success or error."
+  It indexes resources and transaction data and commits either success or error."
   [{:keys [resource-indexer kv-store read-only-matcher] :as node}
    {:keys [t instant tx-cmds] :as tx-data}]
   (log/trace "index transaction with t =" t "and" (count tx-cmds) "command(s)")

--- a/modules/db/src/blaze/db/node/tx_indexer/verify.clj
+++ b/modules/db/src/blaze/db/node/tx_indexer/verify.clj
@@ -339,14 +339,17 @@
        (throw-anom (ba/conflict (ref-integrity-msg type id)))))
    references))
 
+(defn- rev-tuples [db-before resource-handle del-resources]
+  (into
+   []
+   (comp (map rh/local-ref-tuple) (remove del-resources) (take 2))
+   (d/rev-include db-before resource-handle)))
+
 (defn- check-referential-integrity-delete!
-  [db del-resources type id]
-  (when-let [resource-handle (d/resource-handle db type id)]
-    (let [[[type-ref id-ref] second]
-          (into
-           []
-           (comp (map rh/local-ref-tuple) (remove del-resources) (take 2))
-           (d/rev-include db resource-handle))]
+  [db-before del-resources type id]
+  (when-let [resource-handle (d/resource-handle db-before type id)]
+    (let [[[type-ref id-ref] second] (rev-tuples db-before resource-handle
+                                                 del-resources)]
       (when type-ref
         (throw-anom (ref-integrity-del-anom type-ref id-ref type id second))))))
 


### PR DESCRIPTION
* extracted the function rev-tuples in verify in order to make check-referential-integrity-delete! more readable
* add a test deleting a referenced resource that is being created
* separated another slow test