### PR TITLE
Fix File Pattern of cljfmt Checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ $(MODULES):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
 fmt-root:
-	cljfmt --file-pattern "\.(cljs|edn)?$$" check dev profiling resources src test deps.edn tests.edn
+	cljfmt --file-pattern "\.(clj|edn)?$$" check dev profiling resources src test deps.edn tests.edn
 
 fmt: $(MODULES) fmt-root
 

--- a/modules/coll/Makefile
+++ b/modules/coll/Makefile
@@ -1,5 +1,5 @@
 fmt:
-	cljfmt --file-pattern "\.(cljs|edn)?$$" check resources src test build.clj deps.edn tests.edn
+	cljfmt --file-pattern "\.(clj|edn)?$$" check resources src test build.clj deps.edn tests.edn
 
 lint:
 	clj-kondo --lint src test deps.edn

--- a/modules/db-stub/Makefile
+++ b/modules/db-stub/Makefile
@@ -1,5 +1,5 @@
 fmt:
-	cljfmt --file-pattern "\.(cljs|edn)?$$" check resources src deps.edn
+	cljfmt --file-pattern "\.(clj|edn)?$$" check resources src deps.edn
 
 lint:
 	clj-kondo --lint src deps.edn

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -1,5 +1,5 @@
 fmt:
-	cljfmt --file-pattern "\.(cljs|edn)?$$" check resources src test test-perf build.clj deps.edn tests.edn
+	cljfmt --file-pattern "\.(clj|edn)?$$" check resources src test test-perf build.clj deps.edn tests.edn
 
 lint:
 	clj-kondo --lint src test test-perf build.clj deps.edn

--- a/modules/fhir-structure/Makefile
+++ b/modules/fhir-structure/Makefile
@@ -1,5 +1,5 @@
 fmt:
-	cljfmt --file-pattern "\.(cljs|edn)?$$" check resources src test test-perf build.clj deps.edn tests.edn
+	cljfmt --file-pattern "\.(clj|edn)?$$" check resources src test test-perf build.clj deps.edn tests.edn
 
 lint:
 	clj-kondo --lint src test build.clj deps.edn

--- a/modules/module-test-util/Makefile
+++ b/modules/module-test-util/Makefile
@@ -1,5 +1,5 @@
 fmt:
-	cljfmt --file-pattern "\.(cljs|edn)?$$" check resources src deps.edn
+	cljfmt --file-pattern "\.(clj|edn)?$$" check resources src deps.edn
 
 lint:
 	clj-kondo --lint src deps.edn


### PR DESCRIPTION
The file pattern contained cljs (ClojureScript) instead of clj files.