### PR TITLE
Migrate Integrant to v1.0

### DIFF
--- a/modules/module-base/deps.edn
+++ b/modules/module-base/deps.edn
@@ -14,7 +14,7 @@
   {:mvn/version "6.8.0"}
 
   integrant/integrant
-  {:mvn/version "0.13.1"}
+  {:mvn/version "1.0.1"}
 
   prom-metrics/prom-metrics
   {:git/url "https://github.com/alexanderkiel/prom-metrics.git"

--- a/modules/module-test-util/deps.edn
+++ b/modules/module-test-util/deps.edn
@@ -11,4 +11,4 @@
   {:local/root "../test-util"}
 
   integrant/integrant
-  {:mvn/version "0.13.1"}}}
+  {:mvn/version "1.0.1"}}}

--- a/src/blaze/system.clj
+++ b/src/blaze/system.clj
@@ -231,7 +231,7 @@
         config (-> (merge-with merge root-config config)
                    (resolve-config env))]
     (load-namespaces config)
-    (-> config ig/prep ig/init)))
+    (ig/init config)))
 
 (defn shutdown! [system]
   (ig/halt! system))


### PR DESCRIPTION
We have to remove the use of `prep` which we actually never used anyway. So the migration is simpler as expected. In #3022 we can explore the use of the new Integrant features.

Closes: #2704