### PR TITLE
Ignore Vulnerabilities in Docs Generator

### DIFF
--- a/docs/osv-scanner.toml
+++ b/docs/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[PackageOverrides]]
+ignore = true
+reason = "Only affects the documentation generator."


### PR DESCRIPTION
Such vulnerabilities are not relevant for any artifact created by the source code in this repo. The documentation creates static HTML hosted on GitHub Pages.