### PR TITLE
Improve CQL Expression Cache Metrics

### DIFF
--- a/modules/cql/src/blaze/elm/expression/cache/bloom_filter.clj
+++ b/modules/cql/src/blaze/elm/expression/cache/bloom_filter.clj
@@ -24,10 +24,10 @@
   (take 12 (iterate #(* 4 %) 1)))
 
 (defhistogram bloom-filter-creation-duration-seconds
-  "Durations in Cassandra resource store."
+  "Durations in Bloom filter creation."
   {:namespace "blaze"
    :subsystem "cql_expr_cache"}
-  (take 14 (iterate #(* 2 %) 0.1)))
+  (take 16 (iterate #(* 2 %) 0.1)))
 
 (defn might-contain?
   "Returns true if `resource` might have been put in `bloom-filter` or false if

--- a/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
+++ b/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
@@ -24,16 +24,14 @@
 (defhistogram duration-seconds
   "Durations in Cassandra resource store."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "resource_store_cassandra_duration_seconds"}
+   :subsystem "db_resource_store_cassandra"}
   (take 12 (iterate #(* 2 %) 0.0001))
   "op")
 
 (defhistogram resource-bytes
   "Stored resource sizes in bytes in Cassandra resource store."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "resource_store_cassandra_resource_bytes"}
+   :subsystem "db_resource_store_cassandra"}
   (take 14 (iterate #(* 2 %) 128)))
 
 (defn- execute [session op statement]

--- a/modules/db-resource-store/src/blaze/db/resource_store/kv.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store/kv.clj
@@ -27,15 +27,13 @@
 (defhistogram resource-bytes
   "Stored resource sizes in key-value resource store."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "resource_store_kv_resource_bytes"}
+   :subsystem "db_resource_store_kv"}
   (take 16 (iterate #(* 2 %) 32)))
 
 (defhistogram duration-seconds
   "Durations in key-value resource store."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "resource_store_kv_duration_seconds"}
+   :subsystem "db_resource_store_kv"}
   (take 16 (iterate #(* 2 %) 1e-6))
   "op")
 

--- a/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka.clj
+++ b/modules/db-tx-log-kafka/src/blaze/db/tx_log/kafka.clj
@@ -29,8 +29,7 @@
 (defhistogram duration-seconds
   "Durations in Kafka transaction log."
   {:namespace "blaze"
-   :subsystem "db_tx_log"
-   :name "duration_seconds"}
+   :subsystem "db_tx_log"}
   (take 12 (iterate #(* 2 %) 0.0001))
   "op")
 

--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -67,8 +67,7 @@
 (defhistogram duration-seconds
   "Node durations."
   {:namespace "blaze"
-   :subsystem "db_node"
-   :name "duration_seconds"}
+   :subsystem "db_node"}
   (take 16 (iterate #(* 2 %) 0.0001))
   "op")
 

--- a/modules/db/src/blaze/db/node/resource_indexer.clj
+++ b/modules/db/src/blaze/db/node/resource_indexer.clj
@@ -29,16 +29,14 @@
 (defhistogram duration-seconds
   "Durations in resource indexer."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "resource_indexer_duration_seconds"}
+   :subsystem "db_resource_indexer"}
   (take 14 (iterate #(* 2 %) 0.00001))
   "op")
 
 (defhistogram index-entries
   "Number of index entries of a resource."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "resource_indexer_index_entries"}
+   :subsystem "db_resource_indexer"}
   (take 14 (iterate #(* 2 %) 1))
   "type")
 

--- a/modules/db/src/blaze/db/node/tx_indexer/util.clj
+++ b/modules/db/src/blaze/db/node/tx_indexer/util.clj
@@ -8,8 +8,7 @@
 (defhistogram duration-seconds
   "Durations in transaction indexer."
   {:namespace "blaze"
-   :subsystem "db"
-   :name "tx_indexer_duration_seconds"}
+   :subsystem "db_tx_indexer"}
   (take 16 (iterate #(* 2 %) 0.0001))
   "op")
 

--- a/modules/db/src/blaze/db/tx_log/local.clj
+++ b/modules/db/src/blaze/db/tx_log/local.clj
@@ -34,8 +34,7 @@
 (defhistogram duration-seconds
   "Durations in local transaction log."
   {:namespace "blaze"
-   :subsystem "db_tx_log"
-   :name "duration_seconds"}
+   :subsystem "db_tx_log"}
   (take 16 (iterate #(* 2 %) 0.00001))
   "op")
 

--- a/modules/extern-terminology-service/src/blaze/terminology_service/extern.clj
+++ b/modules/extern-terminology-service/src/blaze/terminology_service/extern.clj
@@ -20,8 +20,9 @@
 (set! *warn-on-reflection* true)
 
 (defhistogram request-duration-seconds
-  "Terminology Service request latencies in seconds."
-  {:namespace "terminology_service"}
+  "Extern terminology service request latencies."
+  {:namespace "blaze"
+   :subsystem "terminology_service_extern"}
   (take 14 (iterate #(* 2 %) 0.001)))
 
 (defn- expand-value-set* [base-uri http-client parsing-context writing-context url]

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -41,7 +41,7 @@
   "$evaluate-measure evaluating latencies in seconds."
   {:namespace "fhir"
    :subsystem "evaluate_measure"}
-  (take 22 (iterate #(* 1.4 %) 0.1))
+  (take 16 (iterate #(* 2 %) 0.1))
   "subject_type")
 
 ;; ---- Compilation -----------------------------------------------------------

--- a/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
+++ b/modules/page-store-cassandra/src/blaze/page_store/cassandra.clj
@@ -24,16 +24,14 @@
 (defhistogram duration-seconds
   "Durations in Cassandra page store."
   {:namespace "blaze"
-   :subsystem "page_store"
-   :name "cassandra_duration_seconds"}
+   :subsystem "page_store_cassandra"}
   (take 12 (iterate #(* 2 %) 0.0001))
   "op")
 
 (defhistogram clauses-bytes
   "Stored clauses sizes in bytes in Cassandra page store."
   {:namespace "blaze"
-   :subsystem "page_store"
-   :name "cassandra_clauses_bytes"}
+   :subsystem "page_store_cassandra"}
   (take 10 (iterate #(* 2 %) 128)))
 
 (defn- execute [session op statement]


### PR DESCRIPTION
Also refactor metric naming and change the name of the currently unused extern terminology service.