### PR TITLE
Refactor Resource Handle

### DIFF
--- a/modules/cql/src/blaze/elm/compiler/queries.clj
+++ b/modules/cql/src/blaze/elm/compiler/queries.clj
@@ -45,7 +45,7 @@
      ;; TODO: give the matcher the cr/handle function
       (comp (map cr/handle)
             (d/matcher-transducer db matcher)
-            (map (partial cr/mk-resource db))))
+            (map #(cr/mk-resource db %))))
     (-form [_]
       `(~'matcher ~(d/matcher-clauses matcher)))))
 

--- a/modules/cql/src/blaze/elm/expression/cache/bloom_filter.clj
+++ b/modules/cql/src/blaze/elm/expression/cache/bloom_filter.clj
@@ -35,7 +35,7 @@
   {:arglists '([bloom-filter resource])}
   [^BloomFilterContainer bloom-filter ^Resource resource]
   (or (< (.-t bloom-filter) (.-lastChangeT resource))
-      (.mightContain ^BloomFilter (.-filter bloom-filter) (.-id resource))))
+      (.mightContain ^BloomFilter (.-filter bloom-filter) (:id resource))))
 
 (defn merge [bloom-filter-a bloom-filter-b]
   (.merge ^BloomFilterContainer bloom-filter-a bloom-filter-b))

--- a/modules/cql/test/blaze/elm/compiler/queries_test.clj
+++ b/modules/cql/test/blaze/elm/compiler/queries_test.clj
@@ -16,7 +16,6 @@
    [blaze.elm.literal :as elm]
    [blaze.elm.literal-spec]
    [blaze.elm.util-spec]
-   [blaze.fhir.spec :as fhir-spec]
    [blaze.fhir.spec.type]
    [blaze.fhir.spec.type.system.spec]
    [blaze.test-util :refer [satisfies-prop]]

--- a/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
+++ b/modules/db-resource-store-cassandra/src/blaze/db/resource_store/cassandra.clj
@@ -44,7 +44,7 @@
           hash cause-msg))
 
 (defn- parse-cbor [parsing-context row [type hash variant]]
-  (-> (fhir-spec/parse-cbor parsing-context type row variant)
+  (-> (fhir-spec/parse-cbor parsing-context (name type) row variant)
       (ba/exceptionally
        #(assoc %
                ::anom/message (parse-msg hash (::anom/message %))

--- a/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
+++ b/modules/db-resource-store-cassandra/test/blaze/db/resource_store/cassandra_test.clj
@@ -133,7 +133,7 @@
 
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
-          (given-failed-future (rs/get store ["Patient" hash :complete])
+          (given-failed-future (rs/get store [:fhir/Patient hash :complete])
             ::anom/message :# "Error while parsing resource content with hash `0000000000000000000000000000000000000000000000000000000000000000`:(.|\\s)*"
             :blaze.resource/hash := hash)))))
 
@@ -156,7 +156,7 @@
 
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
-          (is (nil? @(rs/get store ["Patient" hash :complete])))))))
+          (is (nil? @(rs/get store [:fhir/Patient hash :complete])))))))
 
   (testing "execute error"
     (let [hash (hash "0")
@@ -176,7 +176,7 @@
 
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
-          (given-failed-future (rs/get store ["Patient" hash :complete])
+          (given-failed-future (rs/get store [:fhir/Patient hash :complete])
             ::anom/category := ::anom/fault
             ::anom/message := "msg-141754"
             :blaze.resource/hash := hash)))))
@@ -199,7 +199,7 @@
 
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
-          (given-failed-future (rs/get store ["Patient" hash :complete])
+          (given-failed-future (rs/get store [:fhir/Patient hash :complete])
             ::anom/category := ::anom/busy
             ::anom/message := "Cassandra msg-115452"
             :blaze.resource/hash := hash)))))
@@ -225,7 +225,7 @@
 
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
-          (given @(mtu/assoc-thread-name (rs/get store ["Patient" hash :complete]))
+          (given @(mtu/assoc-thread-name (rs/get store [:fhir/Patient hash :complete]))
             [meta :thread-name] :? mtu/common-pool-thread?
             :fhir/type := :fhir/Patient
             :id := "0")))))
@@ -255,7 +255,7 @@
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
           (testing "content matches"
-            (given @(mtu/assoc-thread-name (rs/get store ["Patient" hash :complete]))
+            (given @(mtu/assoc-thread-name (rs/get store [:fhir/Patient hash :complete]))
               [meta :thread-name] :? mtu/common-pool-thread?
               identity := content)))))))
 
@@ -280,7 +280,7 @@
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
           (testing "result is empty"
-            (given @(mtu/assoc-thread-name (rs/multi-get store [["Patient" hash :complete]]))
+            (given @(mtu/assoc-thread-name (rs/multi-get store [[:fhir/Patient hash :complete]]))
               [meta :thread-name] :? mtu/common-pool-thread?
               identity :? empty?))))))
 
@@ -305,9 +305,9 @@
 
       (with-redefs [cass/session (fn [_] session)]
         (with-system [{store ::rs/cassandra} config]
-          (given @(mtu/assoc-thread-name (rs/multi-get store [["Patient" hash :complete]]))
+          (given @(mtu/assoc-thread-name (rs/multi-get store [[:fhir/Patient hash :complete]]))
             [meta :thread-name] :? mtu/common-pool-thread?
-            identity := {["Patient" hash :complete] content}))))))
+            identity := {[:fhir/Patient hash :complete] content}))))))
 
 (def bound-put-statement (reify BoundStatement))
 

--- a/modules/db-resource-store/src/blaze/db/resource_store/kv.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store/kv.clj
@@ -47,7 +47,7 @@
 
 (defn- parse-cbor [parsing-context bytes [type hash variant]]
   (with-open [_ (prom/timer duration-seconds "parse-resource")]
-    (-> (fhir-spec/parse-cbor parsing-context type bytes variant)
+    (-> (fhir-spec/parse-cbor parsing-context (name type) bytes variant)
         (ba/exceptionally #(parse-anom % hash)))))
 
 (defn- get-content [kv-store hash]

--- a/modules/db-resource-store/src/blaze/db/resource_store/spec.clj
+++ b/modules/db-resource-store/src/blaze/db/resource_store/spec.clj
@@ -9,4 +9,4 @@
   #(satisfies? rs/ResourceStore %))
 
 (s/def ::rs/key
-  (s/tuple :fhir.resource/type :blaze.resource/hash :blaze.resource/variant))
+  (s/tuple :fhir/type :blaze.resource/hash :blaze.resource/variant))

--- a/modules/db/java/blaze/db/impl/index/IndexHandle.java
+++ b/modules/db/java/blaze/db/impl/index/IndexHandle.java
@@ -5,9 +5,10 @@ import blaze.fhir.Hash;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static java.util.Objects.requireNonNull;
 
 public final class IndexHandle {
 
@@ -15,8 +16,8 @@ public final class IndexHandle {
     private final int[] hashPrefixes;
 
     private IndexHandle(ByteString id, int[] hashPrefixes) {
-        this.id = id;
-        this.hashPrefixes = hashPrefixes;
+        this.id = requireNonNull(id);
+        this.hashPrefixes = requireNonNull(hashPrefixes);
     }
 
     public static IndexHandle fromIdAndHash(ByteString id, Hash hash) {
@@ -114,14 +115,13 @@ public final class IndexHandle {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
-        IndexHandle that = (IndexHandle) o;
-        return id.equals(that.id) && Arrays.equals(hashPrefixes, that.hashPrefixes);
+        if (this == o) return true;
+        return o instanceof IndexHandle that && id.equals(that.id) && Arrays.equals(hashPrefixes, that.hashPrefixes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, Arrays.hashCode(hashPrefixes));
+        return 31 * id.hashCode() + Arrays.hashCode(hashPrefixes);
     }
 
     @Override

--- a/modules/db/java/blaze/db/impl/index/ResourceHandle.java
+++ b/modules/db/java/blaze/db/impl/index/ResourceHandle.java
@@ -1,0 +1,145 @@
+package blaze.db.impl.index;
+
+import blaze.fhir.Hash;
+import clojure.lang.*;
+
+import java.util.Comparator;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ResourceHandle implements ILookup, IKeywordLookup {
+
+    public static final Comparator<ResourceHandle> ID_CMP = Comparator.comparing(rh -> rh.id);
+
+    private static final Keyword FHIR_TYPE = RT.keyword("fhir", "type");
+    private static final Keyword TID = RT.keyword(null, "tid");
+    private static final Keyword ID = RT.keyword(null, "id");
+    private static final Keyword T = RT.keyword(null, "t");
+    private static final Keyword HASH = RT.keyword(null, "hash");
+    private static final Keyword NUM_CHANGES = RT.keyword(null, "num-changes");
+    private static final Keyword OP = RT.keyword(null, "op");
+    private static final Keyword OP_CREATE = RT.keyword(null, "create");
+    private static final Keyword OP_PUT = RT.keyword(null, "put");
+    private static final Keyword OP_DELETE = RT.keyword(null, "delete");
+
+    private static final ILookupThunk FHIR_TYPE_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? rh.fhirType : this;
+        }
+    };
+
+    private static final ILookupThunk TID_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? rh.tid : this;
+        }
+    };
+
+    private static final ILookupThunk ID_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? rh.id : this;
+        }
+    };
+
+    private static final ILookupThunk T_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? rh.t : this;
+        }
+    };
+
+    private static final ILookupThunk HASH_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? rh.hash : this;
+        }
+    };
+
+    private static final ILookupThunk NUM_CHANGES_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? numChanges(rh.state) : this;
+        }
+    };
+
+    private static final ILookupThunk OP_LOOKUP_THUNK = new ILookupThunk() {
+        @Override
+        public Object get(Object target) {
+            return target instanceof ResourceHandle rh ? op(rh.state) : this;
+        }
+    };
+
+    public static long numChanges(long state) {
+        return state >> 8;
+    }
+
+    public static Keyword op(long state) {
+        return (state & 2) != 0 ? OP_CREATE : (state & 1) != 0 ? OP_DELETE : OP_PUT;
+    }
+
+    private final Keyword fhirType;
+    private final int tid;
+    private final String id;
+    private final long t;
+    private final Hash hash;
+    private final long state;
+
+    public ResourceHandle(Keyword fhirType, int tid, String id, long t, Hash hash, long state) {
+        this.fhirType = requireNonNull(fhirType);
+        this.tid = tid;
+        this.id = requireNonNull(id);
+        this.t = t;
+        this.hash = requireNonNull(hash);
+        this.state = state;
+    }
+
+    @Override
+    public Object valAt(Object key) {
+        return valAt(key, null);
+    }
+
+    @Override
+    public Object valAt(Object key, Object notFound) {
+        if (key == FHIR_TYPE) return fhirType;
+        if (key == TID) return tid;
+        if (key == ID) return id;
+        if (key == T) return t;
+        if (key == HASH) return hash;
+        if (key == NUM_CHANGES) return numChanges(state);
+        if (key == OP) return op(state);
+        return notFound;
+    }
+
+    @Override
+    public ILookupThunk getLookupThunk(Keyword key) {
+        if (key == FHIR_TYPE) return FHIR_TYPE_LOOKUP_THUNK;
+        if (key == TID) return TID_LOOKUP_THUNK;
+        if (key == ID) return ID_LOOKUP_THUNK;
+        if (key == T) return T_LOOKUP_THUNK;
+        if (key == HASH) return HASH_LOOKUP_THUNK;
+        if (key == NUM_CHANGES) return NUM_CHANGES_LOOKUP_THUNK;
+        if (key == OP) return OP_LOOKUP_THUNK;
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o instanceof ResourceHandle that && tid == that.tid && id.equals(that.id) && t == that.t;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tid;
+        result = 31 * result + id.hashCode();
+        result = 31 * result + Long.hashCode(t);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return fhirType.getName() + "[id = " + id + ", t = " + t + ']';
+    }
+}

--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -121,7 +121,9 @@
   (log/trace "fetch resource handle of" (str type "/" id))
   (p/-resource-handle db (codec/tid type) (codec/id-byte-string id)))
 
-(defn resource-handle? [x]
+(defn resource-handle?
+  "Returns `true` if `x` is a resource handle."
+  [x]
   (rh/resource-handle? x))
 
 (defn deleted?

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -28,7 +28,6 @@
    [blaze.db.kv :as kv]
    [blaze.db.node.resource-indexer :as resource-indexer]
    [blaze.db.search-param-registry :as sr]
-   [blaze.fhir.spec.type :as type]
    [blaze.util :refer [str]])
   (:import
    [java.io Writer]
@@ -195,7 +194,7 @@
 
   (-rev-include [db resource-handle]
     (let [search-param-registry (:search-param-registry node)
-          type (name (type/type resource-handle))
+          type (name (:fhir/type resource-handle))
           reference (rh/tid-id resource-handle)]
       (coll/eduction
        (comp
@@ -307,7 +306,7 @@
 (defn- start-patient-id [batch-db tid start-id]
   (let [start-handle (p/-resource-handle batch-db tid start-id)
         start-patient-handle (coll/first (spc/targets batch-db start-handle patient-code-hash))]
-    (codec/id-byte-string (rh/id start-patient-handle))))
+    (codec/id-byte-string (:id start-patient-handle))))
 
 ;; A type query over resources with `tid` and patients with `patient-ids`.
 (defrecord PatientTypeQuery [tid patient-ids compartment-clause clauses

--- a/modules/db/src/blaze/db/impl/index.clj
+++ b/modules/db/src/blaze/db/impl/index.clj
@@ -7,7 +7,6 @@
    [blaze.db.impl.codec :as codec]
    [blaze.db.impl.index.compartment.resource :as cr]
    [blaze.db.impl.index.index-handle :as ih]
-   [blaze.db.impl.index.resource-handle :as rh]
    [blaze.db.impl.protocols :as p]
    [blaze.db.impl.search-param :as search-param]
    [blaze.db.impl.search-param.util :as u]
@@ -238,7 +237,7 @@
       (index-handles batch-db tid first-clause start-id))
      (let [start-id (codec/id-string start-id)]
        (coll/eduction
-        (drop-while #(not= start-id (rh/id %)))
+        (drop-while #(not= start-id (:id %)))
         (unordered-resource-handles batch-db tid clauses))))))
 
 (defn type-query

--- a/modules/db/src/blaze/db/impl/index/index_handle.clj
+++ b/modules/db/src/blaze/db/impl/index/index_handle.clj
@@ -1,8 +1,7 @@
 (ns blaze.db.impl.index.index-handle
   (:refer-clojure :exclude [conj])
   (:require
-   [blaze.db.impl.codec :as codec]
-   [blaze.db.impl.index.resource-handle :as rh])
+   [blaze.db.impl.codec :as codec])
   (:import
    [blaze.db.impl.index IndexHandle SingleVersionId]))
 
@@ -16,8 +15,8 @@
 (defn from-resource-handle
   "Creates an index handle from `resource-handle`."
   [resource-handle]
-  (IndexHandle/fromIdAndHash (codec/id-byte-string (rh/id resource-handle))
-                             (rh/hash resource-handle)))
+  (IndexHandle/fromIdAndHash (codec/id-byte-string (:id resource-handle))
+                             (:hash resource-handle)))
 
 (defn id
   "Returns the id of `index-handle`."

--- a/modules/db/src/blaze/db/impl/index/resource_handle.clj
+++ b/modules/db/src/blaze/db/impl/index/resource_handle.clj
@@ -1,66 +1,30 @@
 (ns blaze.db.impl.index.resource-handle
-  (:refer-clojure :exclude [hash str type])
+  "A resource handle is a detailed pointer to a resource version, containing not
+  only the resource ID and hash, but also the logical timestamp `t` of that
+  version.
+
+  The implementation of the resource handle is done in Java. It's created via
+  the `resource-handle!` function. The access of it's data is performed via
+  keyword lookup. The relevant properties are:
+
+  * :fhir/type - the FHIR type like :fhir/Patient
+  * :tid - the internal type ID as integer
+  * :id - the logical FHIR ID
+  * :t - logical timestamp `t` of the transaction the version of the resource
+         was created
+  * :hash - the content hash of the resource version
+  * :num-changes - the number of changes happened to the resource up to `t`
+  * :op - the transaction operator that lead to this version. One of :create,
+          :put or :delete"
   (:require
    [blaze.byte-buffer :as bb]
    [blaze.db.impl.codec :as codec]
-   [blaze.fhir.hash :as hash]
-   [blaze.fhir.spec.type.protocols :as p]
-   [blaze.util :refer [str]])
+   [blaze.fhir.hash :as hash])
   (:import
-   [clojure.lang ILookup Numbers]))
+   [blaze.db.impl.index ResourceHandle]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
-
-(deftype ResourceHandle [^int tid id ^long t hash ^long num-changes op]
-  p/FhirType
-  (-type [_]
-   ;; TODO: maybe cache this
-    (keyword "fhir" (codec/tid->type tid)))
-
-  ILookup
-  (valAt [rh key]
-    (.valAt rh key nil))
-  (valAt [rh key not-found]
-    (case key
-      :fhir/type (p/-type rh)
-      :tid tid
-      :id id
-      :t t
-      :hash hash
-      :num-changes num-changes
-      :op op
-      not-found))
-
-  Object
-  (equals [rh x]
-    (or (identical? rh x)
-        (and (instance? ResourceHandle x)
-             (= tid (.-tid ^ResourceHandle x))
-             (.equals id (.-id ^ResourceHandle x))
-             (= t (.-t ^ResourceHandle x)))))
-  (hashCode [_]
-    (-> tid
-        (unchecked-multiply-int 31)
-        (unchecked-add-int (.hashCode id))
-        (unchecked-multiply-int 31)
-        (unchecked-add-int t)))
-  (toString [_]
-    (str (codec/tid->type tid) "[id = " id ", t = " t "]")))
-
-(defn state->num-changes
-  "A resource is new if num-changes is 1."
-  {:inline (fn [state] `(bit-shift-right (unchecked-long ~state) 8))}
-  [state]
-  (bit-shift-right (unchecked-long state) 8))
-
-(defn state->op [^long state]
-  ;; TODO: revise this unidiomatic style taken for performance reasons
-  (if (Numbers/testBit state 1)
-    :create
-    (if (Numbers/testBit state 0)
-      :delete
-      :put)))
 
 (defn- no-purged-at? [vb]
   (< (bb/remaining vb) 8))
@@ -71,69 +35,29 @@
 (defn resource-handle!
   "Creates a new resource handle when not purged at `base-t`.
 
-  The type of that handle will be the keyword `:fhir/<resource-type>`."
+  The :fhir/type of that handle will be the keyword `:fhir/<resource-type>`
+  taken from `tid`."
   [tid id t base-t vb]
   (let [hash (hash/from-byte-buffer! vb)
         state (bb/get-long! vb)]
     (when (or (no-purged-at? vb) (not-purged?! base-t vb))
       (ResourceHandle.
+       (keyword "fhir" (codec/tid->type tid))
        tid
        id
        t
        hash
-       (state->num-changes state)
-       (state->op state)))))
+       state))))
 
-(defn resource-handle? [x]
+(defn resource-handle?
+  "Returns `true` if `x` is a resource handle."
+  [x]
   (instance? ResourceHandle x))
 
 (defn deleted?
-  {:inline
-   (fn [rh]
-     `(identical? :delete (.-op ~(with-meta rh {:tag `ResourceHandle}))))}
-  [rh]
-  (identical? :delete (.-op ^ResourceHandle rh)))
+  "Returns `true` if `resource-handle` is deleted."
+  [resource-handle]
+  (identical? :delete (:op resource-handle)))
 
-(defn tid
-  {:inline (fn [rh] `(.-tid ~(with-meta rh {:tag `ResourceHandle})))}
-  [rh]
-  (.-tid ^ResourceHandle rh))
-
-(defn type [rh]
-  (codec/tid->type (tid rh)))
-
-(defn id
-  {:inline (fn [rh] `(.-id ~(with-meta rh {:tag `ResourceHandle})))}
-  [rh]
-  (.-id ^ResourceHandle rh))
-
-(defn t
-  {:inline (fn [rh] `(.-t ~(with-meta rh {:tag `ResourceHandle})))}
-  [rh]
-  (.-t ^ResourceHandle rh))
-
-(defn hash
-  {:inline (fn [rh] `(.-hash ~(with-meta rh {:tag `ResourceHandle})))}
-  [rh]
-  (.-hash ^ResourceHandle rh))
-
-(defn num-changes
-  {:inline (fn [rh] `(.-num_changes ~(with-meta rh {:tag `ResourceHandle})))}
-  [rh]
-  (.-num_changes ^ResourceHandle rh))
-
-(defn op
-  {:inline (fn [rh] `(.-op ~(with-meta rh {:tag `ResourceHandle})))}
-  [rh]
-  (.-op ^ResourceHandle rh))
-
-(defn reference
-  "Returns the reference `<type>/<id>` of `rh`."
-  [rh]
-  (str (codec/tid->type (tid rh)) "/" (id rh)))
-
-(defn local-ref-tuple [rh]
-  [(codec/tid->type (tid rh)) (id rh)])
-
-(defn tid-id [rh]
-  (codec/tid-id (tid rh) (codec/id-byte-string (id rh))))
+(defn tid-id [resource-handle]
+  (codec/tid-id (:tid resource-handle) (codec/id-byte-string (:id resource-handle))))

--- a/modules/db/src/blaze/db/impl/index/single_version_id.clj
+++ b/modules/db/src/blaze/db/impl/index/single_version_id.clj
@@ -1,7 +1,6 @@
 (ns blaze.db.impl.index.single-version-id
   (:require
-   [blaze.db.impl.codec :as codec]
-   [blaze.db.impl.index.resource-handle :as rh])
+   [blaze.db.impl.codec :as codec])
   (:import
    [blaze.db.impl.index SingleVersionId]
    [blaze.fhir Hash]))
@@ -12,8 +11,8 @@
   (SingleVersionId. id (.prefix ^Hash hash)))
 
 (defn from-resource-handle [resource-handle]
-  (SingleVersionId. (codec/id-byte-string (rh/id resource-handle))
-                    (.prefix ^Hash (rh/hash resource-handle))))
+  (SingleVersionId. (codec/id-byte-string (:id resource-handle))
+                    (.prefix ^Hash (:hash resource-handle))))
 
 (defn id [single-version-id]
   (.id ^SingleVersionId single-version-id))

--- a/modules/db/src/blaze/db/impl/search_param/chained.clj
+++ b/modules/db/src/blaze/db/impl/search_param/chained.clj
@@ -5,7 +5,6 @@
    [blaze.coll.core :as coll]
    [blaze.db.impl.codec :as codec]
    [blaze.db.impl.index.index-handle :as ih]
-   [blaze.db.impl.index.resource-handle :as rh]
    [blaze.db.impl.index.resource-search-param-value :as r-sp-v]
    [blaze.db.impl.index.single-version-id :as svi]
    [blaze.db.impl.protocols :as p]
@@ -49,6 +48,9 @@
                                      (svi/hash-prefix single-version-id) c-hash
                                      (bs/size start-value) start-value))))
 
+(defn- reference [rh]
+  (str (name (:fhir/type rh)) "/" (:id rh)))
+
 (defrecord ChainedSearchParam [search-param ref-search-param ref-c-hash ref-tid
                                ref-modifier code]
   p/SearchParam
@@ -61,7 +63,7 @@
   (-index-handles [_ batch-db tid modifier compiled-value]
     (coll/eduction
      (comp (u/resource-handle-xf batch-db ref-tid)
-           (map #(p/-compile-value ref-search-param ref-modifier (rh/reference %)))
+           (map #(p/-compile-value ref-search-param ref-modifier (reference %)))
            (mapcat #(p/-index-handles ref-search-param batch-db tid modifier %)))
      (p/-index-handles search-param batch-db ref-tid modifier compiled-value)))
 
@@ -70,7 +72,7 @@
       (coll/eduction
        (comp (u/resource-handle-xf batch-db tid)
              (distinct)
-             (drop-while #(not= start-id (rh/id %)))
+             (drop-while #(not= start-id (:id %)))
              (map ih/from-resource-handle))
        (p/-index-handles this batch-db tid modifier compiled-value))))
 

--- a/modules/db/src/blaze/db/impl/search_param/list.clj
+++ b/modules/db/src/blaze/db/impl/search_param/list.clj
@@ -5,7 +5,6 @@
    [blaze.coll.core :as coll]
    [blaze.db.impl.codec :as codec]
    [blaze.db.impl.index.index-handle :as ih]
-   [blaze.db.impl.index.resource-handle :as rh]
    [blaze.db.impl.index.resource-search-param-value :as r-sp-v]
    [blaze.db.impl.protocols :as p]
    [blaze.db.impl.search-param.special :as special]
@@ -21,7 +20,7 @@
   (u/non-deleted-resource-handle batch-db list-tid list-id))
 
 (defn- list-hash [batch-db list-id]
-  (some-> (list-handle batch-db list-id) rh/hash))
+  (:hash (list-handle batch-db list-id)))
 
 (defn- referenced-index-handles
   "Returns a reducible collection of index handles of type `tid` that are

--- a/modules/db/src/blaze/db/impl/search_param/quantity.clj
+++ b/modules/db/src/blaze/db/impl/search_param/quantity.clj
@@ -5,7 +5,6 @@
    [blaze.byte-string :as bs]
    [blaze.coll.core :as coll]
    [blaze.db.impl.codec :as codec]
-   [blaze.db.impl.index.resource-handle :as rh]
    [blaze.db.impl.index.resource-search-param-value :as r-sp-v]
    [blaze.db.impl.index.search-param-value-resource :as sp-vr]
    [blaze.db.impl.index.single-version-id :as svi]
@@ -207,7 +206,7 @@
        :lt (bs/< value exact-value)
        true))
    (fn [resource-handle]
-     (+ (r-sp-v/key-size (codec/id-byte-string (rh/id resource-handle)))
+     (+ (r-sp-v/key-size (codec/id-byte-string (:id resource-handle)))
         (long prefix-length)))
    values))
 

--- a/modules/db/src/blaze/db/impl/search_param/util.clj
+++ b/modules/db/src/blaze/db/impl/search_param/util.clj
@@ -77,7 +77,7 @@
   [batch-db tid]
   (rao/resource-handle-type-xf
    batch-db tid ih/id
-   (fn [mvi handle] (ih/matches-hash? mvi (rh/hash handle)))))
+   (fn [mvi handle] (ih/matches-hash? mvi (:hash handle)))))
 
 (defn missing-expression-msg [url]
   (format "Unsupported search parameter with URL `%s`. Required expression is missing."

--- a/modules/db/src/blaze/db/node/resource_indexer.clj
+++ b/modules/db/src/blaze/db/node/resource_indexer.clj
@@ -113,7 +113,7 @@
   (ac/all-of (mapv (partial async-index-resource context) entries)))
 
 (defn- cmd-rs-keys [tx-cmds variant]
-  (into [] (keep (fn [{:keys [type hash]}] (when hash [type hash variant]))) tx-cmds))
+  (into [] (keep (fn [{:keys [type hash]}] (when hash [(keyword "fhir" type) hash variant]))) tx-cmds))
 
 (defn index-resources
   "Returns a CompletableFuture that will complete after all resources of

--- a/modules/db/src/blaze/db/node/util.clj
+++ b/modules/db/src/blaze/db/node/util.clj
@@ -1,7 +1,6 @@
 (ns blaze.db.node.util
   (:refer-clojure :exclude [str])
   (:require
-   [blaze.db.impl.index.resource-handle :as rh]
    [blaze.util :refer [str]]
    [clojure.string :as str]))
 
@@ -21,4 +20,4 @@
 (defn rs-key
   "Returns the resource-store key of `resource-handle` in `variant`."
   [resource-handle variant]
-  [(rh/type resource-handle) (rh/hash resource-handle) variant])
+  [(:fhir/type resource-handle) (:hash resource-handle) variant])

--- a/modules/db/src/blaze/db/node/validation.clj
+++ b/modules/db/src/blaze/db/node/validation.clj
@@ -1,17 +1,16 @@
 (ns blaze.db.node.validation
   (:require
-   [blaze.anomaly :as ba]
-   [blaze.fhir.spec :as fhir-spec]))
+   [blaze.anomaly :as ba]))
 
 (defmulti extract-type-id first)
 
 (defmethod extract-type-id :create
-  [[_ {:keys [id] :as resource}]]
-  [(name (fhir-spec/fhir-type resource)) id])
+  [[_ {:fhir/keys [type] :keys [id]}]]
+  [(name type) id])
 
 (defmethod extract-type-id :put
-  [[_ {:keys [id] :as resource}]]
-  [(name (fhir-spec/fhir-type resource)) id])
+  [[_ {:fhir/keys [type] :keys [id]}]]
+  [(name type) id])
 
 (defmethod extract-type-id :keep
   [[_ type id]]

--- a/modules/db/src/blaze/db/search_param_registry.clj
+++ b/modules/db/src/blaze/db/search_param_registry.clj
@@ -8,7 +8,6 @@
    [blaze.db.impl.search-param.chained :as spc]
    [blaze.db.impl.search-param.core :as sc]
    [blaze.db.search-param-registry.spec]
-   [blaze.fhir.spec :as fhir-spec]
    [blaze.module :as m]
    [blaze.util :refer [conj-vec str]]
    [clojure.java.io :as io]
@@ -122,7 +121,7 @@
       cat)
      conj
      #{}
-     (compartment-index (name (fhir-spec/fhir-type resource)))))
+     (compartment-index (name (:fhir/type resource)))))
 
   (-compartment-resources [_ compartment-type]
     (compartment-resource-index compartment-type []))

--- a/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_handle_spec.clj
@@ -21,45 +21,9 @@
   :ret boolean?)
 
 (s/fdef rh/deleted?
-  :args (s/cat :rh rh/resource-handle?)
+  :args (s/cat :resource-handle :blaze.db/resource-handle)
   :ret boolean?)
 
-(s/fdef rh/tid
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.db/tid)
-
-(s/fdef rh/type
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :fhir.resource/type)
-
-(s/fdef rh/id
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.resource/id)
-
-(s/fdef rh/t
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.db/t)
-
-(s/fdef rh/hash
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.resource/hash)
-
-(s/fdef rh/num-changes
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.db/num-changes)
-
-(s/fdef rh/op
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.db/op)
-
-(s/fdef rh/reference
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.fhir/literal-ref)
-
-(s/fdef rh/local-ref-tuple
-  :args (s/cat :rh rh/resource-handle?)
-  :ret :blaze.fhir/literal-ref-tuple)
-
 (s/fdef rh/tid-id
-  :args (s/cat :rh rh/resource-handle?)
+  :args (s/cat :resource-handle :blaze.db/resource-handle)
   :ret byte-string?)

--- a/modules/db/test/blaze/db/impl/index/resource_handle_test.clj
+++ b/modules/db/test/blaze/db/impl/index/resource_handle_test.clj
@@ -1,119 +1,58 @@
 (ns blaze.db.impl.index.resource-handle-test
-  (:refer-clojure :exclude [hash])
   (:require
-   [blaze.db.impl.index.resource-handle :as rh]
+   [blaze.db.impl.codec :as codec]
+   [blaze.db.impl.index.resource-handle]
    [blaze.db.impl.index.resource-handle-spec]
    [blaze.fhir.hash :as hash]
    [blaze.test-util :as tu :refer [satisfies-prop]]
    [clojure.spec.alpha :as s]
+   [clojure.spec.gen.alpha :as sg]
    [clojure.spec.test.alpha :as st]
    [clojure.test :as test :refer [are deftest is testing]]
-   [clojure.test.check.properties :as prop]))
+   [clojure.test.check.properties :as prop])
+  (:import
+   [blaze.db.impl.index ResourceHandle]))
 
+(set! *warn-on-reflection* true)
 (st/instrument)
 
 (test/use-fixtures :each tu/fixture)
 
-(def ^:private hash
-  (hash/generate {:fhir/type :fhir/Patient :id "0"}))
-
-(defn- resource-handle
-  ([tid id]
-   (resource-handle tid id 0))
-  ([tid id t]
-   (resource-handle tid id t hash))
-  ([tid id t hash]
-   (resource-handle tid id t hash 0))
-  ([tid id t hash num-changes]
-   (resource-handle tid id t hash num-changes :create))
-  ([tid id t hash num-changes op]
-   (rh/->ResourceHandle tid id t hash num-changes op)))
+(defn- resource-handle [type id t]
+  (let [fhir-type (keyword "fhir" type)]
+    (ResourceHandle. fhir-type (codec/tid type) id t
+                     (hash/generate {:fhir/type fhir-type :id id}) 0)))
 
 (deftest state->num-changes-test
-  (are [state num-changes] (= num-changes
-                              (rh/state->num-changes state)
-                              (apply rh/state->num-changes [state]))
+  (are [state num-changes] (= num-changes (ResourceHandle/numChanges state))
     0 0
     256 1
     512 2))
 
-(deftest deleted-test
-  (are [rh] (and (rh/deleted? rh) (apply rh/deleted? [rh]))
-    (resource-handle 0 "0" 0 hash 0 :delete)))
-
-(deftest tid-test
-  (satisfies-prop 100
-    (prop/for-all [tid (s/gen :blaze.db/tid)]
-      (let [rh (resource-handle tid "foo")]
-        (= tid (:tid rh) (rh/tid rh) (apply rh/tid [rh]))))))
-
-(deftest id-test
-  (satisfies-prop 100
-    (prop/for-all [id (s/gen :blaze.resource/id)]
-      (let [rh (resource-handle 0 id)]
-        (= id (:id rh) (rh/id rh) (apply rh/id [rh]))))))
-
-(deftest t-test
-  (satisfies-prop 100
-    (prop/for-all [t (s/gen :blaze.db/t)]
-      (let [rh (resource-handle 0 "foo" t)]
-        (= t (:t rh) (rh/t rh) (apply rh/t [rh]))))))
-
-(deftest hash-test
-  (satisfies-prop 100
-    (prop/for-all [hash (s/gen :blaze.resource/hash)]
-      (let [rh (resource-handle 0 "foo" 0 hash)]
-        (= hash (:hash rh) (rh/hash rh) (apply rh/hash [rh]))))))
-
-(deftest num-changes-test
-  (satisfies-prop 100
-    (prop/for-all [num-changes (s/gen :blaze.db/num-changes)]
-      (let [rh (resource-handle 0 "foo" 0 hash num-changes)]
-        (= num-changes (:num-changes rh) (rh/num-changes rh) (apply rh/num-changes [rh]))))))
-
-(deftest op-test
-  (satisfies-prop 10
-    (prop/for-all [op (s/gen :blaze.db/op)]
-      (let [rh (resource-handle 0 "foo" 0 hash 0 op)]
-        (= op (:op rh) (rh/op rh) (apply rh/op [rh]))))))
-
-(deftest reference-test
-  (satisfies-prop 100
-    (prop/for-all [id (s/gen :blaze.resource/id)]
-      (let [rh (resource-handle 1495153489 id)]
-        (= (str "Condition/" id)
-           (rh/reference rh))))))
-
-(deftest local-ref-tuple-test
-  (satisfies-prop 100
-    (prop/for-all [id (s/gen :blaze.resource/id)]
-      (let [rh (resource-handle 1495153489 id)]
-        (= ["Condition" id]
-           (rh/local-ref-tuple rh))))))
-
 (deftest not-found-key-test
-  (is (nil? (:foo (resource-handle 0 "foo"))))
-  (is (= ::not-found (:foo (resource-handle 0 "foo") ::not-found))))
+  (is (nil? (:foo (resource-handle "Patient" "foo" 0))))
+  (is (= ::not-found (:foo (resource-handle "Patient" "foo" 0) ::not-found))))
 
 (deftest equals-test
   (satisfies-prop 100
-    (prop/for-all [tid (s/gen :blaze.db/tid)
+    (prop/for-all [type (sg/elements ["Patient" "Observation" "Condition"])
                    id (s/gen :blaze.resource/id)
                    t (s/gen :blaze.db/t)]
 
       (testing "same instance"
-        (let [rh (resource-handle tid id t)]
+        (let [rh (resource-handle type id t)]
           (= rh rh)))
 
       (testing "separate instances"
-        (let [rh-1 (resource-handle tid id t)
-              rh-2 (resource-handle tid id t)]
+        (let [rh-1 (resource-handle type id t)
+              rh-2 (resource-handle type id t)]
           (= rh-1 rh-2))))))
 
 (deftest to-string-test
   (satisfies-prop 100
-    (prop/for-all [id (s/gen :blaze.resource/id)
+    (prop/for-all [type (sg/elements ["Patient" "Observation" "Condition"])
+                   id (s/gen :blaze.resource/id)
                    t (s/gen :blaze.db/t)]
 
-      (= (format "Condition[id = %s, t = %d]" id t)
-         (str (resource-handle 1495153489 id t))))))
+      (= (format "%s[id = %s, t = %d]" type id t)
+         (str (resource-handle type id t))))))

--- a/modules/db/test/blaze/db/impl/index/rts_as_of_test_util.clj
+++ b/modules/db/test/blaze/db/impl/index/rts_as_of_test_util.clj
@@ -1,9 +1,11 @@
 (ns blaze.db.impl.index.rts-as-of-test-util
   (:require
    [blaze.byte-buffer :as bb]
-   [blaze.db.impl.index.resource-handle :as rh]
-   [blaze.fhir.hash :as hash]))
+   [blaze.fhir.hash :as hash])
+  (:import
+   [blaze.db.impl.index ResourceHandle]))
 
+(set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
 (defn decode-val [byte-array]
@@ -12,7 +14,7 @@
         state (bb/get-long! buf)]
     (cond->
      {:hash hash
-      :num-changes (rh/state->num-changes state)
-      :op (rh/state->op state)}
+      :num-changes (ResourceHandle/numChanges state)
+      :op (ResourceHandle/op state)}
       (<= 8 (bb/remaining buf))
       (assoc :purged-at (bb/get-long! buf)))))

--- a/modules/db/test/blaze/db/impl/search_param/date_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/date_test.clj
@@ -166,8 +166,7 @@
                  (sr/get search-param-registry "date" "Encounter")
                  [] hash encounter)]
 
-            (testing "the entry is about the min bound as lower bound and the
-                    upper bound of the end of the period"
+            (testing "the entry is about the min bound as lower bound and the upper bound of the end of the period"
               (given (sp-vr-tu/decode-key-human (bb/wrap k0))
                 :code := "date"
                 :type := "Encounter"
@@ -176,7 +175,7 @@
                 :id := "id-160224"
                 :hash-prefix := (hash/prefix hash)))))
 
-        (testing "Encounter date without end"
+        (testing "without end"
           (let [encounter
                 {:fhir/type :fhir/Encounter :id "id-160224"
                  :period
@@ -188,12 +187,30 @@
                  (sr/get search-param-registry "date" "Encounter")
                  [] hash encounter)]
 
-            (testing "the entry is about the lower bound of the start and the max
-                    upper bound"
+            (testing "the entry is about the lower bound of the start and the max upper bound"
               (given (sp-vr-tu/decode-key-human (bb/wrap k0))
                 :code := "date"
                 :type := "Encounter"
                 [:v-hash lower-bound-instant] := (Instant/parse "2019-11-16T23:14:29Z")
+                [:v-hash upper-bound-instant] := (Instant/parse "9999-12-31T23:59:59Z")
+                :id := "id-160224"
+                :hash-prefix := (hash/prefix hash)))))
+
+        (testing "without start and end"
+          (let [encounter
+                {:fhir/type :fhir/Encounter :id "id-160224"
+                 :period #fhir/Period{}}
+                hash (hash/generate encounter)
+                [[_ k0]]
+                (index-entries
+                 (sr/get search-param-registry "date" "Encounter")
+                 [] hash encounter)]
+
+            (testing "the entry is about the min bound of the start and the max upper bound"
+              (given (sp-vr-tu/decode-key-human (bb/wrap k0))
+                :code := "date"
+                :type := "Encounter"
+                [:v-hash lower-bound-instant] := (Instant/parse "0001-01-01T00:00:00Z")
                 [:v-hash upper-bound-instant] := (Instant/parse "9999-12-31T23:59:59Z")
                 :id := "id-160224"
                 :hash-prefix := (hash/prefix hash)))))))

--- a/modules/db/test/blaze/db/impl/search_param/token_test.clj
+++ b/modules/db/test/blaze/db/impl/search_param/token_test.clj
@@ -296,10 +296,10 @@
             :v-hash := (codec/v-hash "system-171339|")))))
 
     (testing "Patient active"
-      (doseq [active [#fhir/boolean true #fhir/boolean false]]
+      (doseq [active [true false]]
         (let [patient
               {:fhir/type :fhir/Patient :id "id-122929"
-               :active active}
+               :active (type/boolean active)}
               hash (hash/generate patient)
               [[_ k0] [_ k1]]
               (index-entries
@@ -310,7 +310,7 @@
             (given (sp-vr-tu/decode-key-human (bb/wrap k0))
               :code := "active"
               :type := "Patient"
-              :v-hash := (codec/v-hash (str (type/value active)))
+              :v-hash := (codec/v-hash (str active))
               :id := "id-122929"
               :hash-prefix := (hash/prefix hash)))
 
@@ -320,7 +320,7 @@
               :id := "id-122929"
               :hash-prefix := (hash/prefix hash)
               :code := "active"
-              :v-hash := (codec/v-hash (str (type/value active)))))))
+              :v-hash := (codec/v-hash (str active))))))
 
       (testing "boolean without values doesn't produce index entries"
         (let [patient

--- a/modules/db/test/blaze/db/node/util_spec.clj
+++ b/modules/db/test/blaze/db/node/util_spec.clj
@@ -1,10 +1,12 @@
 (ns blaze.db.node.util-spec
   (:require
    [blaze.db.node.util :as node-util]
+   [blaze.db.resource-store :as rs]
    [blaze.db.spec]
    [blaze.fhir.spec.spec]
    [clojure.spec.alpha :as s]))
 
 (s/fdef node-util/rs-key
   :args (s/cat :resource-handle :blaze.db/resource-handle
-               :variant :blaze.resource/variant))
+               :variant :blaze.resource/variant)
+  :ret ::rs/key)

--- a/modules/db/test/blaze/db/resource_cache_test.clj
+++ b/modules/db/test/blaze/db/resource_cache_test.clj
@@ -98,17 +98,17 @@
                        code-system-0-hash code-system-0})
 
       (are [key resource] (= resource @(rs/get cache key))
-        ["Patient" patient-0-hash :complete] patient-0
-        ["Patient" patient-1-hash :complete] patient-1
-        ["CodeSystem" code-system-0-hash :complete] code-system-0
-        ["CodeSystem" code-system-0-hash :summary] {:fhir/type :fhir/CodeSystem :id "0"
-                                                    :meta (type/meta {:tag [fu/subsetted]})}
-        ["CodeSystem" code-system-0-hash :complete] code-system-0)))
+        [:fhir/Patient patient-0-hash :complete] patient-0
+        [:fhir/Patient patient-1-hash :complete] patient-1
+        [:fhir/CodeSystem code-system-0-hash :complete] code-system-0
+        [:fhir/CodeSystem code-system-0-hash :summary] {:fhir/type :fhir/CodeSystem :id "0"
+                                                        :meta (type/meta {:tag [fu/subsetted]})}
+        [:fhir/CodeSystem code-system-0-hash :complete] code-system-0)))
 
   (testing "not-found"
     (with-system [{cache :blaze.db/resource-cache} config]
 
-      (is (nil? @(rs/get cache ["Patient" patient-0-hash :complete]))))))
+      (is (nil? @(rs/get cache [:fhir/Patient patient-0-hash :complete]))))))
 
 (deftest multi-get-test
   (testing "found both"
@@ -116,29 +116,29 @@
       @(rs/put! store {patient-0-hash patient-0
                        patient-1-hash patient-1})
 
-      (is (= {["Patient" patient-0-hash :complete] patient-0
-              ["Patient" patient-1-hash :complete] patient-1}
+      (is (= {[:fhir/Patient patient-0-hash :complete] patient-0
+              [:fhir/Patient patient-1-hash :complete] patient-1}
              @(st/with-instrument-disabled
-                (rs/multi-get cache [["Patient" patient-0-hash :complete]
-                                     ["Patient" patient-1-hash :complete]]))))))
+                (rs/multi-get cache [[:fhir/Patient patient-0-hash :complete]
+                                     [:fhir/Patient patient-1-hash :complete]]))))))
 
   (testing "found one"
     (with-system [{cache :blaze.db/resource-cache store ::rs/kv} config]
       @(rs/put! store {patient-0-hash patient-0})
 
-      (is (= {["Patient" patient-0-hash :complete] patient-0}
+      (is (= {[:fhir/Patient patient-0-hash :complete] patient-0}
              @(st/with-instrument-disabled
-                (rs/multi-get cache [["Patient" patient-0-hash :complete]
-                                     ["Patient" patient-1-hash :complete]])))))))
+                (rs/multi-get cache [[:fhir/Patient patient-0-hash :complete]
+                                     [:fhir/Patient patient-1-hash :complete]])))))))
 
 (deftest put-test
   (with-system [{cache :blaze.db/resource-cache store ::rs/kv} config]
     (is (nil? @(rs/put! cache {patient-0-hash patient-0
                                patient-1-hash patient-1})))
-    (is (= {["Patient" patient-0-hash :complete] patient-0
-            ["Patient" patient-1-hash :complete] patient-1}
-           @(rs/multi-get store [["Patient" patient-0-hash :complete]
-                                 ["Patient" patient-1-hash :complete]])))))
+    (is (= {[:fhir/Patient patient-0-hash :complete] patient-0
+            [:fhir/Patient patient-1-hash :complete] patient-1}
+           @(rs/multi-get store [[:fhir/Patient patient-0-hash :complete]
+                                 [:fhir/Patient patient-1-hash :complete]])))))
 
 (deftest stats-test
   (with-system [{cache :blaze.db/resource-cache store ::rs/kv} config]
@@ -146,13 +146,13 @@
     (is (zero? (ccp/-estimated-size cache)))
 
     @(rs/put! store {patient-0-hash patient-0})
-    @(rs/get cache ["Patient" patient-0-hash :complete])
+    @(rs/get cache [:fhir/Patient patient-0-hash :complete])
 
     (is (= 1 (.missCount ^CacheStats (ccp/-stats cache))))
     (is (zero? (.hitCount ^CacheStats (ccp/-stats cache))))
     (is (= 1 (ccp/-estimated-size cache)))
 
-    @(rs/get cache ["Patient" patient-0-hash :complete])
+    @(rs/get cache [:fhir/Patient patient-0-hash :complete])
 
     (is (= 1 (.missCount ^CacheStats (ccp/-stats cache))))
     (is (= 1 (.hitCount ^CacheStats (ccp/-stats cache))))
@@ -161,7 +161,7 @@
 (deftest invalidate-all-test
   (with-system [{cache :blaze.db/resource-cache store ::rs/kv} config]
     @(rs/put! store {patient-0-hash patient-0})
-    @(rs/get cache ["Patient" patient-0-hash :complete])
+    @(rs/get cache [:fhir/Patient patient-0-hash :complete])
 
     (is (= 1 (ccp/-estimated-size cache)))
 

--- a/modules/db/test/blaze/db/search_param_registry_test.clj
+++ b/modules/db/test/blaze/db/search_param_registry_test.clj
@@ -5,7 +5,6 @@
    [blaze.db.search-param-registry :as sr]
    [blaze.db.search-param-registry-spec]
    [blaze.fhir-path :as fhir-path]
-   [blaze.fhir.spec.type]
    [blaze.fhir.test-util :refer [structure-definition-repo]]
    [blaze.module.test-util :refer [given-failed-system with-system]]
    [blaze.test-util :as tu]

--- a/modules/fhir-client/src/blaze/fhir_client/impl.clj
+++ b/modules/fhir-client/src/blaze/fhir_client/impl.clj
@@ -43,7 +43,7 @@
     (if (ba/anomaly? data)
       (assoc data ::anom/category ::anom/fault)
       (cond-> (anomaly* data)
-        (identical? :fhir/OperationOutcome (-> data :body fhir-spec/fhir-type))
+        (identical? :fhir/OperationOutcome (-> data :body :fhir/type))
         (assoc :fhir/issues (-> data :body :issue))))))
 
 (defn- handle-error [e]

--- a/modules/interaction/src/blaze/interaction/create.clj
+++ b/modules/interaction/src/blaze/interaction/create.clj
@@ -9,7 +9,6 @@
    [blaze.db.api :as d]
    [blaze.db.spec]
    [blaze.fhir.response.create :as response]
-   [blaze.fhir.spec.type :as type]
    [blaze.handler.util :as handler-util]
    [blaze.interaction.util :as iu]
    [blaze.module :as m]
@@ -39,7 +38,7 @@
 
 (defn- resource-content-not-found-msg [{:blaze.db/keys [resource-handle]}]
   (format "The resource `%s/%s` was successfully created but it's content with hash `%s` was not found during response creation."
-          (name (type/type resource-handle)) (:id resource-handle)
+          (name (:fhir/type resource-handle)) (:id resource-handle)
           (:hash resource-handle)))
 
 (defn- handler [{:keys [node] :as context}]

--- a/modules/interaction/src/blaze/interaction/history/system.clj
+++ b/modules/interaction/src/blaze/interaction/history/system.clj
@@ -6,7 +6,6 @@
    [blaze.async.comp :as ac]
    [blaze.db.api :as d]
    [blaze.db.spec]
-   [blaze.fhir.spec :as fhir-spec]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.interaction.history.util :as history-util]
    [blaze.interaction.search.util :as search-util]
@@ -30,7 +29,7 @@
   (->> (history-util/page-nav-url
         context query-params
         (:t resource-handle)
-        (-> resource-handle fhir-spec/fhir-type name)
+        (-> resource-handle :fhir/type name)
         (:id resource-handle))
        (link "next")))
 

--- a/modules/interaction/src/blaze/interaction/search/include.clj
+++ b/modules/interaction/src/blaze/interaction/search/include.clj
@@ -1,7 +1,6 @@
 (ns blaze.interaction.search.include
   (:require
-   [blaze.db.api :as d]
-   [blaze.fhir.spec :as fhir-spec]))
+   [blaze.db.api :as d]))
 
 (defn- forward-includes* [db handle {:keys [code target-type]}]
   (if target-type
@@ -17,14 +16,14 @@
    (comp
     (mapcat #(forward-includes* db handle %))
     (mapcat #(into [%] (forward-includes db include-defs :iterate %))))
-   (get-in include-defs [key :forward (name (fhir-spec/fhir-type handle))])))
+   (get-in include-defs [key :forward (name (:fhir/type handle))])))
 
 (defn- reverse-includes [db include-defs key handle]
   (into
    []
    (mapcat #(reverse-includes* db handle %))
    (concat
-    (get-in include-defs [key :reverse (name (fhir-spec/fhir-type handle))])
+    (get-in include-defs [key :reverse (name (:fhir/type handle))])
     (get-in include-defs [key :reverse :any]))))
 
 (defn- includes [db include-defs key handle]

--- a/modules/interaction/src/blaze/interaction/transaction.clj
+++ b/modules/interaction/src/blaze/interaction/transaction.clj
@@ -119,7 +119,7 @@
 
 (defn- resource-content-not-found-msg [{:blaze.db/keys [resource-handle]}]
   (format "The transaction was successful but the resource content of `%s/%s` with hash `%s` was not found during response creation."
-          (name (type/type resource-handle)) (:id resource-handle)
+          (name (:fhir/type resource-handle)) (:id resource-handle)
           (:hash resource-handle)))
 
 (defn- resource-content-not-found-anom [e]

--- a/modules/interaction/src/blaze/interaction/update.clj
+++ b/modules/interaction/src/blaze/interaction/update.clj
@@ -7,7 +7,6 @@
    [blaze.async.comp :as ac]
    [blaze.db.api :as d]
    [blaze.fhir.response.create :as response]
-   [blaze.fhir.spec.type :as type]
    [blaze.fhir.util :as fu]
    [blaze.handler.util :as handler-util]
    [blaze.interaction.util :as iu]
@@ -64,7 +63,7 @@
 
 (defn- resource-content-not-found-msg [{:blaze.db/keys [resource-handle]}]
   (format "The resource `%s/%s` was successfully updated but it's content with hash `%s` was not found during response creation."
-          (name (type/type resource-handle)) (:id resource-handle)
+          (name (:fhir/type resource-handle)) (:id resource-handle)
           (:hash resource-handle)))
 
 (defn- update-resource

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/cql.clj
@@ -8,7 +8,6 @@
    [blaze.elm.expression :as expr]
    [blaze.elm.resource :as cr]
    [blaze.elm.util :as elm-util]
-   [blaze.fhir.spec :as fhir-spec]
    [taoensso.timbre :as log]))
 
 (set! *warn-on-reflection* true)
@@ -249,9 +248,9 @@
         (function-def context name)
         (missing-expression-anom name))))
 
-(defn- incorrect-stratum-msg [{:keys [id] :as resource} expression-name]
+(defn- incorrect-stratum-msg [{:fhir/keys [type] :keys [id]} expression-name]
   (format "CQL expression `%s` returned more than one value for resource `%s/%s`."
-          expression-name (-> resource fhir-spec/fhir-type name) id))
+          expression-name (name type) id))
 
 (defn- evaluate-stratum-expression [context subject name expression]
   (let [result (evaluate-expression-1* context subject name expression)]

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure.clj
@@ -14,7 +14,6 @@
    [blaze.fhir.operation.evaluate-measure.measure.population :as pop]
    [blaze.fhir.operation.evaluate-measure.measure.stratifier :as strat]
    [blaze.fhir.operation.evaluate-measure.measure.util :as u]
-   [blaze.fhir.spec :as fhir-spec]
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.luid :as luid]
@@ -108,7 +107,8 @@
 
 (defn- non-deleted-library-handle [db id]
   (when-let [handle (d/resource-handle db "Library" id)]
-    (when-not (= (:op handle) :delete) handle)))
+    (when-not (d/deleted? handle)
+      handle)))
 
 (defn- find-library-handle [db library-ref]
   (if-let [handle (first-library-by-url db library-ref)]
@@ -350,7 +350,7 @@
       (type/quantity {:value (type/decimal (bigdec (count bloom-filters)))})})}))
 
 (defn- local-ref [handle]
-  (str (name (fhir-spec/fhir-type handle)) "/" (:id handle)))
+  (str (name (:fhir/type handle)) "/" (:id handle)))
 
 (defn- measure-report
   [{:keys [now report-type subject-handle bloom-filters] :as context} measure

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/util.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/measure/util.clj
@@ -35,8 +35,8 @@
 (defn list-reference [list-id]
   (type/reference {:reference (type/string (str "List/" list-id))}))
 
-(defn- resource-reference [{:keys [id] :as resource}]
-  (type/reference {:reference (type/string (str (name (type/type resource)) "/" id))}))
+(defn- resource-reference [resource]
+  (type/reference {:reference (type/string (str (name (:fhir/type resource)) "/" (:id resource)))}))
 
 (defn population-tx-ops [list-id handles]
   [[:create

--- a/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
+++ b/modules/operation-measure-evaluate-measure/src/blaze/fhir/operation/evaluate_measure/middleware/params.clj
@@ -4,7 +4,6 @@
    [blaze.async.comp :as ac]
    [blaze.fhir.operation.evaluate-measure.measure :as-alias measure]
    [blaze.fhir.operation.evaluate-measure.measure.spec]
-   [blaze.fhir.spec :as fhir-spec]
    [blaze.fhir.spec.type :as type]
    [blaze.fhir.spec.type.system :as system]
    [clojure.spec.alpha :as s]))
@@ -43,7 +42,7 @@
   (if (string? value) value (invalid-string-param-anom name value)))
 
 (defn- get-param-value-from-resource [body name]
-  (when (identical? :fhir/Parameters (fhir-spec/fhir-type body))
+  (when (identical? :fhir/Parameters (:fhir/type body))
     (some #(when (= name (-> % :name type/value)) (-> % :value type/value))
           (:parameter body))))
 

--- a/modules/rest-util/src/blaze/fhir/response/create.clj
+++ b/modules/rest-util/src/blaze/fhir/response/create.clj
@@ -3,7 +3,6 @@
   (:require
    [blaze.async.comp :as ac :refer [do-sync]]
    [blaze.db.api :as d]
-   [blaze.fhir.spec :as fhir-spec]
    [blaze.handler.fhir.util :as fhir-util]
    [blaze.util :refer [str]]
    [ring.util.response :as ring]
@@ -28,7 +27,7 @@
 
 (defn build-response
   [{:blaze/keys [db] :as context} tx-op old-handle {:keys [id] :as new-handle}]
-  (let [type (name (fhir-spec/fhir-type new-handle))
+  (let [type (name (:fhir/type new-handle))
         tx (d/tx db (:t new-handle))
         vid (str (:blaze.db/t tx))
         created (and (not (keep? tx-op))


### PR DESCRIPTION
Resource handle is now a Java class with keyword lookup sites. They allow for efficient keyword lookup of the data of resource handle. Gone are all access functions in the resource-handle namespace.

Removed the FhirType protocol from resource handle and CQL resource. Fhir type information is accessed by the :fhir/type keyword.

Keys of the resource store now contain the fhir type of the resource as keyword like :fhir/Patient instead of the string "Patient". This ensures that the type part of the keys is always interned.