### PR TITLE
Refactor d/pull-many

### DIFF
--- a/modules/db-protocols/src/blaze/db/impl/protocols.clj
+++ b/modules/db-protocols/src/blaze/db/impl/protocols.clj
@@ -104,7 +104,7 @@
 
   (-pull-content [pull resource-handle variant])
 
-  (-pull-many [pull resource-handles variant]))
+  (-pull-many [pull resource-handles opts]))
 
 (defprotocol SearchParam
   (-compile-value [search-param modifier value] "Can return an anomaly.")

--- a/modules/db/src/blaze/db/api.clj
+++ b/modules/db/src/blaze/db/api.clj
@@ -528,17 +528,20 @@
   "Returns a CompletableFuture that will complete with a vector of all resources
   of all `resource-handles` in the same order.
 
-  Optional, `variant` can be given which is either a content variant like
-  :complete or :summary or a list of top-level keys to return instead of all
-  keys (elements). Certain mandatory and modifier elements are returned
-  regardless of if they are specified in `variant`. In addition the resources
-  are marked with the tag SUBSETTED in this case.
+  The following options are available:
+  * :variant - which is either :complete or :summary
+  * :elements - a list of top-level keys to return instead of all
+
+  Certain mandatory and modifier elements are returned regardless of not being
+  specified in :elements. In addition the resources are marked with the tag
+  SUBSETTED if one of :variant :summary or :elements are given.
 
   Returns a failed CompletableFuture if one pull fails."
+  {:arglists '([node-or-db resource-handles opts?])}
   ([node-or-db resource-handles]
-   (p/-pull-many node-or-db resource-handles :complete))
-  ([node-or-db resource-handles variant]
-   (p/-pull-many node-or-db resource-handles variant)))
+   (p/-pull-many node-or-db resource-handles {}))
+  ([node-or-db resource-handles opts]
+   (p/-pull-many node-or-db resource-handles opts)))
 
 ;; ---- (Re) Index ------------------------------------------------------------
 

--- a/modules/db/src/blaze/db/api_spec.clj
+++ b/modules/db/src/blaze/db/api_spec.clj
@@ -281,9 +281,8 @@
 
 (s/fdef d/pull-many
   :args (s/cat :node-or-db (s/or :node :blaze.db/node :db :blaze.db/db)
-               :resource-handles (cs/coll-of :blaze.db/resource-handle)
-               :variant (s/? (s/or :variant :blaze.resource/variant
-                                   :elements (s/coll-of keyword?))))
+               :resource-handles (s/coll-of :blaze.db/resource-handle)
+               :opts (s/? (s/keys :opt-un [:blaze.resource/variant :blaze.resource/elements])))
   :ret ac/completable-future?)
 
 (s/fdef d/re-index-total

--- a/modules/db/src/blaze/db/impl/batch_db.clj
+++ b/modules/db/src/blaze/db/impl/batch_db.clj
@@ -267,8 +267,8 @@
   (-pull-content [_ resource-handle variant]
     (p/-pull-content node resource-handle variant))
 
-  (-pull-many [_ resource-handles variant]
-    (p/-pull-many node resource-handles variant))
+  (-pull-many [_ resource-handles opts]
+    (p/-pull-many node resource-handles opts))
 
   AutoCloseable
   (close [_]

--- a/modules/db/src/blaze/db/impl/db.clj
+++ b/modules/db/src/blaze/db/impl/db.clj
@@ -237,8 +237,8 @@
   (-pull-content [_ resource-handle variant]
     (p/-pull-content node resource-handle variant))
 
-  (-pull-many [_ resource-handles variant]
-    (p/-pull-many node resource-handles variant)))
+  (-pull-many [_ resource-handles opts]
+    (p/-pull-many node resource-handles opts)))
 
 (defmethod print-method Db [^Db db ^Writer w]
   (.write w (format "Db[t=%d]" (.t db))))

--- a/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
+++ b/modules/fhir-structure/src/blaze/fhir/spec/spec.clj
@@ -28,6 +28,9 @@
 (s/def :blaze.resource/variant
   #{:complete :summary})
 
+(s/def :blaze.resource/elements
+  (s/coll-of simple-keyword?))
+
 (s/def :fhir/Resource
   #(s2/valid? :fhir/Resource %))
 

--- a/modules/interaction/src/blaze/interaction/history/instance.clj
+++ b/modules/interaction/src/blaze/interaction/history/instance.clj
@@ -33,7 +33,7 @@
         next-link (partial next-link context query-params)]
     ;; we need to take here again because we take page-size + 1 above
     (-> (d/pull-many db (into [] (take page-size) paged-version-handles)
-                     (fhir-util/summary query-params))
+                     {:variant (fhir-util/summary query-params)})
         (ac/exceptionally
          #(assoc %
                  ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/history/system.clj
+++ b/modules/interaction/src/blaze/interaction/history/system.clj
@@ -40,7 +40,7 @@
         next-link (partial next-link context query-params)]
     ;; we need to take here again because we take page-size + 1 above
     (-> (d/pull-many db (into [] (take page-size) paged-version-handles)
-                     (fhir-util/summary query-params))
+                     {:variant (fhir-util/summary query-params)})
         (ac/exceptionally
          #(assoc %
                  ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/history/type.clj
+++ b/modules/interaction/src/blaze/interaction/history/type.clj
@@ -35,7 +35,7 @@
         next-link (partial next-link context query-params)]
     ;; we need to take here again because we take page-size + 1 above
     (-> (d/pull-many db (into [] (take page-size) paged-version-handles)
-                     (fhir-util/summary query-params))
+                     {:variant (fhir-util/summary query-params)})
         (ac/exceptionally
          #(assoc %
                  ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/search_system.clj
+++ b/modules/interaction/src/blaze/interaction/search_system.clj
@@ -32,7 +32,7 @@
   (into [] (take (inc page-size)) (handles* context)))
 
 (defn- entries [{:blaze/keys [db] :keys [pull-variant] :as context}]
-  (-> (d/pull-many db (handles context) pull-variant)
+  (-> (d/pull-many db (handles context) {:variant pull-variant})
       (ac/exceptionally
        #(assoc %
                ::anom/category ::anom/fault

--- a/modules/interaction/src/blaze/interaction/search_type.clj
+++ b/modules/interaction/src/blaze/interaction/search_type.clj
@@ -93,10 +93,10 @@
 (defn- pull-matches-xf [{:keys [summary elements]} db]
   (cond
     (seq elements)
-    (map #(d/pull-many db % elements))
+    (map #(d/pull-many db % {:elements elements}))
 
     (= "true" summary)
-    (map #(d/pull-many db % :summary))
+    (map #(d/pull-many db % {:variant :summary}))
 
     :else
     (map (partial d/pull-many db))))

--- a/modules/job-test-util/src/blaze/job/test_util.clj
+++ b/modules/job-test-util/src/blaze/job/test_util.clj
@@ -47,7 +47,7 @@
   ([{:blaze/keys [job-scheduler] :as system}]
    (pull-job-history system (job-id job-scheduler)))
   ([{:blaze.db.admin/keys [node]} job-id]
-   (-> (d/pull-many node (d/instance-history (d/db node) "Task" job-id))
+   (-> (d/pull-many node (vec (d/instance-history (d/db node) "Task" job-id)))
        (ac/then-apply reverse))))
 
 (defn pull-other-resource [{:blaze.db.admin/keys [node]} type id]

--- a/modules/operation-graph/src/blaze/operation/graph.clj
+++ b/modules/operation-graph/src/blaze/operation/graph.clj
@@ -26,8 +26,11 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- graph-def-query [db uri]
+  (d/type-query db "GraphDefinition" [["url" uri]]))
+
 (defn- find-graph-def [db uri]
-  (do-sync [graph-defs (d/pull-many db (d/type-query db "GraphDefinition" [["url" uri]]))]
+  (do-sync [graph-defs (d/pull-many db (vec (graph-def-query db uri)))]
     (or (first (fu/sort-by-priority graph-defs))
         (ba/not-found (format "The graph definition `%s` was not found." uri)
                       :http/status 400))))

--- a/modules/operation-graphql/src/blaze/fhir/operation/graphql.clj
+++ b/modules/operation-graphql/src/blaze/fhir/operation/graphql.clj
@@ -66,7 +66,7 @@
 (defn- resolve-type-list [type {:keys [writing-context db]} args _]
   (log/trace (format "execute %sList query" type))
   (let [result (resolve/resolve-promise)]
-    (-> (d/pull-many db (type-query db type args))
+    (-> (d/pull-many db (vec (type-query db type args)))
         (ac/when-complete
          (fn [r e]
            (resolve/deliver! result (mapv (partial write-read-json writing-context) r) (some-> e to-error)))))

--- a/modules/rest-api/src/blaze/rest_api/capabilities_handler.clj
+++ b/modules/rest-api/src/blaze/rest_api/capabilities_handler.clj
@@ -304,7 +304,7 @@
   (d/type-query db "StructureDefinition" [["type" type] ["derivation" "constraint"]]))
 
 (defn- supported-profiles [db type]
-  (do-sync [profiles (d/pull-many db (supported-profiles-query db type))]
+  (do-sync [profiles (d/pull-many db (vec (supported-profiles-query db type)))]
     (mapv profile-canonical profiles)))
 
 (defn- assoc-supported-profiles** [db {:keys [type] :as resource}]

--- a/modules/rest-api/src/blaze/rest_api/structure_definitions.clj
+++ b/modules/rest-api/src/blaze/rest_api/structure_definitions.clj
@@ -19,7 +19,7 @@
     :code #fhir/code "read-only"})
 
 (defn- structure-definitions [db]
-  (d/pull-many db (d/type-list db "StructureDefinition")))
+  (d/pull-many db (vec (d/type-list db "StructureDefinition"))))
 
 (def ^:private url-filter
   (filter #(str/starts-with? % "http://hl7.org/fhir/StructureDefinition")))

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system.clj
@@ -32,6 +32,9 @@
           (type/value url))))
    code-systems))
 
+(defn- pull-code-systems [db]
+  (d/pull-many db (vec (d/type-list db "CodeSystem")) {:variant :summary}))
+
 (defn list
   "Returns a CompletableFuture that will complete with an index of CodeSystem
   resources or complete exceptionally in case of errors.
@@ -39,7 +42,7 @@
   The index consists of a map of CodeSystem URL to a list of CodeSystem
   resources ordered by falling priority."
   [db]
-  (do-sync [code-systems (d/pull-many db (d/type-list db "CodeSystem") :summary)]
+  (do-sync [code-systems (pull-code-systems db)]
     (into
      {}
      (map

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/sct.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/sct.clj
@@ -25,6 +25,9 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- code-system-query [db url version]
+  (d/type-query db "CodeSystem" [["url" url] ["version" version]]))
+
 (defn- handles [db version]
   (cond
     (re-matches sct-u/module-only-version-pattern version)
@@ -34,7 +37,7 @@
        code-systems))
 
     :else
-    (d/pull-many db (d/type-query db "CodeSystem" [["url" url] ["version" version]]))))
+    (d/pull-many db (vec (code-system-query db url version)))))
 
 (defn- assoc-context [{:keys [version] :as code-system} context]
   (when-ok [[module-id version] (sct-u/module-version (type/value version))]

--- a/modules/terminology-service/src/blaze/terminology_service/local/code_system/util.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/code_system/util.clj
@@ -7,7 +7,7 @@
    [blaze.module :as m]))
 
 (defn code-systems [db url]
-  (d/pull-many db (d/type-query db "CodeSystem" [["url" url]])))
+  (d/pull-many db (vec (d/type-query db "CodeSystem" [["url" url]]))))
 
 (defn code-system-versions [db url]
   (do-sync [code-systems (code-systems db url)]

--- a/modules/terminology-service/src/blaze/terminology_service/local/value_set/default.clj
+++ b/modules/terminology-service/src/blaze/terminology_service/local/value_set/default.clj
@@ -9,6 +9,9 @@
 (defn- clauses [url version]
   (cond-> [["url" url]] version (conj ["version" version])))
 
+(defn- value-set-query [db url version]
+  (d/type-query db "ValueSet" (clauses url version)))
+
 (defn- not-found-msg [url version]
   (if version
     (format "The value set `%s|%s` was not found." url version)
@@ -16,6 +19,6 @@
 
 (defmethod c/find :default
   [{:keys [db]} url & [version]]
-  (do-sync [value-sets (d/pull-many db (d/type-query db "ValueSet" (clauses url version)))]
+  (do-sync [value-sets (d/pull-many db (vec (value-set-query db url version)))]
     (or (first (fu/sort-by-priority value-sets))
         (ba/not-found (not-found-msg url version)))))

--- a/modules/terminology-service/test/blaze/terminology_service/local_test.clj
+++ b/modules/terminology-service/test/blaze/terminology_service/local_test.clj
@@ -190,10 +190,13 @@
    ::loinc {}
    ::cs/sct {:release-path (path "sct-release")}))
 
+(defn- pull-type-list [node type]
+  @(d/pull-many node (vec (d/type-list (d/db node) type))))
+
 (deftest init-bcp-13-test
   (with-system [{:blaze.db/keys [node]} bcp-13-config]
     (testing "the BCP-13 code system is available"
-      (given @(d/pull-many node (d/type-list (d/db node) "CodeSystem"))
+      (given (pull-type-list node "CodeSystem")
         count := 1
         [0 :id] := "AAAAAAAAAAAAAAAA"
         [0 :url] := #fhir/uri "urn:ietf:bcp:13"))
@@ -206,7 +209,7 @@
 (deftest init-bcp-47-test
   (with-system [{:blaze.db/keys [node]} bcp-47-config]
     (testing "the BCP-47 code system is available"
-      (given @(d/pull-many node (d/type-list (d/db node) "CodeSystem"))
+      (given (pull-type-list node "CodeSystem")
         count := 1
         [0 :id] := "AAAAAAAAAAAAAAAA"
         [0 :url] := #fhir/uri "urn:ietf:bcp:47"))
@@ -219,7 +222,7 @@
 (deftest init-loinc-test
   (with-system [{:blaze.db/keys [node]} loinc-config]
     (testing "the LOINC code system is available"
-      (given @(d/pull-many node (d/type-list (d/db node) "CodeSystem"))
+      (given (pull-type-list node "CodeSystem")
         count := 1
         [0 :id] := "AAAAAAAAAAAAAAAA"
         [0 :url] := #fhir/uri "http://loinc.org"))
@@ -232,7 +235,7 @@
 (deftest init-sct-test
   (with-system [{:blaze.db/keys [node]} sct-config]
     (testing "SNOMED CT code systems are available"
-      (given @(d/pull-many node (d/type-list (d/db node) "CodeSystem"))
+      (given (pull-type-list node "CodeSystem")
         count := 25
         [0 :id] := "AAAAAAAAAAAAAAAA"
         [0 :url] := #fhir/uri "http://snomed.info/sct"))
@@ -245,7 +248,7 @@
 (deftest init-ucum-test
   (with-system [{:blaze.db/keys [node]} ucum-config]
     (testing "the UCUM code system is available"
-      (given @(d/pull-many node (d/type-list (d/db node) "CodeSystem"))
+      (given (pull-type-list node "CodeSystem")
         count := 1
         [0 :id] := "AAAAAAAAAAAAAAAA"
         [0 :url] := #fhir/uri "http://unitsofmeasure.org"))


### PR DESCRIPTION
It now requires a concrete collection instead of accepting a reducible one in order to not having to first realize it.

The variant argument is now an option map in preparation for later additions from #3086.