### PR TITLE
Refactor Resource Cache

### DIFF
--- a/dev/blaze/dev.clj
+++ b/dev/blaze/dev.clj
@@ -4,7 +4,7 @@
    [blaze.cache-collector.protocols :as ccp]
    [blaze.db.api :as d]
    [blaze.db.api-spec]
-   [blaze.db.resource-cache :as resource-cache]
+   [blaze.db.resource-cache :as rc]
    [blaze.db.resource-store :as rs]
    [blaze.db.tx-log :as tx-log]
    [blaze.elm.expression :as-alias expr]
@@ -50,13 +50,13 @@
 ;; Transaction Cache
 (comment
   (str (ccp/-stats (:blaze.db/tx-cache system)))
-  (resource-cache/invalidate-all! (:blaze.db/tx-cache system)))
+  (rc/invalidate-all! (:blaze.db/tx-cache system)))
 
 ;; Resource Cache
 (comment
   (str (ccp/-stats (:blaze.db/resource-cache system)))
   (ccp/-estimated-size (:blaze.db/resource-cache system))
-  (resource-cache/invalidate-all! (:blaze.db/resource-cache system)))
+  (rc/invalidate-all! (:blaze.db/resource-cache system)))
 
 ;; CQL Expression Cache
 (comment

--- a/modules/admin-api/test/blaze/admin_api_test.clj
+++ b/modules/admin-api/test/blaze/admin_api_test.clj
@@ -8,6 +8,7 @@
    [blaze.db.kv :as-alias kv]
    [blaze.db.kv.rocksdb :as rocksdb]
    [blaze.db.node :as node]
+   [blaze.db.resource-cache]
    [blaze.db.resource-store :as rs]
    [blaze.db.resource-store.kv :as rs-kv]
    [blaze.db.tx-log :as tx-log]
@@ -62,6 +63,7 @@
      {:tx-log (ig/ref :blaze.db.main/tx-log)
       :tx-cache (ig/ref :blaze.db.main/tx-cache)
       :indexer-executor (ig/ref :blaze.db.node.main/indexer-executor)
+      :resource-cache (ig/ref :blaze.db/resource-cache)
       :resource-store (ig/ref :blaze.db/resource-store)
       :kv-store (ig/ref :blaze.db.main/index-kv-store)
       :resource-indexer (ig/ref :blaze.db.node.main/resource-indexer)
@@ -73,12 +75,16 @@
      {:tx-log (ig/ref :blaze.db.admin/tx-log)
       :tx-cache (ig/ref :blaze.db.admin/tx-cache)
       :indexer-executor (ig/ref :blaze.db.node.admin/indexer-executor)
+      :resource-cache (ig/ref :blaze.db/resource-cache)
       :resource-store (ig/ref :blaze.db/resource-store)
       :kv-store (ig/ref :blaze.db.admin/index-kv-store)
       :resource-indexer (ig/ref :blaze.db.node.admin/resource-indexer)
       :search-param-registry (ig/ref :blaze.db/search-param-registry)
       :scheduler (ig/ref :blaze/scheduler)
       :poll-timeout (time/millis 10)}
+
+     :blaze.db/resource-cache
+     {:resource-store (ig/ref :blaze.db/resource-store)}
 
      [::tx-log/local :blaze.db.main/tx-log]
      {:kv-store (ig/ref :blaze.db.main/transaction-kv-store)

--- a/modules/db-stub/src/blaze/db/api_stub.clj
+++ b/modules/db-stub/src/blaze/db/api_stub.clj
@@ -36,12 +36,16 @@
    {:tx-log (ig/ref ::tx-log/local)
     :tx-cache (ig/ref :blaze.db/tx-cache)
     :indexer-executor (ig/ref ::node/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref ::rs/kv)
     :kv-store (ig/ref :blaze.db/index-kv-store)
     :resource-indexer (ig/ref ::node/resource-indexer)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref ::rs/kv)}
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)

--- a/modules/db/src/blaze/db/resource_cache/protocol.clj
+++ b/modules/db/src/blaze/db/resource_cache/protocol.clj
@@ -1,0 +1,6 @@
+(ns blaze.db.resource-cache.protocol)
+
+(defprotocol ResourceCache
+  (-get [cache key])
+
+  (-multi-get [cache key]))

--- a/modules/db/src/blaze/db/resource_cache/spec.clj
+++ b/modules/db/src/blaze/db/resource_cache/spec.clj
@@ -1,6 +1,10 @@
 (ns blaze.db.resource-cache.spec
   (:require
+   [blaze.db.resource-cache.protocol :as p]
    [clojure.spec.alpha :as s]))
+
+(s/def :blaze.db/resource-cache
+  #(satisfies? p/ResourceCache %))
 
 (s/def :blaze.db.resource-cache/max-size
   nat-int?)

--- a/modules/db/src/blaze/db/spec.clj
+++ b/modules/db/src/blaze/db/spec.clj
@@ -20,9 +20,6 @@
 (s/def :blaze.db/tx-cache
   #(instance? LoadingCache %))
 
-(s/def :blaze.db/resource-cache
-  :blaze.db/resource-store)
-
 (s/def :blaze.db/op
   #{:create :put :delete})
 

--- a/modules/db/test/blaze/db/resource_cache_spec.clj
+++ b/modules/db/test/blaze/db/resource_cache_spec.clj
@@ -1,5 +1,17 @@
 (ns blaze.db.resource-cache-spec
   (:require
+   [blaze.async.comp :as ac]
    [blaze.async.comp-spec]
+   [blaze.db.resource-cache :as rc]
    [blaze.db.resource-cache.spec]
-   [blaze.db.resource-store.spec]))
+   [blaze.db.resource-store :as rs]
+   [blaze.db.resource-store.spec]
+   [clojure.spec.alpha :as s]))
+
+(s/fdef rc/get
+  :args (s/cat :store :blaze.db/resource-cache :key ::rs/key)
+  :ret ac/completable-future?)
+
+(s/fdef rc/multi-get
+  :args (s/cat :store :blaze.db/resource-cache :keys (s/coll-of ::rs/key))
+  :ret ac/completable-future?)

--- a/modules/db/test/blaze/db/test_util.clj
+++ b/modules/db/test/blaze/db/test_util.clj
@@ -36,12 +36,16 @@
    {:tx-log (ig/ref ::tx-log/local)
     :tx-cache (ig/ref :blaze.db/tx-cache)
     :indexer-executor (ig/ref ::node/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref ::rs/kv)
     :kv-store (ig/ref :blaze.db/index-kv-store)
     :resource-indexer (ig/ref ::node/resource-indexer)
     :search-param-registry (:blaze.db/search-param-registry root-system)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref ::rs/kv)}
 
    ::tx-log/local
    {:kv-store (ig/ref :blaze.db/transaction-kv-store)

--- a/modules/job-async-interaction/test/blaze/job/async_interaction_test.clj
+++ b/modules/job-async-interaction/test/blaze/job/async_interaction_test.clj
@@ -65,6 +65,7 @@
    {:tx-log (ig/ref :blaze.db.main/tx-log)
     :tx-cache (ig/ref :blaze.db.main/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.main/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.main/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.main/resource-indexer)
@@ -76,12 +77,16 @@
    {:tx-log (ig/ref :blaze.db.admin/tx-log)
     :tx-cache (ig/ref :blaze.db.admin/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.admin/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.admin/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.admin/resource-indexer)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref :blaze.db/resource-store)}
 
    [::tx-log/local :blaze.db.main/tx-log]
    {:kv-store (ig/ref :blaze.db.main/transaction-kv-store)

--- a/modules/job-compact/test/blaze/job/compact_test.clj
+++ b/modules/job-compact/test/blaze/job/compact_test.clj
@@ -51,12 +51,16 @@
    {:tx-log (ig/ref :blaze.db.admin/tx-log)
     :tx-cache (ig/ref :blaze.db.admin/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.admin/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.admin/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.admin/resource-indexer)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref :blaze.db/resource-store)}
 
    [::tx-log/local :blaze.db.admin/tx-log]
    {:kv-store (ig/ref :blaze.db.admin/transaction-kv-store)

--- a/modules/job-re-index/test/blaze/job/re_index_test.clj
+++ b/modules/job-re-index/test/blaze/job/re_index_test.clj
@@ -60,6 +60,7 @@
    {:tx-log (ig/ref :blaze.db.main/tx-log)
     :tx-cache (ig/ref :blaze.db.main/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.main/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.main/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.main/resource-indexer)
@@ -71,12 +72,16 @@
    {:tx-log (ig/ref :blaze.db.admin/tx-log)
     :tx-cache (ig/ref :blaze.db.admin/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.admin/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.admin/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.admin/resource-indexer)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref :blaze.db/resource-store)}
 
    [::tx-log/local :blaze.db.main/tx-log]
    {:kv-store (ig/ref :blaze.db.main/transaction-kv-store)

--- a/modules/job-scheduler/test/blaze/job_scheduler_test.clj
+++ b/modules/job-scheduler/test/blaze/job_scheduler_test.clj
@@ -124,6 +124,7 @@
    {:tx-log (ig/ref :blaze.db.main/tx-log)
     :tx-cache (ig/ref :blaze.db.admin/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.main/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.main/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.main/resource-indexer)
@@ -135,12 +136,16 @@
    {:tx-log (ig/ref :blaze.db.admin/tx-log)
     :tx-cache (ig/ref :blaze.db.admin/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.admin/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.admin/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.admin/resource-indexer)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref :blaze.db/resource-store)}
 
    [::tx-log/local :blaze.db.main/tx-log]
    {:kv-store (ig/ref :blaze.db.main/transaction-kv-store)

--- a/modules/page-id-cipher/test/blaze/page_id_cipher_test.clj
+++ b/modules/page-id-cipher/test/blaze/page_id_cipher_test.clj
@@ -49,12 +49,16 @@
    {:tx-log (ig/ref :blaze.db.admin/tx-log)
     :tx-cache (ig/ref :blaze.db.admin/tx-cache)
     :indexer-executor (ig/ref :blaze.db.node.admin/indexer-executor)
+    :resource-cache (ig/ref :blaze.db/resource-cache)
     :resource-store (ig/ref :blaze.db/resource-store)
     :kv-store (ig/ref :blaze.db.admin/index-kv-store)
     :resource-indexer (ig/ref :blaze.db.node.admin/resource-indexer)
     :search-param-registry (ig/ref :blaze.db/search-param-registry)
     :scheduler (ig/ref :blaze/scheduler)
     :poll-timeout (time/millis 10)}
+
+   :blaze.db/resource-cache
+   {:resource-store (ig/ref :blaze.db/resource-store)}
 
    [::tx-log/local :blaze.db.admin/tx-log]
    {:kv-store (ig/ref :blaze.db.admin/transaction-kv-store)

--- a/profiling/blaze/profiling.clj
+++ b/profiling/blaze/profiling.clj
@@ -4,7 +4,7 @@
   (:require
    [blaze.cache-collector.protocols :as ccp]
    [blaze.db.kv.rocksdb :as rocksdb]
-   [blaze.db.resource-cache :as resource-cache]
+   [blaze.db.resource-cache :as rc]
    [blaze.elm.expression :as-alias expr]
    [blaze.elm.expression.cache :as ec]
    [blaze.system :as system]
@@ -42,12 +42,12 @@
 ;; Transaction Cache
 (comment
   (str (ccp/-stats (:blaze.db/tx-cache system)))
-  (resource-cache/invalidate-all! (:blaze.db/tx-cache system)))
+  (rc/invalidate-all! (:blaze.db/tx-cache system)))
 
 ;; Resource Cache
 (comment
   (str (ccp/-stats (:blaze.db/resource-cache system)))
-  (resource-cache/invalidate-all! (:blaze.db/resource-cache system)))
+  (rc/invalidate-all! (:blaze.db/resource-cache system)))
 
 ;; CQL Expression Cache
 (comment

--- a/resources/blaze.edn
+++ b/resources/blaze.edn
@@ -314,7 +314,8 @@
    :tx-log #blaze/ref :blaze.db.main/tx-log
    :tx-cache #blaze/ref :blaze.db.main/tx-cache
    :indexer-executor #blaze/ref :blaze.db.node.main/indexer-executor
-   :resource-store #blaze/ref :blaze.db/resource-cache
+   :resource-cache #blaze/ref :blaze.db/resource-cache
+   :resource-store #blaze/ref :blaze.db/resource-store
    :kv-store #blaze/ref :blaze.db.main/index-kv-store
    :resource-indexer #blaze/ref :blaze.db.node.main/resource-indexer
    :search-param-registry #blaze/ref :blaze.db/search-param-registry
@@ -332,7 +333,8 @@
    :tx-log #blaze/ref :blaze.db.admin/tx-log
    :tx-cache #blaze/ref :blaze.db.admin/tx-cache
    :indexer-executor #blaze/ref :blaze.db.node.admin/indexer-executor
-   :resource-store #blaze/ref :blaze.db/resource-cache
+   :resource-cache #blaze/ref :blaze.db/resource-cache
+   :resource-store #blaze/ref :blaze.db/resource-store
    :kv-store #blaze/ref :blaze.db.admin/index-kv-store
    :resource-indexer #blaze/ref :blaze.db.node.admin/resource-indexer
    :search-param-registry #blaze/ref :blaze.db/search-param-registry
@@ -348,7 +350,7 @@
   ;;
   [:blaze.db.node/resource-indexer :blaze.db.node.main/resource-indexer]
   {:kv-store #blaze/ref :blaze.db.main/index-kv-store
-   :resource-store #blaze/ref :blaze.db/resource-cache
+   :resource-store #blaze/ref :blaze.db/resource-store
    :search-param-registry #blaze/ref :blaze.db/search-param-registry
    :executor #blaze/ref :blaze.db.node.resource-indexer.main/executor}
 
@@ -360,7 +362,7 @@
   ;;
   [:blaze.db.node/resource-indexer :blaze.db.node.admin/resource-indexer]
   {:kv-store #blaze/ref :blaze.db.admin/index-kv-store
-   :resource-store #blaze/ref :blaze.db/resource-cache
+   :resource-store #blaze/ref :blaze.db/resource-store
    :search-param-registry #blaze/ref :blaze.db/search-param-registry
    :executor #blaze/ref :blaze.db.node.resource-indexer.admin/executor}
 


### PR DESCRIPTION
Before this change, the resource cache implemented the resource store protocol. So the resource cache was a transparent layer on top of the resource store. Normally this is a good idea but in #3086 we need additional functionality in the resource cache.

This refactoring gives the resource cache it's own protocol and set of access functions. The database node needs now both the resource cache and the resource store, because the resource cache has no longer the write functionality.

Also in case of a resource cache size of zero, a real no-op cache is returned.