### PR TITLE
Refactor History Page Building

### DIFF
--- a/modules/interaction/src/blaze/interaction/history/type.clj
+++ b/modules/interaction/src/blaze/interaction/history/type.clj
@@ -29,13 +29,11 @@
        (link "next")))
 
 (defn- build-response
-  [{:blaze/keys [db] :as context} query-params total version-handles]
+  [{:blaze/keys [db] :as context} query-params total handles]
   (let [page-size (fhir-util/page-size query-params)
-        paged-version-handles (into [] (take (inc page-size)) version-handles)
+        {:keys [handles next-handle]} (history-util/build-page page-size handles)
         next-link (partial next-link context query-params)]
-    ;; we need to take here again because we take page-size + 1 above
-    (-> (d/pull-many db (into [] (take page-size) paged-version-handles)
-                     {:variant (fhir-util/summary query-params)})
+    (-> (d/pull-many db handles (history-util/pull-opts query-params))
         (ac/exceptionally
          #(assoc %
                  ::anom/category ::anom/fault
@@ -49,8 +47,8 @@
               :entry
               (mapv (partial history-util/build-entry context) paged-versions))
 
-              (< page-size (count paged-version-handles))
-              (update :link conj-vec (next-link (peek paged-version-handles))))))))))
+              next-handle
+              (update :link conj-vec (next-link next-handle)))))))))
 
 (defmethod m/pre-init-spec :blaze.interaction.history/type [_]
   (s/keys :req [::search-util/link]
@@ -64,7 +62,7 @@
         {{:fhir.resource/keys [type]} :data} ::reitit/match}]
     (let [page-t (history-util/page-t params)
           page-id (when page-t (fhir-util/page-id params))
-          since (history-util/since params)
+          since (fhir-util/since params)
           db (cond-> db since (d/since since))
           total (d/total-num-of-type-changes db type)
           version-handles (d/type-history db type page-t page-id)

--- a/modules/interaction/test/blaze/interaction/history/util_spec.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_spec.clj
@@ -11,19 +11,9 @@
    [clojure.spec.alpha :as s]
    [reitit.core :as reitit]))
 
-(s/fdef util/since
-  :args (s/cat :query-params (s/nilable :ring.request/query-params))
-  :ret (s/nilable inst?))
-
 (s/fdef util/page-t
   :args (s/cat :query-params (s/nilable :ring.request/query-params))
   :ret (s/nilable :blaze.db/t))
-
-(s/fdef util/self-link
-  :args
-  (s/cat
-   :context (s/keys :req [::search-util/link :blaze/base-url ::reitit/match])
-   :query-params (s/nilable :ring.request/query-params)))
 
 (s/fdef util/page-nav-url
   :args

--- a/modules/interaction/test/blaze/interaction/history/util_test.clj
+++ b/modules/interaction/test/blaze/interaction/history/util_test.clj
@@ -21,22 +21,6 @@
 
 (test/use-fixtures :each tu/fixture)
 
-(deftest since-test
-  (testing "no query param"
-    (is (nil? (history-util/since {}))))
-
-  (testing "invalid query param"
-    (are [t] (nil? (history-util/since {"_since" t}))
-      "<invalid>"
-      "-1"
-      ""))
-
-  (testing "valid query param"
-    (are [v t] (= t (history-util/since {"_since" v}))
-      "2015-02-07T13:28:17+02:00" (Instant/ofEpochSecond 1423308497)
-      ["<invalid>" "2015-02-07T13:28:17+02:00"] (Instant/ofEpochSecond 1423308497)
-      ["2015-02-07T13:28:17+02:00" "2015-02-07T13:28:17Z"] (Instant/ofEpochSecond 1423308497))))
-
 (deftest page-t-test
   (testing "no query param"
     (is (nil? (history-util/page-t {}))))

--- a/modules/operation-patient-everything/src/blaze/operation/patient/everything.clj
+++ b/modules/operation-patient-everything/src/blaze/operation/patient/everything.clj
@@ -7,7 +7,6 @@
    [blaze.db.api :as d]
    [blaze.fhir.spec.type :as type]
    [blaze.handler.fhir.util :as fhir-util]
-   [blaze.interaction.history.util :as history-util]
    [blaze.interaction.search.util :as search-util]
    [blaze.interaction.search.util.spec]
    [blaze.middleware.fhir.decrypt-page-id :as decrypt-page-id]
@@ -85,7 +84,7 @@
         :keys [query-params] :as request}]
     (let [page-size (fhir-util/page-size query-params max-size nil)
           page-offset (fhir-util/page-offset query-params)
-          since (history-util/since query-params)]
+          since (fhir-util/since query-params)]
       (when-ok [start (fhir-util/date query-params "start")
                 end (fhir-util/date query-params "end")
                 {:keys [handles next-offset]}

--- a/modules/rest-util/src/blaze/handler/fhir/util.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util.clj
@@ -17,8 +17,8 @@
    [cognitect.anomalies :as anom]
    [reitit.core :as reitit])
   (:import
-   [java.time Instant ZoneId ZonedDateTime]
-   [java.time.format DateTimeFormatter]
+   [java.time Instant OffsetDateTime ZoneId ZonedDateTime]
+   [java.time.format DateTimeFormatter DateTimeParseException]
    [java.util.concurrent TimeUnit]))
 
 (set! *warn-on-reflection* true)
@@ -92,6 +92,18 @@
   {:arglists '([query-params])}
   [{v "_elements"}]
   (into [] (comp (mapcat #(str/split % #"\s*,\s*")) (remove str/blank?) (map keyword)) (u/to-seq v)))
+
+(defn since
+  "Tries to parse a valid instant out of the `_since` query param.
+
+  Returns nil on absent or invalid instant."
+  {:arglists '([query-params])}
+  [{v "_since"}]
+  (some
+   #(try
+      (Instant/from (OffsetDateTime/parse %))
+      (catch DateTimeParseException _))
+   (u/to-seq v)))
 
 (defn- incorrect-date-msg [name value]
   (format "The value `%s` of the query param `%s` is no valid date." value name))

--- a/modules/rest-util/src/blaze/handler/fhir/util_spec.clj
+++ b/modules/rest-util/src/blaze/handler/fhir/util_spec.clj
@@ -45,6 +45,10 @@
   :args (s/cat :query-params (s/nilable :ring.request/query-params))
   :ret (s/nilable (s/coll-of simple-keyword?)))
 
+(s/fdef fhir-util/since
+  :args (s/cat :query-params (s/nilable :ring.request/query-params))
+  :ret (s/nilable inst?))
+
 (s/fdef fhir-util/date
   :args (s/cat :query-params (s/nilable :ring.request/query-params)
                :name string?)

--- a/modules/rest-util/test/blaze/handler/fhir/util_test.clj
+++ b/modules/rest-util/test/blaze/handler/fhir/util_test.clj
@@ -26,7 +26,7 @@
    [reitit.core :as reitit]
    [ring.util.response :as ring])
   (:import
-   [java.time ZoneId ZonedDateTime]
+   [java.time Instant ZoneId ZonedDateTime]
    [java.time.format DateTimeFormatter]))
 
 (set! *warn-on-reflection* true)
@@ -176,6 +176,22 @@
               query-params {"_elements" values}]
           (= (set (fhir-util/elements query-params))
              (apply set/union (map (comp set :vector) fields))))))))
+
+(deftest since-test
+  (testing "no query param"
+    (is (nil? (fhir-util/since {}))))
+
+  (testing "invalid query param"
+    (are [t] (nil? (fhir-util/since {"_since" t}))
+      "<invalid>"
+      "-1"
+      ""))
+
+  (testing "valid query param"
+    (are [v t] (= t (fhir-util/since {"_since" v}))
+      "2015-02-07T13:28:17+02:00" (Instant/ofEpochSecond 1423308497)
+      ["<invalid>" "2015-02-07T13:28:17+02:00"] (Instant/ofEpochSecond 1423308497)
+      ["2015-02-07T13:28:17+02:00" "2015-02-07T13:28:17Z"] (Instant/ofEpochSecond 1423308497))))
 
 (deftest date-test
   (testing "missing"


### PR DESCRIPTION
Moved history util namespace back to module interaction because the everything module only needs since.

Moved page splitting into a single history-util/build-page function.