### PR TITLE
Perform Releases as Draft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2846,4 +2846,5 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2
       with:
+        draft: true
         files: target/blaze-*-standalone.jar


### PR DESCRIPTION
Because we will edit the release message by hand, the release should not performed finally. Otherwise notifications will go out without any release message.