### PR TITLE
Fix CVE-2025-64756: glob Command Injection

### DIFF
--- a/modules/frontend/Dockerfile
+++ b/modules/frontend/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:24-alpine@sha256:c921b97d4b74f51744057454b306b418cf693865e73b8100559189605f6955b8
 
+RUN npm r -g npm
+
 COPY build /app
-COPY package*.json /app/
 
 WORKDIR /app
 USER 1001


### PR DESCRIPTION
The fix is done by uninstalling NPM from the blaze-frontend image, as it is actually not needed. Also the package files are not needed.