### PR TITLE
Cache FHIR Packages

### DIFF
--- a/.github/validation/validate.sh
+++ b/.github/validation/validate.sh
@@ -9,6 +9,7 @@ java -jar validator_cli.jar -version 4.0.1 -level error \
   -output-style csv -output result.csv \
   -tx http://localhost:8080/fhir -authorise-non-conformant-tx-servers \
   -clear-tx-cache \
+  -ig de.basisprofil.r4#1.5.4 \
   -ig de.medizininformatikinitiative.kerndatensatz.person#2025.0.0 \
   -ig de.medizininformatikinitiative.kerndatensatz.laborbefund#2025.0.2 \
   -ig de.medizininformatikinitiative.kerndatensatz.medikation#2025.0.0 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1824,6 +1824,19 @@ jobs:
     - name: Install Validator
       run: .github/scripts/install-validator.sh
 
+    - name: Download FHIR Package Cache
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        repository: medizininformatik-initiative/fhir-package-store
+        ref: cache-store
+        path: ~/.fhir
+
+    - name: Cache FHIR Packages
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: ~/.fhir/packages
+        key: fhir-packages-integration-test-validation
+
     - name: Download Blaze Image
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
       with:
@@ -1893,6 +1906,19 @@ jobs:
 
     - name: Install Validator
       run: .github/scripts/install-validator.sh
+
+    - name: Download FHIR Package Cache
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        repository: medizininformatik-initiative/fhir-package-store
+        ref: cache-store
+        path: ~/.fhir
+
+    - name: Cache FHIR Packages
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: ~/.fhir/packages
+        key: fhir-packages-terminology-tests
 
     - name: Download Blaze Image
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7


### PR DESCRIPTION
On top of the caching, I had to download packages directly because the server https://packages2.fhir.org/packages is currently incomplete and the recovery will take days. The issue https://github.com/samply/blaze/issues/3245 tracks the removal of the extra download.