### PR TITLE
Improve Mem Size Estimation for Large Heaps

### DIFF
--- a/modules/fhir-structure/java/blaze/fhir/spec/type/Base.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/Base.java
@@ -87,7 +87,7 @@ public interface Base extends IPersistentMap, IKeywordLookup, Map<Object, Object
     /**
      * This is an estimate of a hash map entry.
      */
-    int MEM_SIZE_PERSISTENT_HASH_MAP_ENTRY = MEM_SIZE_REFERENCE == 4 ? 64 : 96;
+    int MEM_SIZE_PERSISTENT_HASH_MAP_ENTRY = MEM_SIZE_REFERENCE == 4 ? 64 : 128;
 
     /**
      * Memory size {@link java.util.concurrent.atomic.AtomicReference}.


### PR DESCRIPTION
I increased the mem size estimate for a PersistentHashMap entry from 96 bytes to 128 bytes for large heaps. For small heaps it's still 64 bytes. So now the isze is double the size for small heaps which would suggest that entries consist only of references, which is not true. Nevertheless we get frequent CI failures on the large heap test. So the estimate is sometimes wrong. With PersistentHashMaps it's not easy because the internal tree structure isn't visiable. Increasing the estimate put's us on the safe side.