### PR TITLE
Update Cassandra java-driver-core

### DIFF
--- a/modules/cassandra/deps.edn
+++ b/modules/cassandra/deps.edn
@@ -5,9 +5,8 @@
   blaze/util
   {:local/root "../util"}
 
-  com.datastax.oss/java-driver-core
-  {:mvn/version "4.17.0"
-   :exclusions [com.github.spotbugs/spotbugs-annotations]}
+  org.apache.cassandra/java-driver-core
+  {:mvn/version "4.19.2"}
 
   ;; current version of transitive dependency of com.datastax.oss/java-driver-core
   com.fasterxml.jackson.core/jackson-databind


### PR DESCRIPTION
The lib moved from com.datastax.oss to java-driver-core so Renovate didn't saw it.