### PR TITLE
Fix Mem Size Calculation of SerializedString

### DIFF
--- a/modules/fhir-structure/java/blaze/fhir/spec/type/system/Strings.java
+++ b/modules/fhir-structure/java/blaze/fhir/spec/type/system/Strings.java
@@ -20,7 +20,18 @@ public interface Strings {
      */
     int MEM_SIZE_OBJECT = (MEM_SIZE_OBJECT_HEADER + MEM_SIZE_REFERENCE + 4 + 1 + 1 + 7) & ~7;
 
-    int MEM_SIZE_SERIALIZED_STRING_OBJECT = 32;
+    /**
+     * Memory size of {@link SerializedString}.
+     * <p>
+     * 8 byte - object header
+     * 4 or 8 byte - String reference
+     * 4 or 8 byte - byte array reference
+     * 4 or 8 byte - byte array reference
+     * 4 or 8 byte - char array reference
+     * 4 or 8 byte - String reference
+     */
+    int MEM_SIZE_SERIALIZED_STRING_OBJECT = (MEM_SIZE_OBJECT_HEADER + 5 * MEM_SIZE_REFERENCE + 7) & ~7;
+
     byte HASH_MARKER = 1;
 
     @SuppressWarnings("UnstableApiUsage")

--- a/modules/fhir-structure/test/blaze/fhir/spec/memory.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec/memory.clj
@@ -1,8 +1,5 @@
 (ns blaze.fhir.spec.memory
   (:import
-   [blaze.fhir.spec.type ExtensionData]
-   [clojure.lang PersistentVector]
-   [java.time ZoneOffset]
    [org.openjdk.jol.info ClassLayout GraphLayout]))
 
 (set! *warn-on-reflection* true)
@@ -13,50 +10,20 @@
 (defn class-layout ^ClassLayout [x]
   (ClassLayout/parseInstance x))
 
-(defn total-size [& roots]
-  (-> ^GraphLayout (apply graph-layout roots)
-      (.subtract (graph-layout ExtensionData/EMPTY))
-      (.subtract (graph-layout PersistentVector/EMPTY_NODE))
-      (.subtract (graph-layout PersistentVector/EMPTY))
-      (.subtract (graph-layout ZoneOffset/UTC))
-      (.totalSize)))
-
-(defn total-size* [x y]
+(defn total-size [x y]
   (-> (graph-layout x y)
       (.subtract (graph-layout x))
       (.totalSize)))
 
-(defn total-size-exclude [x & excludes]
-  (-> (graph-layout x)
-      (.subtract (graph-layout ExtensionData/EMPTY))
-      (.subtract (graph-layout PersistentVector/EMPTY_NODE))
-      (.subtract (graph-layout PersistentVector/EMPTY))
-      (.subtract (graph-layout ZoneOffset/UTC))
-      (.subtract (apply graph-layout excludes))
-      (.totalSize)))
+(defn print-footprint [x y]
+  (-> (graph-layout x y)
+      (.subtract (graph-layout x))
+      (.toFootprint)))
 
-(defn print-layout [x & excludes]
-  (-> (graph-layout x)
-      (.subtract (graph-layout ExtensionData/EMPTY))
-      (.subtract (graph-layout PersistentVector/EMPTY_NODE))
-      (.subtract (graph-layout PersistentVector/EMPTY))
-      (.subtract (graph-layout ZoneOffset/UTC))
-      (.subtract (apply graph-layout excludes))
+(defn print-layout [x y]
+  (-> (graph-layout x y)
+      (.subtract (graph-layout x))
       (.toPrintable)))
-
-(defn print-footprint [x & excludes]
-  (-> (graph-layout x)
-      (.subtract (graph-layout ExtensionData/EMPTY))
-      (.subtract (graph-layout PersistentVector/EMPTY_NODE))
-      (.subtract (graph-layout PersistentVector/EMPTY))
-      (.subtract (graph-layout ZoneOffset/UTC))
-      (.subtract (apply graph-layout excludes))
-      (.toFootprint)))
-
-(defn print-footprint* [x y]
-  (-> (graph-layout x y)
-      (.subtract (graph-layout x))
-      (.toFootprint)))
 
 (defn print-total-layout [& roots]
   (-> ^GraphLayout (apply graph-layout roots)


### PR DESCRIPTION
For large heaps the calulation was wrong. Because #3253 isn't released yet, this is not a bug. So we can make a silent PR here.