### PR TITLE
Allow Memlock for Cassandra

### DIFF
--- a/.github/distributed-test/docker-compose.yml
+++ b/.github/distributed-test/docker-compose.yml
@@ -69,6 +69,8 @@ services:
     environment:
       CASSANDRA_SEEDS: "cassandra-1,cassandra-2"
       MAX_HEAP_SIZE: "2G"
+    ulimits:
+      memlock: -1
     healthcheck:
       test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
       start_period: 45s
@@ -83,6 +85,8 @@ services:
     environment:
       CASSANDRA_SEEDS: "cassandra-1,cassandra-2"
       MAX_HEAP_SIZE: "2G"
+    ulimits:
+      memlock: -1
     healthcheck:
       test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
       start_period: 45s


### PR DESCRIPTION
Cassandra tries to lock it's memory so that it would not be swapped out. In order to allow this, the memlock ulimit has to be set to -1 in the docker compose file.