### PR TITLE
Fix Dependency Download of prom-metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build-byte-buffer:
 	$(MAKE) -C modules/byte-buffer build
 
 prep: build-byte-buffer
+	$(MAKE) -C modules/module-base prep
 	clojure -X:deps prep
 
 test-root: prep

--- a/deps.edn
+++ b/deps.edn
@@ -86,14 +86,7 @@
   {:mvn/version "2.0.17"}
 
   org.slf4j/slf4j-jdk-platform-logging
-  {:mvn/version "2.0.17"}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+  {:mvn/version "2.0.17"}}
 
  :aliases
  {:build

--- a/modules/admin-api/Makefile
+++ b/modules/admin-api/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/admin-api/deps.edn
+++ b/modules/admin-api/deps.edn
@@ -92,14 +92,7 @@
 
   org.fhir/ucum
   {:mvn/version "1.0.10"
-   :exclusions [xpp3/xpp3 xpp3/xpp3_xpath]}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+   :exclusions [xpp3/xpp3 xpp3/xpp3_xpath]}}
 
  :aliases
  {:test

--- a/modules/cache-collector/Makefile
+++ b/modules/cache-collector/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/cql/Makefile
+++ b/modules/cql/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --fail-level error --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 cql-test:

--- a/modules/cql/deps.edn
+++ b/modules/cql/deps.edn
@@ -34,13 +34,6 @@
   org.apache.commons/commons-text
   {:mvn/version "1.15.0"}
 
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}
-
   systems.uom/systems-quantity
   {:mvn/version "2.2"}
 

--- a/modules/db-resource-store-cassandra/Makefile
+++ b/modules/db-resource-store-cassandra/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/db-resource-store/Makefile
+++ b/modules/db-resource-store/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/db-tx-log-kafka/Makefile
+++ b/modules/db-tx-log-kafka/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/db-tx-log/Makefile
+++ b/modules/db-tx-log/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --fail-level error --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test test-perf build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 build: prep

--- a/modules/extern-terminology-service/Makefile
+++ b/modules/extern-terminology-service/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/fhir-structure/Makefile
+++ b/modules/fhir-structure/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 build: prep

--- a/modules/http-client/Makefile
+++ b/modules/http-client/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/interaction/Makefile
+++ b/modules/interaction/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/jepsen/Makefile
+++ b/modules/jepsen/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/jepsen/deps.edn
+++ b/modules/jepsen/deps.edn
@@ -3,14 +3,7 @@
   {:local/root "../fhir-client"}
 
   jepsen/jepsen
-  {:mvn/version "0.3.11"}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+  {:mvn/version "0.3.11"}}
 
  :aliases
  {:test

--- a/modules/job-async-interaction/Makefile
+++ b/modules/job-async-interaction/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 build: prep

--- a/modules/job-compact/Makefile
+++ b/modules/job-compact/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 build: prep

--- a/modules/job-compact/deps.edn
+++ b/modules/job-compact/deps.edn
@@ -5,14 +5,7 @@
   {:local/root "../job-scheduler"}
 
   blaze/kv
-  {:local/root "../kv"}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+  {:local/root "../kv"}}
 
  :deps/prep-lib
  {:alias :build

--- a/modules/job-re-index/Makefile
+++ b/modules/job-re-index/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 build: prep

--- a/modules/job-scheduler/Makefile
+++ b/modules/job-scheduler/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --fail-level error --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 build: prep

--- a/modules/job-util/Makefile
+++ b/modules/job-util/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/job-util/deps.edn
+++ b/modules/job-util/deps.edn
@@ -1,13 +1,6 @@
 {:deps
  {blaze/db
-  {:local/root "../db"}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+  {:local/root "../db"}}
 
  :aliases
  {:test

--- a/modules/kv/Makefile
+++ b/modules/kv/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --fail-level error --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 build: prep

--- a/modules/metrics/Makefile
+++ b/modules/metrics/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 build: prep

--- a/modules/openid-auth/Makefile
+++ b/modules/openid-auth/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/operation-code-system-validate-code/Makefile
+++ b/modules/operation-code-system-validate-code/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-compact/Makefile
+++ b/modules/operation-compact/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-cql/Makefile
+++ b/modules/operation-cql/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-cql/deps.edn
+++ b/modules/operation-cql/deps.edn
@@ -21,14 +21,7 @@
   {:local/root "../spec"}
 
   blaze/thread-pool-executor-collector
-  {:local/root "../thread-pool-executor-collector"}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+  {:local/root "../thread-pool-executor-collector"}}
 
  :aliases
  {:test

--- a/modules/operation-graph/Makefile
+++ b/modules/operation-graph/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-graphql/Makefile
+++ b/modules/operation-graphql/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-measure-evaluate-measure/Makefile
+++ b/modules/operation-measure-evaluate-measure/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-measure-evaluate-measure/deps.edn
+++ b/modules/operation-measure-evaluate-measure/deps.edn
@@ -21,14 +21,7 @@
   {:local/root "../spec"}
 
   blaze/thread-pool-executor-collector
-  {:local/root "../thread-pool-executor-collector"}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+  {:local/root "../thread-pool-executor-collector"}}
 
  :aliases
  {:test

--- a/modules/operation-patient-everything/Makefile
+++ b/modules/operation-patient-everything/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-patient-purge/Makefile
+++ b/modules/operation-patient-purge/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-totals/Makefile
+++ b/modules/operation-totals/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-value-set-expand/Makefile
+++ b/modules/operation-value-set-expand/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/operation-value-set-validate-code/Makefile
+++ b/modules/operation-value-set-validate-code/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/page-id-cipher/Makefile
+++ b/modules/page-id-cipher/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/page-store-cassandra/Makefile
+++ b/modules/page-store-cassandra/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/page-store/Makefile
+++ b/modules/page-store/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/rest-api/Makefile
+++ b/modules/rest-api/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/rest-api/deps.edn
+++ b/modules/rest-api/deps.edn
@@ -19,14 +19,7 @@
 
   buddy/buddy-auth
   {:mvn/version "3.0.323"
-   :exclusions [buddy/buddy-sign]}
-
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}}
+   :exclusions [buddy/buddy-sign]}}
 
  :aliases
  {:test

--- a/modules/rest-util/Makefile
+++ b/modules/rest-util/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/rocksdb/Makefile
+++ b/modules/rocksdb/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/scheduler/Makefile
+++ b/modules/scheduler/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep

--- a/modules/server/Makefile
+++ b/modules/server/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 build: prep

--- a/modules/terminology-service-local/Makefile
+++ b/modules/terminology-service-local/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 build: prep

--- a/modules/terminology-service-local/deps.edn
+++ b/modules/terminology-service-local/deps.edn
@@ -27,13 +27,6 @@
   ca.uhn.hapi.fhir/org.hl7.fhir.r5
   {:mvn/version "6.8.1"}
 
-  ;; this dependency is only here because otherwise it gets loaded concurrently
-  ;; which breaks caching
-  prom-metrics/prom-metrics
-  {:git/url "https://github.com/alexanderkiel/prom-metrics.git"
-   :git/tag "v0.6-alpha.8"
-   :git/sha "45bc7368b9f6045719bc8b63ebfc82f955469da3"}
-
   ring/ring-codec
   {:mvn/version "1.3.0"}}
 

--- a/modules/terminology-service/Makefile
+++ b/modules/terminology-service/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep

--- a/modules/thread-pool-executor-collector/Makefile
+++ b/modules/thread-pool-executor-collector/Makefile
@@ -5,6 +5,7 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
+	$(MAKE) -C ../module-base prep
 	clojure -X:deps prep
 
 test: prep


### PR DESCRIPTION
tools.deps has a problem while downloading git dependencies concurrently. By prepping module-base first, we can solve that.