### PR TITLE
Remove RocksDB riscv64 Native Lib

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -110,6 +110,7 @@
             ".*-ppc64le.so$"
             ".*-s390x.so$"
             ".*-linux32.so$"
+            ".*-linux-riscv64.so$"
             ".*.dll$"
             ".*.jnilib$"]
            :conflict-handlers


### PR DESCRIPTION
We only support AMD64 and ARM64.