### PR TITLE
Optimize Module Build Process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,7 @@ lint: $(MODULES) lint-root
 build-job-ig:
 	$(MAKE) -C job-ig build
 
-build-byte-buffer:
-	$(MAKE) -C modules/byte-buffer build
-
-prep: build-byte-buffer
+prep:
 	$(MAKE) -C modules/module-base prep
 	clojure -X:deps prep
 
@@ -78,7 +75,7 @@ cloc-test-root:
 
 cloc-test: $(MODULES) cloc-test-root
 
-.PHONY: $(MODULES) lint-root lint build-job-ig build-byte-buffer prep \
+.PHONY: $(MODULES) lint-root lint build-job-ig prep \
     test-root test test-coverage clean-root clean build-frontend \
     build-frontend-image build-ingress uberjar build-all \
 	outdated deps-tree deps-list emacs-repl cloc-prod cloc-test

--- a/modules/byte-buffer/Makefile
+++ b/modules/byte-buffer/Makefile
@@ -5,15 +5,12 @@ lint:
 	clj-kondo --lint src test build.clj deps.edn
 
 prep:
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build compile
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 deps-tree:
@@ -31,4 +28,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/coll/Makefile
+++ b/modules/coll/Makefile
@@ -5,15 +5,12 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build compile
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 deps-tree:
@@ -31,4 +28,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -6,24 +6,21 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build all
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci --skip-meta :slow
 
-test-slow: build
+test-slow: prep
 	clojure -M:test:kaocha --profile :ci --focus-meta :slow
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage --skip-meta :slow
 
-test-coverage-slow: build
+test-coverage-slow: prep
 	clojure -M:test:coverage --focus-meta :slow
 
-test-coverage-all: build
+test-coverage-all: prep
 	clojure -M:test:coverage
 
 deps-tree:
@@ -41,4 +38,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/fhir-structure/Makefile
+++ b/modules/fhir-structure/Makefile
@@ -6,21 +6,18 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build all
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci --skip-meta :mem-size
 
-test-mem-size-normal-heap: build
+test-mem-size-normal-heap: prep
 	clojure -J-XX:+UseCompactObjectHeaders -J--sun-misc-unsafe-memory-access=allow -J-Xmx4g -M:test:kaocha --profile :ci --focus-meta :mem-size
 
-test-mem-size-large-heap: build
+test-mem-size-large-heap: prep
 	clojure -J-XX:+UseCompactObjectHeaders -J--sun-misc-unsafe-memory-access=allow -J-Xmx32g -M:test:kaocha --profile :ci --focus-meta :mem-size
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage --skip-meta :mem-size
 
 deps-tree:
@@ -38,4 +35,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/frontend/Makefile
+++ b/modules/frontend/Makefile
@@ -11,7 +11,7 @@ lint: install
 	npm run lint
 
 build-fhir-structure:
-	$(MAKE) -C ../fhir-structure build
+	$(MAKE) -C ../fhir-structure prep
 
 test: install build-fhir-structure
 	npm run test:unit

--- a/modules/job-async-interaction/Makefile
+++ b/modules/job-async-interaction/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep :aliases '[:test]'
+	clojure -X:deps prep :aliases '[:test]' :current true
 
-build: prep
-	clojure -T:build copy-profiles
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 cloc-prod:
@@ -29,4 +26,4 @@ validator_cli.jar:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean

--- a/modules/job-compact/Makefile
+++ b/modules/job-compact/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep :aliases '[:test]'
+	clojure -X:deps prep :aliases '[:test]' :current true
 
-build: prep
-	clojure -T:build copy-profiles
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 cloc-prod:
@@ -26,4 +23,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean

--- a/modules/job-re-index/Makefile
+++ b/modules/job-re-index/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep :aliases '[:test]'
+	clojure -X:deps prep :aliases '[:test]' :current true
 
-build: prep
-	clojure -T:build copy-profiles
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 cloc-prod:
@@ -26,4 +23,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean

--- a/modules/job-scheduler/Makefile
+++ b/modules/job-scheduler/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep :aliases '[:test]'
+	clojure -X:deps prep :aliases '[:test]' :current true
 
-build: prep
-	clojure -T:build copy-profiles
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 cloc-prod:
@@ -26,4 +23,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean

--- a/modules/kv/Makefile
+++ b/modules/kv/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build compile
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 cloc-prod:
@@ -26,4 +23,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean

--- a/modules/metrics/Makefile
+++ b/modules/metrics/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build compile
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 cloc-prod:
@@ -26,4 +23,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage cloc-prod cloc-test clean

--- a/modules/server/Makefile
+++ b/modules/server/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build compile
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 deps-tree:
@@ -32,4 +29,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/terminology-service-local/Makefile
+++ b/modules/terminology-service-local/Makefile
@@ -6,15 +6,12 @@ lint:
 
 prep:
 	$(MAKE) -C ../module-base prep
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build download-loinc
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 deps-tree:
@@ -32,4 +29,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean

--- a/modules/util/Makefile
+++ b/modules/util/Makefile
@@ -5,15 +5,12 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
-	clojure -X:deps prep
+	clojure -X:deps prep :current true
 
-build: prep
-	clojure -T:build compile
-
-test: build
+test: prep
 	clojure -M:test:kaocha --profile :ci
 
-test-coverage: build
+test-coverage: prep
 	clojure -M:test:coverage
 
 deps-tree:
@@ -31,4 +28,4 @@ cloc-test:
 clean:
 	rm -rf .clj-kondo/.cache .cpcache target
 
-.PHONY: fmt lint prep build test test-coverage deps-tree deps-list cloc-prod cloc-test clean
+.PHONY: fmt lint prep test test-coverage deps-tree deps-list cloc-prod cloc-test clean


### PR DESCRIPTION
Use prep current instead of extra build step. This is especially good in case make test-coverage is called after make test because it doesn't build again.