### PR TITLE
Tidy up CQL Retrieve Expressions

### DIFF
--- a/.github/scripts/cql/inpatient-stress.cql
+++ b/.github/scripts/cql/inpatient-stress.cql
@@ -11,7 +11,7 @@ define Stress:
   [Condition: Code '73595000' from sct]
 
 define "Inpatient Encounter":
-  [Encounter: class in Code 'IMP' from act]
+  [Encounter: class ~ Code 'IMP' from act]
 
 define InInitialPopulation:
   exists Stress C

--- a/docs/performance/cql/inpatient-stress.cql
+++ b/docs/performance/cql/inpatient-stress.cql
@@ -11,7 +11,7 @@ define Stress:
   [Condition: Code '73595000' from sct]
 
 define "Inpatient Encounter":
-  [Encounter: class in Code 'IMP' from act]
+  [Encounter: class ~ Code 'IMP' from act]
 
 define InInitialPopulation:
   exists Stress C

--- a/docs/performance/cql/measures/inpatient-condition-code.cql
+++ b/docs/performance/cql/measures/inpatient-condition-code.cql
@@ -7,7 +7,7 @@ codesystem act: 'http://terminology.hl7.org/CodeSystem/v3-ActCode'
 context Patient
 
 define "Inpatient Encounter":
-  [Encounter: class in Code 'IMP' from act]
+  [Encounter: class ~ Code 'IMP' from act]
 
 define InInitialPopulation:
   from [Condition] C


### PR DESCRIPTION
Replace `in` operator with `~` operator, because the `in` operator is for ValueSets.