### PR TITLE
Increase Access Token Lifespan

### DIFF
--- a/.github/openid-auth-test/realm/realm.json
+++ b/.github/openid-auth-test/realm/realm.json
@@ -6,7 +6,7 @@
   "notBefore" : 0,
   "revokeRefreshToken" : false,
   "refreshTokenMaxReuse" : 0,
-  "accessTokenLifespan" : 60,
+  "accessTokenLifespan" : 300,
   "accessTokenLifespanForImplicitFlow" : 900,
   "ssoSessionIdleTimeout" : 1800,
   "ssoSessionMaxLifespan" : 36000,


### PR DESCRIPTION
Blaze only checks every minute for access token refreshes. So an access token lifespan of 1 minute is too short. 5 minutes is better.