### PR TITLE
Fix Renovate hapi/hl7 Grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,13 +29,13 @@
     {
       "groupName": "hapi-fhir",
       "matchPackageNames": [
-        "ca.uhn.hapi.fhir/hapi-fhir*"
+        "ca.uhn.hapi.fhir:hapi-fhir*"
       ]
     },
     {
       "groupName": "hl7-fhir",
       "matchPackageNames": [
-        "ca.uhn.hapi.fhir/org.hl7.fhir*"
+        "ca.uhn.hapi.fhir:org.hl7.fhir*"
       ]
     },
     {


### PR DESCRIPTION
This is a package vs dep name problem. Renovate extracts the following for hapi-fhir-base

```json
"depName": "ca.uhn.hapi.fhir/hapi-fhir-base",
"packageName": "ca.uhn.hapi.fhir:hapi-fhir-base",
```

We fix this by matching for `:` in `matchPackageNames` (instead of `/`). Another option would be to use `matchDepNames`

Fixes #3661