### PR TITLE
Cleanup Standalone Sync Function

### DIFF
--- a/modules/db/src/blaze/db/node.clj
+++ b/modules/db/src/blaze/db/node.clj
@@ -515,8 +515,8 @@
     (fn sync-distributed [^Node node]
       (-> (tx-log/last-t (.-tx_log node))
           (ac/then-compose #(np/-sync node %))))
-    (fn sync-standalone [^Node node]
-      (ac/completed-future (db/db node (:t @(.-state node)))))))
+    (fn sync-standalone [node]
+      (ac/completed-future (np/-db node)))))
 
 (defn- initial-plc-index-entries [{:keys [state] :as node}]
   (into


### PR DESCRIPTION
The np/-db method does already the sync on local t. No need to implement that twice.