### PR TITLE
Track Shared Claude Code Settings in Git

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make fmt)",
+      "Bash(make lint)",
+      "Bash(make test)",
+      "Bash(make test-coverage)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ validator_cli.jar
 
 # Cursive-generated module files (derived from deps.edn, regenerated on sync)
 *.iml
+
+# Claude Code (track shared settings, ignore local/machine-specific files)
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Stop git-ignoring the shared Claude Code project settings.

The `.claude` directory is excluded by a global gitignore, which prevented `.claude/settings.json` (the shared, project-level permission config) from being tracked. This adds un-ignore rules to the project `.gitignore` so the shared settings file is committed while keeping machine-specific files (`settings.local.json`, `worktrees/`) ignored.