### PR TITLE
Update LOINC to Version 2.82

### DIFF
--- a/.github/scripts/check-terminology-capabilities-no-auth.sh
+++ b/.github/scripts/check-terminology-capabilities-no-auth.sh
@@ -15,5 +15,5 @@ test "URL" "$(echo "$terminology_capabilities" | jq -r .implementation.url)" "ht
 
 test "BCP-13 version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "urn:ietf:bcp:13").version[0].code' )" "1.0.0"
 test "BCP-47 version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "urn:ietf:bcp:47").version[0].code' )" "1.0.0"
-test "LOINC version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "http://loinc.org").version[0].code' )" "2.78"
+test "LOINC version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "http://loinc.org").version[0].code' )" "2.82"
 test "UCUM version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "http://unitsofmeasure.org").version[0].code' )" "2013.10.21"

--- a/.github/scripts/check-terminology-capabilities-openid-auth.sh
+++ b/.github/scripts/check-terminology-capabilities-openid-auth.sh
@@ -22,5 +22,5 @@ test "URL" "$(echo "$terminology_capabilities" | jq -r .implementation.url)" "ht
 
 test "BCP-13 version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "urn:ietf:bcp:13").version[0].code' )" "1.0.0"
 test "BCP-47 version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "urn:ietf:bcp:47").version[0].code' )" "1.0.0"
-test "LOINC version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "http://loinc.org").version[0].code' )" "2.78"
+test "LOINC version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "http://loinc.org").version[0].code' )" "2.82"
 test "UCUM version" "$(echo "$terminology_capabilities" | jq -r '.codeSystem[] | select(.uri == "http://unitsofmeasure.org").version[0].code' )" "2013.10.21"

--- a/.github/validation/validate.sh
+++ b/.github/validation/validate.sh
@@ -48,7 +48,6 @@ java -Xmx8g -jar validator_cli.jar -version 4.0.1 -level error \
   "$test_data_dir/MedicationAdministration-*.json" \
   "$test_data_dir/MedicationRequest-*.json" \
   "$test_data_dir/MedicationStatement-*.json" \
-  "$test_data_dir/Observation-mii-exa-test-data-patient-1-labobs-6.json" \
   "$test_data_dir/Observation-mii-exa-test-data-patient-1-patho-diagnostic-conclusion-2.json" \
   "$test_data_dir/Observation-mii-exa-test-data-patient-1-patho-diagnostic-conclusion-3.json" \
   "$test_data_dir/Observation-mii-exa-test-data-patient-1-patho-diagnostic-conclusion-grouper.json" \
@@ -61,7 +60,6 @@ java -Xmx8g -jar validator_cli.jar -version 4.0.1 -level error \
   "$test_data_dir/Observation-mii-exa-test-data-patient-3-molgen-ergebnis-zusammenfassung-1.json" \
   "$test_data_dir/Observation-mii-exa-test-data-patient-3-molgen-msi-1.json" \
   "$test_data_dir/Observation-mii-exa-test-data-patient-3-molgen-mutationslast-1.json" \
-  "$test_data_dir/Observation-mii-exa-test-data-patient-3-patho-fnding-1.json" \
   "$test_data_dir/Organization-mii-exa-test-data-organization-charite.json" \
   "$test_data_dir/Organization-mii-exa-test-data-organization-labor-berlin.json" \
   "$test_data_dir/Patient-mii-exa-test-data-patient-1.json" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,11 +244,11 @@ jobs:
     - name: Download LOINC ZIP
       uses: ./.github/actions/speicherwolke-download
       with:
-        token: S8Bej7LPjbGACdo
-        filename: Loinc_2.78.zip
+        token: F9JSkDk7eCskzLE
+        filename: Loinc_2.82.zip
 
     - name: Copy LOINC ZIP
-      run: cp Loinc_2.78.zip modules/terminology-service-local/Loinc_2.78.zip
+      run: cp Loinc_2.82.zip modules/terminology-service-local/Loinc_2.82.zip
 
     - name: Test
       run: make -C modules/${{ matrix.module }} test
@@ -330,11 +330,11 @@ jobs:
     - name: Download LOINC ZIP
       uses: ./.github/actions/speicherwolke-download
       with:
-        token: S8Bej7LPjbGACdo
-        filename: Loinc_2.78.zip
+        token: F9JSkDk7eCskzLE
+        filename: Loinc_2.82.zip
 
     - name: Copy LOINC ZIP
-      run: cp Loinc_2.78.zip modules/terminology-service-local/Loinc_2.78.zip
+      run: cp Loinc_2.82.zip modules/terminology-service-local/Loinc_2.82.zip
 
     - name: Test
       run: make -C modules/${{ matrix.module }} test-slow
@@ -450,11 +450,11 @@ jobs:
     - name: Download LOINC ZIP
       uses: ./.github/actions/speicherwolke-download
       with:
-        token: S8Bej7LPjbGACdo
-        filename: Loinc_2.78.zip
+        token: F9JSkDk7eCskzLE
+        filename: Loinc_2.82.zip
 
     - name: Copy LOINC ZIP
-      run: cp Loinc_2.78.zip modules/terminology-service-local/Loinc_2.78.zip
+      run: cp Loinc_2.82.zip modules/terminology-service-local/Loinc_2.82.zip
 
     - name: Test Coverage
       if: ${{ matrix.kind == 'normal' }}
@@ -531,11 +531,11 @@ jobs:
     - name: Download LOINC ZIP
       uses: ./.github/actions/speicherwolke-download
       with:
-        token: S8Bej7LPjbGACdo
-        filename: Loinc_2.78.zip
+        token: F9JSkDk7eCskzLE
+        filename: Loinc_2.82.zip
 
     - name: Copy LOINC ZIP
-      run: cp Loinc_2.78.zip modules/terminology-service-local/Loinc_2.78.zip
+      run: cp Loinc_2.82.zip modules/terminology-service-local/Loinc_2.82.zip
 
     - name: Test
       run: make test-root
@@ -616,11 +616,11 @@ jobs:
     - name: Download LOINC ZIP
       uses: ./.github/actions/speicherwolke-download
       with:
-        token: S8Bej7LPjbGACdo
-        filename: Loinc_2.78.zip
+        token: F9JSkDk7eCskzLE
+        filename: Loinc_2.82.zip
 
     - name: Copy LOINC ZIP
-      run: cp Loinc_2.78.zip modules/terminology-service-local/Loinc_2.78.zip
+      run: cp Loinc_2.82.zip modules/terminology-service-local/Loinc_2.82.zip
 
     - name: Build Uberjar
       run: make uberjar

--- a/docs/terminology-service.md
+++ b/docs/terminology-service.md
@@ -23,7 +23,7 @@ Currently the external code systems shown in the following table are supported.
 |---------------------------------------------------------|-----------------------|-----------------------------------|
 | [BCP-13](terminology-service/bcp-13.md) (Media Types)   | 1.0.0                 | enabled by default                |
 | [BCP-47](terminology-service/bcp-47.md) (Language Tags) | 1.0.0                 | enabled by default                |
-| [LOINC](terminology-service/loinc.md)                   | 2.78                  | has to be enabled                 |
+| [LOINC](terminology-service/loinc.md)                   | 2.82                  | has to be enabled                 |
 | [SNOMED CT](terminology-service/snomed-ct.md)           | all versions provided | release files have to be provided |
 | [UCUM](terminology-service/ucum.md)                     | 2013.10.21            | enabled by default                |
 

--- a/docs/terminology-service/loinc.md
+++ b/docs/terminology-service/loinc.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > LOINC data is build into the Blaze image. Because LOINC support needs additional memory, it has to be enabled by setting the environment variable `ENABLE_TERMINOLOGY_LOINC` to `true`.
 
-Blaze supports the [LOINC](https://loinc.org) terminology in version 2.78.
+Blaze supports the [LOINC](https://loinc.org) terminology in version 2.82.
 
 ## Copyright
 

--- a/modules/frontend-e2e/src/code-system.spec.ts
+++ b/modules/frontend-e2e/src/code-system.spec.ts
@@ -33,11 +33,11 @@ test('Search for LOINC', async ({ page }) => {
 
   await expect(breadcrumbItem(page, 'CodeSystem')).toBeVisible();
 
-  await expect(page.getByRole('link', { name: 'LOINC Code System v2.78' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'LOINC Code System v2.82' })).toBeVisible();
   await expect(
     page.getByRole('listitem').filter({ hasText: 'Url http://loinc.org' })
   ).toBeVisible();
-  await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.78' })).toBeVisible();
+  await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.82' })).toBeVisible();
   await expect(page.getByRole('listitem').filter({ hasText: 'Name LOINC' })).toBeVisible();
   await expect(
     page.getByRole('listitem').filter({ hasText: 'Title LOINC Code System' })
@@ -49,11 +49,11 @@ test('Search for LOINC', async ({ page }) => {
   ).toBeVisible();
   await expect(page.getByRole('listitem').filter({ hasText: 'Content not-present' })).toBeVisible();
 
-  await page.getByRole('link', { name: 'LOINC Code System v2.78' }).click();
+  await page.getByRole('link', { name: 'LOINC Code System v2.82' }).click();
 
   await expect(breadcrumbItem(page, 'CodeSystem')).toBeVisible();
-  await expect(breadcrumbItem(page, 'LOINC Code System v2.78')).toBeVisible();
-  await expect(page.getByRole('link', { name: 'LOINC Code System v2.78' })).toBeVisible();
+  await expect(breadcrumbItem(page, 'LOINC Code System v2.82')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'LOINC Code System v2.82' })).toBeVisible();
 });
 
 test.describe('$validate-code', () => {
@@ -78,22 +78,22 @@ test.describe('$validate-code', () => {
       await expect(
         page.getByRole('listitem').filter({ hasText: 'System http://loinc.org' })
       ).toBeVisible();
-      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.78' })).toBeVisible();
+      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.82' })).toBeVisible();
     });
 
     test('instance-level', async ({ page }) => {
       await page.goto('/fhir/CodeSystem?url=http://loinc.org');
 
-      await page.getByRole('link', { name: 'LOINC Code System v2.78' }).click();
+      await page.getByRole('link', { name: 'LOINC Code System v2.82' }).click();
 
-      await expect(breadcrumbItem(page, 'LOINC Code System v2.78')).toBeVisible();
+      await expect(breadcrumbItem(page, 'LOINC Code System v2.82')).toBeVisible();
       await page.getByRole('button', { name: 'Operations' }).click();
       await page.getByRole('menuitem', { name: '$validate-code' }).click();
 
-      await page.getByRole('heading', { name: 'LOINC Code System v2.78' }).click();
+      await page.getByRole('heading', { name: 'LOINC Code System v2.82' }).click();
 
       await expect(breadcrumbItem(page, 'CodeSystem')).toBeVisible();
-      await expect(breadcrumbItem(page, 'LOINC Code System v2.78')).toBeVisible();
+      await expect(breadcrumbItem(page, 'LOINC Code System v2.82')).toBeVisible();
       await expect(breadcrumbItem(page, '$validate-code')).toBeVisible();
 
       await page.getByRole('heading', { name: 'Parameters' }).click();
@@ -108,7 +108,7 @@ test.describe('$validate-code', () => {
       await expect(
         page.getByRole('listitem').filter({ hasText: 'System http://loinc.org' })
       ).toBeVisible();
-      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.78' })).toBeVisible();
+      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.82' })).toBeVisible();
     });
   });
 });
@@ -128,7 +128,7 @@ test.describe('$lookup', () => {
       await page.getByRole('button', { name: 'Submit' }).click();
 
       await expect(page.getByRole('listitem').filter({ hasText: 'Name LOINC' })).toBeVisible();
-      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.78' })).toBeVisible();
+      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.82' })).toBeVisible();
       await expect(
         page.getByRole('listitem').filter({ hasText: 'Display Hemoglobin [Mass/volume] in Blood' })
       ).toBeVisible();
@@ -137,16 +137,16 @@ test.describe('$lookup', () => {
     test('instance-level', async ({ page }) => {
       await page.goto('/fhir/CodeSystem?url=http://loinc.org');
 
-      await page.getByRole('link', { name: 'LOINC Code System v2.78' }).click();
+      await page.getByRole('link', { name: 'LOINC Code System v2.82' }).click();
 
-      await expect(breadcrumbItem(page, 'LOINC Code System v2.78')).toBeVisible();
+      await expect(breadcrumbItem(page, 'LOINC Code System v2.82')).toBeVisible();
       await page.getByRole('button', { name: 'Operations' }).click();
       await page.getByRole('menuitem', { name: '$lookup' }).click();
 
-      await page.getByRole('heading', { name: 'LOINC Code System v2.78' }).click();
+      await page.getByRole('heading', { name: 'LOINC Code System v2.82' }).click();
 
       await expect(breadcrumbItem(page, 'CodeSystem')).toBeVisible();
-      await expect(breadcrumbItem(page, 'LOINC Code System v2.78')).toBeVisible();
+      await expect(breadcrumbItem(page, 'LOINC Code System v2.82')).toBeVisible();
       await expect(breadcrumbItem(page, '$lookup')).toBeVisible();
 
       await page.getByRole('heading', { name: 'Parameters' }).click();
@@ -154,7 +154,7 @@ test.describe('$lookup', () => {
       await page.getByRole('button', { name: 'Submit' }).click();
 
       await expect(page.getByRole('listitem').filter({ hasText: 'Name LOINC' })).toBeVisible();
-      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.78' })).toBeVisible();
+      await expect(page.getByRole('listitem').filter({ hasText: 'Version 2.82' })).toBeVisible();
       await expect(
         page.getByRole('listitem').filter({ hasText: 'Display Hemoglobin [Mass/volume] in Blood' })
       ).toBeVisible();

--- a/modules/terminology-service-local/build.clj
+++ b/modules/terminology-service-local/build.clj
@@ -46,10 +46,10 @@
                        :actual actual-sha})))))
 
 (defn download-loinc [_]
-  (let [filename "Loinc_2.78.zip"]
+  (let [filename "Loinc_2.82.zip"]
     (when-not (.exists (io/file filename))
-      (download-file (str "https://speicherwolke.uni-leipzig.de/index.php/s/S8Bej7LPjbGACdo/download/" filename) filename))
-    (verify-download filename "ab5528a4c703bdc79deabbdd5e1def1335d127a643da97b68f686814ed526d46")
+      (download-file (str "https://speicherwolke.uni-leipzig.de/index.php/s/F9JSkDk7eCskzLE/download/" filename) filename))
+    (verify-download filename "d34b9f15a8e5156698650b8ca1fa1a13f9d5356a5182109720fcfc21fc8a4f03")
     (b/unzip {:zip-file filename :target-dir "target/generated-resources/blaze/terminology_service/local/code_system/loinc"})
     (b/delete {:path filename}))
   (b/write-file {:path "target/prep-done" :string ""}))

--- a/modules/terminology-service-local/src/blaze/terminology_service/local/code_system/loinc/context.clj
+++ b/modules/terminology-service-local/src/blaze/terminology_service/local/code_system/loinc/context.clj
@@ -13,9 +13,9 @@
 
 (def ^:const ^String url "http://loinc.org")
 (def ^:const ^String value-set-prefix "http://loinc.org/vs/")
-(def ^:const ^String version "2.78")
+(def ^:const ^String version "2.82")
 (def ^:const copyright #fhir/markdown "This material contains content from LOINC (http://loinc.org). LOINC is copyright Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc.")
-(def ^:const ^String resources "blaze/terminology_service/local/code_system/loinc/")
+(def ^:const ^String resources (str "blaze/terminology_service/local/code_system/loinc/Loinc_" version "/"))
 (def ^:const ^String table (str resources "LoincTable/Loinc.csv"))
 (def ^:const ^String answer-lists (str resources "AccessoryFiles/AnswerFile/AnswerList.csv"))
 (def ^:const ^String parts (str resources "AccessoryFiles/PartFile/Part.csv"))

--- a/modules/terminology-service-local/test/blaze/terminology_service/local/value_set/vcl_test.clj
+++ b/modules/terminology-service-local/test/blaze/terminology_service/local/value_set/vcl_test.clj
@@ -30,10 +30,10 @@
       [:compose :include 0 :filter 0 :value] := #fhir/string "true")
 
     (testing "with version"
-      (given (vcl/parse-expr "(http://loinc.org|2.78)*")
+      (given (vcl/parse-expr "(http://loinc.org|2.82)*")
         :fhir/type := :fhir/ValueSet
         [:compose :include count] := 1
-        [:compose :include 0 :system] := #fhir/uri "http://loinc.org|2.78"
+        [:compose :include 0 :system] := #fhir/uri "http://loinc.org|2.82"
         [:compose :include 0 :filter count] := 1
         [:compose :include 0 :filter 0 :property] := #fhir/code "concept"
         [:compose :include 0 :filter 0 :op] := #fhir/code "exists"

--- a/modules/terminology-service-local/test/blaze/terminology_service/local_test.clj
+++ b/modules/terminology-service-local/test/blaze/terminology_service/local_test.clj
@@ -794,7 +794,7 @@
                   "code" (type/code code))
           :fhir/type := :fhir/Parameters
           [(parameter "name") 0 :value] := #fhir/string "LOINC"
-          [(parameter "version") 0 :value] := #fhir/string "2.78"
+          [(parameter "version") 0 :value] := #fhir/string "2.82"
           [(parameter "display") 0 :value] := (type/string display)))
 
       (testing "with version"
@@ -804,10 +804,10 @@
           (given @(code-system-lookup ts
                     "system" #fhir/uri "http://loinc.org"
                     "code" (type/code code)
-                    "version" #fhir/string "2.78")
+                    "version" #fhir/string "2.82")
             :fhir/type := :fhir/Parameters
             [(parameter "name") 0 :value] := #fhir/string "LOINC"
-            [(parameter "version") 0 :value] := #fhir/string "2.78"
+            [(parameter "version") 0 :value] := #fhir/string "2.82"
             [(parameter "display") 0 :value] := (type/string display))))
 
       (testing "inactive"
@@ -816,7 +816,7 @@
                   "code" #fhir/code "1009-0")
           :fhir/type := :fhir/Parameters
           [(parameter "name") 0 :value] := #fhir/string "LOINC"
-          [(parameter "version") 0 :value] := #fhir/string "2.78")))
+          [(parameter "version") 0 :value] := #fhir/string "2.82")))
 
     (testing "non-existing code"
       (doseq [code ["non-existing" "0815" "718-8"]]
@@ -1584,7 +1584,7 @@
           [(parameter "result") 0 :value] := #fhir/boolean true
           [(parameter "code") 0 :value] := (type/code code)
           [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-          [(parameter "version") 0 :value] := #fhir/string "2.78"
+          [(parameter "version") 0 :value] := #fhir/string "2.82"
           [(parameter "display") 0 :value] := (type/string display)))
 
       (testing "with version"
@@ -1594,12 +1594,12 @@
           (given @(code-system-validate-code ts
                     "url" #fhir/uri "http://loinc.org"
                     "code" (type/code code)
-                    "version" #fhir/string "2.78")
+                    "version" #fhir/string "2.82")
             :fhir/type := :fhir/Parameters
             [(parameter "result") 0 :value] := #fhir/boolean true
             [(parameter "code") 0 :value] := (type/code code)
             [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-            [(parameter "version") 0 :value] := #fhir/string "2.78"
+            [(parameter "version") 0 :value] := #fhir/string "2.82"
             [(parameter "display") 0 :value] := (type/string display))))
 
       (testing "wrong display"
@@ -1612,7 +1612,7 @@
           [(parameter "message") 0 :value] := #fhir/string "Invalid display `wrong` for code `http://loinc.org#718-7`. A valid display is `Hemoglobin [Mass/volume] in Blood`."
           [(parameter "code") 0 :value] := #fhir/code "718-7"
           [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-          [(parameter "version") 0 :value] := #fhir/string "2.78"
+          [(parameter "version") 0 :value] := #fhir/string "2.82"
           [(parameter "display") 0 :value] := #fhir/string "Hemoglobin [Mass/volume] in Blood"
           [(parameter "issues") 0 :resource :issue 0 :severity] := #fhir/code "error"
           [(parameter "issues") 0 :resource :issue 0 :code] := #fhir/code "invalid"
@@ -1628,7 +1628,7 @@
           [(parameter "result") 0 :value] := #fhir/boolean true
           [(parameter "code") 0 :value] := #fhir/code "1009-0"
           [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-          [(parameter "version") 0 :value] := #fhir/string "2.78"
+          [(parameter "version") 0 :value] := #fhir/string "2.82"
           [(parameter "display") 0 :value] := #fhir/string "Deprecated Direct antiglobulin test.poly specific reagent [Presence] on Red Blood Cells"
           [(parameter "inactive") 0 :value] := #fhir/boolean true)))
 
@@ -1639,10 +1639,10 @@
                   "code" (type/code code))
           :fhir/type := :fhir/Parameters
           [(parameter "result") 0 :value] := #fhir/boolean false
-          [(parameter "message") 0 :value] := (type/string (format "Unknown code `%s` was not found in the code system `http://loinc.org|2.78`." code))
+          [(parameter "message") 0 :value] := (type/string (format "Unknown code `%s` was not found in the code system `http://loinc.org|2.82`." code))
           [(parameter "code") 0 :value] := (type/code code)
           [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-          [(parameter "version") 0 :value] := #fhir/string "2.78")))
+          [(parameter "version") 0 :value] := #fhir/string "2.82")))
 
     (testing "non-existing system version"
       (given-failed-future
@@ -7651,7 +7651,7 @@
       [(parameter "code") 0 :value] := #fhir/code "26465-5"
       [(parameter "display") 0 :value] := #fhir/string "Leukocytes [#/volume] in Cerebral spinal fluid"
       [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-      [(parameter "version") 0 :value] := #fhir/string "2.78"))
+      [(parameter "version") 0 :value] := #fhir/string "2.82"))
 
   (testing "with supplement"
     (with-system-data [{ts ::ts/local} loinc-config]
@@ -7687,7 +7687,7 @@
           [(parameter "code") 0 :value] := #fhir/code "26465-5"
           [(parameter "display") 0 :value] := #fhir/string "Leukocytes [#/volume] in Cerebral spinal fluid"
           [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-          [(parameter "version") 0 :value] := #fhir/string "2.78"))
+          [(parameter "version") 0 :value] := #fhir/string "2.82"))
 
       (testing "with displayLanguage"
         (given @(value-set-validate-code ts
@@ -7701,7 +7701,7 @@
           [(parameter "code") 0 :value] := #fhir/code "26465-5"
           [(parameter "display") 0 :value] := #fhir/string "designation-104319"
           [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-          [(parameter "version") 0 :value] := #fhir/string "2.78")))))
+          [(parameter "version") 0 :value] := #fhir/string "2.82")))))
 
 (deftest value-set-validate-code-loinc-include-concept-test
   (testing "non-matching concept"
@@ -7754,7 +7754,7 @@
         [(parameter "code") 0 :value] := #fhir/code "26465-5"
         [(parameter "display") 0 :value] := #fhir/string "Leukocytes [#/volume] in Cerebral spinal fluid"
         [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-        [(parameter "version") 0 :value] := #fhir/string "2.78")))
+        [(parameter "version") 0 :value] := #fhir/string "2.82")))
 
   (testing "inactive concept"
     (with-system [{ts ::ts/local} loinc-config]
@@ -7777,7 +7777,7 @@
         [(parameter "display") 0 :value] := #fhir/string "Deprecated Direct antiglobulin test.poly specific reagent [Presence] on Red Blood Cells"
         [(parameter "inactive") 0 :value] := #fhir/boolean true
         [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-        [(parameter "version") 0 :value] := #fhir/string "2.78")
+        [(parameter "version") 0 :value] := #fhir/string "2.82")
 
       (testing "with active only"
         (with-system [{ts ::ts/local} loinc-config]
@@ -7802,7 +7802,7 @@
             [(parameter "display") 0 :value] := #fhir/string "Deprecated Direct antiglobulin test.poly specific reagent [Presence] on Red Blood Cells"
             [(parameter "inactive") 0 :value] := #fhir/boolean true
             [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
-            [(parameter "version") 0 :value] := #fhir/string "2.78"
+            [(parameter "version") 0 :value] := #fhir/string "2.82"
             [(parameter "issues") 0 :resource :issue 0 :severity] := #fhir/code "error"
             [(parameter "issues") 0 :resource :issue 0 :code] := #fhir/code "code-invalid"
             [(parameter "issues") 0 :resource :issue 0 :details :coding] :? (tx-issue-type "not-in-vs")
@@ -8437,7 +8437,7 @@
         [(parameter "code") 0 :value] := #fhir/code "LA26422-8"
         [(parameter "system") 0 :value] := #fhir/uri "http://loinc.org"
         [(parameter "display") 0 :value] := #fhir/string "Decrease dose"
-        [(parameter "version") 0 :value] := #fhir/string "2.78")))
+        [(parameter "version") 0 :value] := #fhir/string "2.82")))
 
   (testing "unknown"
     (with-system [{ts ::ts/local} loinc-config]


### PR DESCRIPTION
Closes: #3711

Two KDS test resources are removed from validation because their LOINC display value has changed from 2.78 to 2.82.