### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v1.9.0
+
+### Performance
+
+* Optimize _lastUpdated Search Parameter ([#3624](https://github.com/samply/blaze/issues/3624))
+
+### Bugfixes
+
+* Fix Wrong _lastUpdated Search Results After No-op Updates ([#3710](https://github.com/samply/blaze/issues/3710))
+* Fix Use of Bloom Filters Newer Than the Database ([#3698](https://github.com/samply/blaze/issues/3698))
+
+### Maintenance
+
+* Update LOINC to Version 2.82 ([#3711](https://github.com/samply/blaze/issues/3711))
+
+The full changelog can be found [here](https://github.com/samply/blaze/milestone/125?closed=1).
+
 ## v1.8.0
 
 ### Survey

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/
 
 RUN mkdir -p /app/data && chown 1001:1001 /app/data
-COPY target/blaze-1.8.0-standalone.jar /app/
+COPY target/blaze-1.9.0-standalone.jar /app/
 
 WORKDIR /app
 USER 1001
@@ -20,4 +20,4 @@ ENV RESOURCE_DB_DIR="/app/data/resource"
 ENV ADMIN_INDEX_DB_DIR="/app/data/admin-index"
 ENV ADMIN_TRANSACTION_DB_DIR="/app/data/admin-transaction"
 
-CMD ["sh", "-c", "JAVA_TOOL_OPTIONS=\"${BASE_JAVA_TOOL_OPTIONS} ${JAVA_TOOL_OPTIONS}\" exec java -jar blaze-1.8.0-standalone.jar"]
+CMD ["sh", "-c", "JAVA_TOOL_OPTIONS=\"${BASE_JAVA_TOOL_OPTIONS} ${JAVA_TOOL_OPTIONS}\" exec java -jar blaze-1.9.0-standalone.jar"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A demo installation can be found [here](https://blaze.life.uni-leipzig.de/fhir) 
 
 Blaze is stable and widely used in the [Medical Informatics Initiative](https://www.medizininformatik-initiative.de) in Germany and in [Biobanks](https://www.bbmri-eric.eu) across Europe.
 
-Latest release: [v1.8.0][5]
+Latest release: [v1.9.0][5]
 
 ## Key Features
 
@@ -79,7 +79,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [2]: <https://samply.github.io/blaze/api/operation/measure-evaluate-measure.html>
 [3]: <https://cql.hl7.org/tests.html>
 [4]: <https://alexanderkiel.gitbook.io/blaze/deployment>
-[5]: <https://github.com/samply/blaze/releases/tag/v1.8.0>
+[5]: <https://github.com/samply/blaze/releases/tag/v1.9.0>
 [6]: <https://www.yourkit.com/java/profiler/>
 [7]: <https://www.yourkit.com/.net/profiler/>
 [8]: <https://www.yourkit.com/youmonitor/>

--- a/build.clj
+++ b/build.clj
@@ -5,7 +5,7 @@
    [java.time LocalDate]))
 
 (def lib 'samply/blaze)
-(def version "1.8.0")
+(def version "1.9.0")
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))

--- a/modules/frontend-e2e/package-lock.json
+++ b/modules/frontend-e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-e2e",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-e2e",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "1.57.0",

--- a/modules/frontend-e2e/package.json
+++ b/modules/frontend-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-e2e",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/modules/frontend/package-lock.json
+++ b/modules/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blaze-frontend",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blaze-frontend",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@auth/sveltekit": "^1.11.1",
         "@fontsource-variable/lexend": "^5.0.0",

--- a/modules/frontend/package.json
+++ b/modules/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-frontend",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
Prepares the **v1.9.0** release.

## Changes
- Bump version `1.8.0` → `1.9.0` (`build.clj`, `Dockerfile`, `README.md`, frontend & frontend-e2e `package.json` + lockfiles)
- Add `v1.9.0` CHANGELOG entry

## Changelog
### Performance
* Optimize _lastUpdated Search Parameter (#3624)

### Bugfixes
* Fix Use of Bloom Filters Newer Than the Database (#3698)

### Maintenance
* Update LOINC to Version 2.82 (#3711)

The full changelog can be found [here](https://github.com/samply/blaze/milestone/125?closed=1).

## Milestone housekeeping
The 5 issues still open in the v1.9.0 milestone were moved to the new **v1.10.0** milestone (#3710, #3575, #3311, #3245, #3164). The v1.9.0 milestone is now fully closed.

## Next step (manual)
After merge, create the GitHub Release **v1.9.0** (tag on `main`) to trigger the publish workflows.