### PR TITLE
Add Claude Attribution Settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,5 +18,10 @@
         ]
       }
     ]
+  },
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
   }
 }


### PR DESCRIPTION
We don't like to have any attribution. It's already part of AGENTS.md but here again more explicit.