### PR TITLE
Remove Unsafe memory Access JVM Flag

### DIFF
--- a/modules/admin-api/Makefile
+++ b/modules/admin-api/Makefile
@@ -9,13 +9,13 @@ prep:
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-focus: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci --focus "$(FOCUS)"
+	clojure -M:test:kaocha --profile :ci --focus "$(FOCUS)"
 
 test-coverage: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha:coverage
+	clojure -M:test:kaocha:coverage
 
 deps-tree:
 	clojure -X:deps tree

--- a/modules/db/Makefile
+++ b/modules/db/Makefile
@@ -9,22 +9,22 @@ prep:
 	clojure -X:deps prep :current true
 
 test: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci --skip-meta :slow
+	clojure -M:test:kaocha --profile :ci --skip-meta :slow
 
 test-focus: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci --focus "$(FOCUS)"
+	clojure -M:test:kaocha --profile :ci --focus "$(FOCUS)"
 
 test-slow: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci --focus-meta :slow
+	clojure -M:test:kaocha --profile :ci --focus-meta :slow
 
 test-coverage: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha:coverage --skip-meta :slow
+	clojure -M:test:kaocha:coverage --skip-meta :slow
 
 test-coverage-slow: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha:coverage --focus-meta :slow
+	clojure -M:test:kaocha:coverage --focus-meta :slow
 
 test-coverage-all: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha:coverage
+	clojure -M:test:kaocha:coverage
 
 deps-tree:
 	clojure -X:deps tree

--- a/modules/interaction/Makefile
+++ b/modules/interaction/Makefile
@@ -9,13 +9,13 @@ prep:
 	clojure -X:deps prep :aliases '[:test]'
 
 test: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci
+	clojure -M:test:kaocha --profile :ci
 
 test-focus: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha --profile :ci --focus "$(FOCUS)"
+	clojure -M:test:kaocha --profile :ci --focus "$(FOCUS)"
 
 test-coverage: prep
-	clojure -J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory-access=allow -M:test:kaocha:coverage
+	clojure -M:test:kaocha:coverage
 
 deps-list:
 	clojure -X:deps list


### PR DESCRIPTION
The flag prevents the Java 21 JVM to start. So scheduled workflows that include Java 21 fail. The flag only suppresses a warning. We can enable it again if we drop support for Java 21 JVM.