### PR TITLE
Quarantine Flaky medication-administration-mem-size-test

### DIFF
--- a/modules/fhir-structure/test/blaze/fhir/spec_test.clj
+++ b/modules/fhir-structure/test/blaze/fhir/spec_test.clj
@@ -6967,7 +6967,10 @@
       (prop/for-all [medication-administration (fg/medication-administration)]
         (murmur3 medication-administration)))))
 
-(deftest ^:mem-size medication-administration-mem-size-test
+;; Flaky: the calculated size occasionally falls more than 10% short of the
+;; real size on minimal shrunk counterexamples. See
+;; https://github.com/samply/blaze/issues/3897 for the root-cause analysis.
+(deftest ^:mem-size ^:kaocha/pending medication-administration-mem-size-test
   (satisfies-prop 20
     (memsize-prop "medication-administration")))
 


### PR DESCRIPTION
## Summary

Weekly CI flakiness scan (2026-07-12 to 2026-07-19) found `blaze.fhir.spec-test/medication-administration-mem-size-test` failing on a commit where it also passed (same SHA, different runs). Two other flaky tests found in the same scan were already fixed by earlier commits:

- `blaze.db.node.tx-indexer.verify-test/verify-tx-cmds-test` — fixed by 5b95f5a
- `blaze.page-store.token-test` — fixed by 030e232 (#3891)

This is the one remaining unfixed flake.

## Root cause

`blaze.fhir.spec.type.String.Interned#memSize()` returns `0` for short interned strings under the assumption their cost is amortized elsewhere. `Base/memSize`'s "calculated size" applies that assumption per-instance. The property test compares this against a JOL-measured "real size" with a 10%-relative tolerance. For a `test.check`-shrunk *minimal* counterexample dominated by several short strings, the fixed per-string omission can exceed 10% of the (very small) total, even though it's negligible for realistic resources.

I could not get a reliable local repro to confirm this and safely fix the underlying calculation under this repo's mandatory TDD workflow (write a failing test, then fix): JOL's `Instrumentation` agent can't attach in the sandbox this was investigated in (`Unable to get Instrumentation. Dynamic Attach failed`), so the "real size" measurement there doesn't match what the actual `test-mem-size (large-heap)` CI runner sees — re-running with the exact recorded seed against the exact failing commit passed locally.

Full analysis: #3897

## Changes

Quarantines the test with `^:kaocha/pending` (skip, reported as pending — not run) and a comment linking #3897, per the flaky-test playbook: fix if confident, quarantine if not.

## Verification

- `make -C modules/fhir-structure fmt` — passes
- `make -C modules/fhir-structure lint` — passes
- `make -C modules/fhir-structure test` — 220 tests, 4561 assertions, 0 failures
- `make -C modules/fhir-structure test-mem-size-large-heap` (the job that was flaky) — 64 tests, 118 assertions, **1 pending**, 0 failures

## Test plan

- [x] Confirm the target test is skipped and reported `PENDING`, not silently vanished
- [x] Confirm the rest of the `test-mem-size-large-heap` suite (63 other mem-size tests) still passes
- [x] Confirm the regular module test suite is unaffected
- [ ] Follow-up (tracked in #3897): reproduce with real JOL instrumentation (on CI or a machine that allows agent attach) and land a real fix — widen tolerance with an absolute floor, or stop assuming 0 cost for interned strings, or bound generator size.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDCkYRndNpFzjWQrvGDvcj)_