### PR TITLE
Retry Maven Central Downloads During `clojure -X:deps prep`

### DIFF
--- a/modules/module-base/Makefile
+++ b/modules/module-base/Makefile
@@ -5,7 +5,16 @@ lint:
 	clj-kondo --lint src test deps.edn
 
 prep:
-	clojure -X:deps prep
+	n=0; \
+	until clojure -X:deps prep; do \
+		n=$$((n + 1)); \
+		if [ $$n -ge 3 ]; then \
+			echo "clojure -X:deps prep failed after 3 attempts" >&2; \
+			exit 1; \
+		fi; \
+		echo "clojure -X:deps prep failed (attempt $$n/3), retrying in $$((n * 5))s..." >&2; \
+		sleep $$((n * 5)); \
+	done
 
 test: prep
 	clojure -M:test:kaocha --profile :ci


### PR DESCRIPTION
Closes: #4020

## Root cause

A weekly flaky-test survey of the last 7 days of `Build` workflow runs (2026-07-26 … 2026-08-02) found the `prep` step of `modules/module-base/Makefile` (`clojure -X:deps prep`) intermittently failing while downloading `org.clojure/tools.deps.cli` from Maven Central, aborting the job before any test ever ran:

- https://github.com/samply/blaze/actions/runs/30230396773/job/89868178040 (`main`, schedule, 2026-07-27 01:43 UTC) — `make[1]: *** [Makefile:8: prep] Error 1`
- https://github.com/samply/blaze/actions/runs/30344573106/job/90227852339 (`main`, push, 2026-07-28 08:58 UTC) — `org.eclipse.aether...ArtifactResolutionException`: Maven Central returned `403 Forbidden` resolving `org.clojure:tools.deps.cli:0.31.158`

Every module's own `prep` target delegates to this one first (`$(MAKE) -C ../module-base prep`), so this single step is a shared choke point: any transient Maven Central hiccup fails the whole module's job outright, with no test ever running. Both observed failures are on `main`/`push`/`schedule` runs, not caused by the PR author's changes, and the same dependency resolves fine on adjacent/rerun attempts — confirming it's transient upstream flakiness rather than a real build problem.

## Fix

Wrap `clojure -X:deps prep` in `modules/module-base/Makefile` with a 3-attempt retry loop (5s/10s backoff between attempts), matching the smallest change that protects every module at once.

## Verification

- `make prep` (real Maven Central) still succeeds normally.
- Simulated with a fake `clojure` binary that fails twice then succeeds: the target retries with backoff and exits 0 on the 3rd attempt.
- Simulated with a fake `clojure` binary that always fails: the target retries twice then exits non-zero (`make: *** [Makefile:8: prep] Error 1`) after 3 attempts, so a genuine failure still fails the build rather than being silently swallowed.
- `make fmt` passes across the whole repo.

No test-code change was possible here (this is a Makefile network-retry fix, not application/test logic), so verification was done by simulating the failure/success paths directly as described above.

---
_Generated by [Claude Code](https://claude.ai/code/session_011yHijbgNffGLTBexAasmiF)_