### PR TITLE
Fix Error After Frontend Session Expiry

### DIFF
--- a/docs/implementation/frontend.md
+++ b/docs/implementation/frontend.md
@@ -34,6 +34,17 @@ request was made. SvelteKit puts it into the right envelope by itself:
 | `__data.json` data request     | `{ type: 'redirect' }`, which the client router turns into a `goto`   |
 | `use:enhance`d form submission | a redirect `ActionResult`, which `applyAction` turns into a navigation |
 
+### Rejected access tokens
+
+`handleAuthorization` only knows what the Auth.js session claims, which is its `expiresAt`. The backend can still reject 
+the access token that session carries — revoked at the identity provider, clock skew, a realm mismatch — and
+answers 401. `handleFetch` redirects to the sign-in page in that case, for the same reason `handleAuthorization` can: 
+the request it was serving is one SvelteKit turns into a navigation.
+
+The recovery lives in the hook rather than in the load that made the request, because `event.url` — the page the 
+user is on, and so the return-to target — is not something a load can read. A 403 is passed through instead:
+there the token was accepted, and the user simply may not do this, which signing in again does not change.
+
 ### Backend URLs
 
 Backend request URLs are built by prefixing `base` from `$app/paths`, for example
@@ -58,6 +69,18 @@ the `{:catch}` block as the jsonified error *body* — SvelteKit runs it through
 therefore carries an optional `status`, which the `appError` functions in `src/routes/[type=type]/util.ts` and
 `src/lib/metadata.ts` set. Every `error(…)` body that can surface in such a block has to carry it — that includes the
 StructureDefinition loads made while transforming a streamed bundle and the one `handleFetch` throws.
+
+Both streamed loads — `src/routes/[type=type]/+page.server.ts` and
+`src/routes/[type=type]/__page/[pageId=pageId]/+page.server.ts` — await `fetchSearchMetadata` before they return the
+streamed promise. That ordering is what lets a rejected access token still reach the sign-in page: a `redirect` thrown
+after `load` has returned cannot become a navigation, because SvelteKit has already committed to the response and
+serializes the rejection into the streamed chunk, where it surfaces as a generic 500. `fetchSearchMetadata` hits
+`/metadata`, which Blaze protects with the same `wrap-auth-guard` as everything else
+(`modules/rest-api/src/blaze/rest_api/routes.clj`, applied at the root `""` level), so `handleFetch` sees the 401 while
+a redirect can still be acted upon.
+
+The StructureDefinition loads are the exception: they run inside the streamed promise, via `transformBundle`. A token
+revoked between the `/metadata` call and them ends in an error card rather than the sign-in page.
 
 [1]: <https://authjs.dev>
 [2]: <https://www.npmjs.com/package/@auth/sveltekit>

--- a/modules/frontend-e2e/src/sign-in.spec.ts
+++ b/modules/frontend-e2e/src/sign-in.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach('Sign In', async ({ page }) => {
+  await page.goto('/fhir');
+
+  // Blaze Sign-In Page
+  await expect(page).toHaveTitle('Sign-In - Blaze');
+  await page.getByRole('button', { name: 'Sign in with Keycloak' }).click();
+
+  // Keycloak Sign-In Page
+  await expect(page).toHaveTitle('Sign in to Keycloak');
+  await page.getByLabel('Username or email').fill('john');
+  await page.getByLabel('Password', { exact: true }).fill('insecure');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await expect(page).toHaveTitle('Home - Blaze');
+});
+
+// A session that is gone has to be recovered from a client-side
+// navigation, not only from a full page load.
+//
+// This covers the `handleAuthorization` half: without the session cookie,
+// there is no session at all, so the redirect is thrown before any backend
+// request is made. What it exercises that a unit test cannot is the envelope
+// — SvelteKit fetches `__data.json` for a client-side navigation, and the
+// client router has to turn the redirect it finds there into a navigation.
+//
+// The other half of #4082 — a session Auth.js still considers valid whose
+// token the backend rejects, which is what `handleFetch` recovers from — is
+// covered by `src/hooks.server.test.ts`. Reaching it from here would mean
+// revoking the Keycloak session behind the app's back.
+test('an in-app navigation without a session goes to the sign-in page and returns afterwards', async ({
+  page,
+  context
+}) => {
+  // Simulates the session ending while the app is open: the cookie is gone,
+  // but the running app has no way of knowing that ahead of time, so the very
+  // next navigation is the one that has to discover and recover from it.
+  await context.clearCookies();
+
+  // A client-side navigation, not a full page load. This is what issues the
+  // `__data.json` request for the load of `[type=type]/+page.server.ts`.
+  await page.getByRole('link', { name: 'Patient' }).click();
+
+  // Blaze Sign-In Page
+  await expect(page).toHaveTitle('Sign-In - Blaze');
+
+  // The intended destination is remembered for after signing in.
+  await expect(page).toHaveURL(/redirect=.*Patient/);
+
+  await page.getByRole('button', { name: 'Sign in with Keycloak' }).click();
+
+  // Keycloak Sign-In Page
+  await expect(page).toHaveTitle('Sign in to Keycloak');
+  await page.getByLabel('Username or email').fill('john');
+  await page.getByLabel('Password', { exact: true }).fill('insecure');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Back on the page the user originally navigated to.
+  await expect(page).toHaveTitle('Patient - Blaze');
+});

--- a/modules/frontend/src/hooks.server.test.ts
+++ b/modules/frontend/src/hooks.server.test.ts
@@ -167,4 +167,57 @@ describe('handleFetch test', () => {
 
     expect(result.status).toBe(404);
   });
+
+  // The backend rejecting the access token even though `handleAuthorization`
+  // found the Auth.js session valid — revoked at the identity provider, clock
+  // skew, a realm mismatch. Recovering here rather than in the load that made
+  // the request is what keeps the return-to target: `event.url` is the page
+  // the user is on, which the load cannot read.
+  it('redirects to the sign-in page when the backend rejects the access token', async () => {
+    const event = fetchEvent({ accessToken: 'token' });
+
+    try {
+      await callHandleFetch(event, new Response('', { status: 401 }));
+      expect.fail('expected handleFetch to throw');
+    } catch (e) {
+      expect(isRedirect(e)).toBe(true);
+      expect((e as { status: number }).status).toBe(307);
+      expect((e as { location: string }).location).toBe(
+        '/fhir/__sign-in?redirect=%2Ffhir%2FPatient'
+      );
+    }
+  });
+
+  // The redirect has to point at the page, not at the backend request that
+  // failed. Those differ whenever a load fetches something other than the
+  // resource the page shows.
+  it('returns to the page, not to the backend URL that was rejected', async () => {
+    const event = fetchEvent({
+      accessToken: 'token',
+      url: 'http://localhost/fhir/Patient?_count=50&_summary=true'
+    });
+
+    try {
+      await callHandleFetch(
+        event,
+        new Response('', { status: 401 }),
+        'http://localhost/fhir/metadata'
+      );
+      expect.fail('expected handleFetch to throw');
+    } catch (e) {
+      const location = (e as { location: string }).location;
+
+      expect(new URL(location, 'http://localhost').searchParams.get('redirect')).toBe(
+        '/fhir/Patient?_count=50&_summary=true'
+      );
+    }
+  });
+
+  it('passes a 403 through rather than redirecting', async () => {
+    const event = fetchEvent({ accessToken: 'token' });
+
+    const { result } = await callHandleFetch(event, new Response('', { status: 403 }));
+
+    expect(result.status).toBe(403);
+  });
 });

--- a/modules/frontend/src/hooks.server.ts
+++ b/modules/frontend/src/hooks.server.ts
@@ -75,5 +75,20 @@ export const handleFetch: HandleFetch = async ({ request, fetch, event }) => {
     duplex: 'half'
   });
 
-  return fetch(request);
+  const res = await fetch(request);
+
+  // The backend rejected a token that `handleAuthorization` considered valid:
+  // revoked at the identity provider, clock skew, a realm mismatch. Recovering
+  // here rather than in the load that made the request is what keeps the
+  // return-to target — `event.url` is the page the user is on, which the load
+  // cannot read.
+  //
+  // Both streamed loads await a backend request before they start streaming,
+  // which is what lets this redirect still reach the browser; see
+  // `docs/implementation/frontend.md`.
+  if (res.status === 401) {
+    redirect(307, signInUrl(event.url));
+  }
+
+  return res;
 };


### PR DESCRIPTION
Closes: #4082

#4163 moved every load server side, which removed the reported symptom: the universal loads that fetched a `+server.ts` proxy with a plain browser `fetch`, silently followed the 307 to the sign-in page and choked on its HTML in `res.json()`. Every request now either is a document load, SvelteKit's own `__data.json` request or a `use:enhance`d submission — all of which SvelteKit turns into a navigation when answered with a redirect.

What that does not reach is the case `handleAuthorization` cannot see: the Auth.js session is valid, but the backend rejects the access token — revoked at the IdP, clock skew, a realm mismatch. Today that 401 reaches the load and becomes an error page.

So `handleFetch` redirects on a backend 401, reusing the `signInUrl` from #4144. It has to happen in the hook rather than in the load, because `event.url` — the page the user is on, and so the return-to target — is not something a load can read. A 403 is passed through: there the token was accepted and signing in again changes nothing.

One consequence, documented rather than fixed: a load that streams must await at least one backend request first. A redirect thrown after `load` has returned cannot become a navigation; SvelteKit serializes it into the streamed chunk as a 500. Both streamed loads already await `fetchSearchMetadata`, and `/metadata` is behind the same `wrap-auth-guard` as everything else, so a rejected token is always discovered while a redirect still works. The StructureDefinition loads inside `transformBundle` remain the narrow exception.

The e2e test covers the `handleAuthorization` half — it clears the session cookie, so no session exists and no backend request is made. What it adds over the unit tests is the envelope: it is the first test to exercise the client router turning a redirect found in a `__data.json` response into a navigation, which #4163 verified only by reading `@sveltejs/kit`. Reaching `handleFetch` from Playwright would mean revoking the Keycloak session behind the app's back; `src/hooks.server.test.ts` covers it instead.